### PR TITLE
Fix GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,9 @@ jobs:
         run: deno task test
       - name: Build
         run: deno task build
-      - name: Upload Pages artifact
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
         with:
+          name: dist
           path: dist
+          if-no-files-found: error

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,12 @@
+# Deploy the static Web Shell to GitHub Pages.
+# Requires: Settings → Pages → Build and deployment → Source: GitHub Actions
+
 name: Deploy GitHub Pages
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -25,9 +29,10 @@ jobs:
         with:
           deno-version: v2.x
       - run: deno task vendor
+      - run: deno task test
       - run: deno task build
       - uses: actions/configure-pages@v5
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: dist
       - id: deployment

--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ deno task build    # outputs static site to dist/
 deno task dev      # serve dist/ on http://localhost:5173
 ```
 
-Open `dist/index.html` (or use `deno task dev`) to use the Web Shell.
+### GitHub Pages
+
+The Web Shell is published on every push to `main` via the **Deploy GitHub Pages** workflow (also runnable manually from Actions). Ensure **Settings → Pages → Build and deployment → Source** is **GitHub Actions**.
+
+Open `dist/index.html` (or use `deno task dev`) to use the Web Shell locally.
 
 ## Implementation layout
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Now that GitHub Pages is enabled (Actions source), this updates the workflows:

- **CI** (`ci.yml`): test + build only; uploads `dist` as a regular artifact (no Pages API)
- **Pages** (`pages.yml`): deploy on every `main` push + `workflow_dispatch`; runs tests before deploy; uses `upload-pages-artifact@v4`

## Test plan
- [ ] CI passes on this PR
- [ ] Deploy GitHub Pages succeeds after merge to `main`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39c43ab0-2e59-4b3b-993b-e24654fa2bbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39c43ab0-2e59-4b3b-993b-e24654fa2bbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

