### PR TITLE
docs: note docs-only status for Cursor Cloud agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,12 @@ If running in interactive mode (e.g. Gemini CLI) then stop after each parent tas
 - Intended stack (per the PRD/prompt): a local-first TypeScript static web app
   (GitHub Pages "Web Shell") using Blockly + CodeMirror, `ehrtslib` for openEHR
   TypeScript, and `fontoxpath` for source queries; a VS Code extension follows
-  later. Once implementation begins and a JS manifest appears, the startup update
-  script already installs dependencies (npm/pnpm auto-detected from the lockfile).
-- Node.js and `pnpm` are available in this environment; `deno` is not installed
-  (AGENTS.md prefers Deno for the *local Windows* dev environment — install it in
-  the VM only if a future toolchain requires it).
+  later. Per repo preference, this is a **Deno-based** project (not Node/npm).
+- `deno` (latest stable, 2.9.0 at setup time) is installed in the VM and on
+  `PATH` via `~/.deno/env` (sourced from `~/.bashrc`). Node.js and `pnpm` also
+  happen to be present but are not the intended toolchain. Use `deno` for
+  install/lint/test/run/build once code exists (e.g. `deno install`,
+  `deno lint`, `deno test`, `deno task <name>`).
+- Once implementation begins and a `deno.json`/`deno.jsonc` (or `package.json`)
+  appears, the startup update script already runs `deno install` to fetch
+  dependencies. Until then it is a no-op.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,3 +64,20 @@ If running in interactive mode (e.g. Gemini CLI) then stop after each parent tas
 - The local environment is a Windows machine without admin privileges,
   Powershell is available. It uses [Scoop](https://scoop.sh/) for package
   installation, so base any advice on that.
+
+## Cursor Cloud specific instructions
+
+- This repository is currently **specification/planning only** — it contains
+  Markdown docs (`README.md`, `CONTEXT.md`, `INITIAL_PROMPT.md`, `docs/`), a PRD
+  (`tasks/PRD-intehrgrator-v1.md`), a Pencil wireframe (`mapping-interface.pen`),
+  and a UI mockup PNG. There is **no application code, `package.json`, lockfile,
+  build, lint, or test target yet**, so there is nothing to install/build/run.
+  Do not fabricate an app or dependency setup based on this note alone.
+- Intended stack (per the PRD/prompt): a local-first TypeScript static web app
+  (GitHub Pages "Web Shell") using Blockly + CodeMirror, `ehrtslib` for openEHR
+  TypeScript, and `fontoxpath` for source queries; a VS Code extension follows
+  later. Once implementation begins and a JS manifest appears, the startup update
+  script already installs dependencies (npm/pnpm auto-detected from the lockfile).
+- Node.js and `pnpm` are available in this environment; `deno` is not installed
+  (AGENTS.md prefers Deno for the *local Windows* dev environment — install it in
+  the VM only if a future toolchain requires it).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Attempted to set up a development environment for this repository. Investigation found that this is a **specification/planning-only repository** — it currently contains only Markdown docs, a PRD, a Pencil wireframe (`.pen`), and a UI mockup PNG. There is **no application code, `package.json`, lockfile, or build/lint/test target**, so there is nothing to install, build, run, or test yet (the PRD status is "Ready for implementation").

Per the repo's tooling preference, the project is set up as **Deno-based** (not Node/npm).

## Changes

- Added/updated a `## Cursor Cloud specific instructions` section in `AGENTS.md` recording the durable, non-obvious facts:
  - The repo is docs/spec-only today; no code/build/test exists.
  - Intended stack (per PRD): Deno-based TypeScript static web app using Blockly + CodeMirror, `ehrtslib`, and `fontoxpath`.
  - `deno` (latest stable, 2.9.0) is installed in the VM and on `PATH` via `~/.deno/env`.
  - The startup update script runs `deno install` once a `deno.json`/`package.json` appears.

## Environment

- Installed latest stable Deno (2.9.0) in the VM; verified it runs and type-checks TypeScript (`deno eval`).

## Update script

Registered a minimal, guarded, idempotent Deno-based startup update script that is a safe no-op in the current state and installs deps once a manifest is committed:

```
if [ -f deno.json ] || [ -f deno.jsonc ] || [ -f package.json ]; then
  [ -x "$HOME/.deno/bin/deno" ] && export PATH="$HOME/.deno/bin:$PATH"
  deno install
fi
```

No application code was created or modified beyond the AGENTS.md documentation note.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68033a6f-ca7f-4c1f-9d91-060b163399b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68033a6f-ca7f-4c1f-9d91-060b163399b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

