### PR TITLE
UI testing for Click-to-Map + architecture deepening for openEHR source & dual builds

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,6 +119,10 @@ _Avoid_: AI paste, bulk map
 Shared interface for environment-specific bindings (file access, storage, AI) so the core mapping logic is host-agnostic. v1 implements the web adapter only.
 _Avoid_: Environment abstraction layer, platform bindings
 
+**Workbench Test API**:
+Programmatic seam exposed as `window.intehrgratorTestApi` when the Web Shell is opened with `?testMode=1`. Loads Template Skeleton / Source Schema / Example Instance fixtures without file pickers; reports Mapping Model, Blockly block summary, and Test Run results. UI tests still click Target value slots, Example Instance tree rows, and **Run Test** so Click-to-Map is exercised through the real DOM. See `docs/UI_TESTING.md`.
+_Avoid_: formTestApi (kintegrate name), Cypress-only harness
+
 **Export Target**:
 Workspace setting choosing which code generator runs for Output Previews and Export (`typescript` | `java`). Downstream of the Mapping Model — Blockly blocks and mappings are language-agnostic.
 _Avoid_: Target language, output format

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Visual integration workbench for mapping source data (JSON/XML) to openEHR Compo
 
 ```bash
 deno task vendor   # clone ehrtslib into vendor/ (first time)
-deno task test
+deno task test     # unit tests (no browser)
+deno task test:ui  # Playwright: Click-to-Map + Test Run (see docs/UI_TESTING.md)
 deno task build    # outputs static site to dist/
 deno task dev      # serve dist/ on http://localhost:5173
 ```
@@ -27,6 +28,8 @@ Open `dist/index.html` (or use `deno task dev`) to use the Web Shell locally.
 | `src/host/` | `HostAdapter` + browser implementation |
 | `web/` | HTML/CSS entry; bundled to `dist/bundle.js` |
 | `test/` | Deno unit tests + OPT fixtures |
+| `test/ui/` | Playwright UI tests (Workbench Test API) |
+| `src/ui_test/` | Workbench Test API types / helpers |
 
 ## Documentation
 
@@ -36,6 +39,7 @@ Open `dist/index.html` (or use `deno task dev`) to use the Web Shell locally.
 | **Project prompt** | [INITIAL_PROMPT.md](INITIAL_PROMPT.md) |
 | **PRD (v1)** | [tasks/PRD-intehrgrator-v1.md](tasks/PRD-intehrgrator-v1.md) · [tasks/TASKS-intehrgrator-v1.md](tasks/TASKS-intehrgrator-v1.md) |
 | **UI design** | [docs/UI_ARCHITECTURE.md](docs/UI_ARCHITECTURE.md) · [mockup](docs/assets/prototype-ui-v1-consolidated.png) |
+| **UI testing** | [docs/UI_TESTING.md](docs/UI_TESTING.md) |
 | **Blockly** | [docs/BLOCKLY_INTEGRATION.md](docs/BLOCKLY_INTEGRATION.md) |
 | **Mapping spec** | [docs/MAPPING_SPECIFICATION.md](docs/MAPPING_SPECIFICATION.md) |
 | **Source data** | [docs/SOURCE_FORMATS.md](docs/SOURCE_FORMATS.md) · [docs/SOURCE_QUERY.md](docs/SOURCE_QUERY.md) |

--- a/deno.json
+++ b/deno.json
@@ -37,7 +37,8 @@
   },
   "tasks": {
     "vendor": "deno run -A scripts/vendor-ehrtslib.ts",
-    "test": "deno test -A --no-check --parallel",
+    "test": "deno test -A --no-check --parallel --ignore=test/ui test/",
+    "test:ui": "deno run -A scripts/ui-test.ts",
     "lint": "deno lint src test scripts",
     "check": "deno check src/**/*.ts web/main.ts scripts/*.ts",
     "build": "deno run -A scripts/build.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -41,6 +41,7 @@
     "npm:fast-xml-parser@^4.5.6": "4.5.6",
     "npm:fflate@~0.8.2": "0.8.3",
     "npm:fontoxpath@^3.33.2": "3.34.0",
+    "npm:playwright@1.51.0": "1.51.0",
     "npm:temporal-polyfill@0.2.5": "0.2.5",
     "npm:yaml@^2.3.4": "2.9.0",
     "npm:yaml@^2.9.0": "2.9.0"
@@ -797,6 +798,11 @@
         "mime-types"
       ]
     },
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
     "function-bind@1.1.2": {
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
@@ -924,6 +930,20 @@
       "dependencies": [
         "entities"
       ]
+    },
+    "playwright-core@1.51.0": {
+      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
+      "bin": true
+    },
+    "playwright@1.51.0": {
+      "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
     },
     "prsc@4.0.0": {
       "integrity": "sha512-OmXQ2v76RlXNx/gqv7+oB6jyKnudJ/rsMfAIVexhbDFxXAJPoWKMxJkZU2ohlu4miCiSQCG+horf2DV4/kNc1Q=="

--- a/docs/UI_TESTING.md
+++ b/docs/UI_TESTING.md
@@ -1,0 +1,66 @@
+# UI Testing (v1)
+
+First-cut browser tests for the Web Shell Mapping Editor: prove that **Click-to-Map** (Listening Mode → Example Instance node → Blockly `source_query`) and **Test Run** produce sensible Output Previews.
+
+Inspired by kintegrate’s `formTestApi` + browser harness pattern ([CyEmulator / formTestApi](https://deepwiki.com/ErikSundvall/kintegrate)), adapted to Deno + Playwright.
+
+## Goals
+
+| Goal | v1 approach |
+|------|-------------|
+| Avoid fragile file-picker automation | **Workbench Test API** loads OPT / Source Schema / Example Instance from fixture strings |
+| Still exercise real UI | Arm slots via Target value slots rail; bind via Example Instance tree click; **Run Test** button |
+| Assert sensible output | Mapping Model expression, Blockly `source_query` block, Test Run slot value, `#test-output` text |
+| Stay Deno-native | `deno task test:ui` builds, serves `dist/`, runs Playwright under Deno |
+
+## Workbench Test API
+
+Enabled only when the shell is opened with `?testMode=1`.
+
+| Method | Role |
+|--------|------|
+| `ready()` | Resolves after Blockly inject + first render |
+| `loadTemplate` / `loadSchema` / `addExample` | Fixture setup (no Host file picker) |
+| `armSlot` / `bindFromNode` | Programmatic equivalents of Click-to-Map (available; UI test prefers DOM clicks) |
+| `runTest` / `setAutoplay` | Drive Conversion Test Run(s) |
+| `getSnapshot()` | Mapping Model, Test Run result, Blockly block summary |
+| `findSlotIdBySuffix` | Stable slot lookup for long OPT slotIds |
+
+Global: `window.intehrgratorTestApi` (types in `src/ui_test/test_api.ts`).
+
+## Running
+
+```bash
+deno task vendor   # once
+deno task test:ui  # build + serve + Playwright
+```
+
+Skip rebuild when iterating:
+
+```bash
+UI_TEST_SKIP_BUILD=1 deno task test:ui
+```
+
+Unit tests remain `deno task test` (no browser).
+
+## Fixtures
+
+| File | Use |
+|------|-----|
+| `test/fixtures/blood_pressure.opt` | Target Template Skeleton |
+| `test/fixtures/ui/bp_source_schema.json` | Source Schema |
+| `test/fixtures/ui/bp_example.json` | Active Example (`systolic: 120`) |
+
+Primary scenario maps systolic (`…/items/at0004/value/value/value`) → `$.systolic` and expects Test Run slot value `120`.
+
+## What this does *not* cover yet
+
+- Full Generated Export execution through ehrtslib Composition builders (Test Run is still slot-evaluation preview — see architecture deepening candidates)
+- Drag-and-drop Click-to-Map
+- Autoplay debounce behaviour
+- VS Code webview host (same Test API should mount there later behind Host Abstraction)
+- openEHR-as-source (future Source Format Handler)
+
+## CI
+
+`deno task test:ui` is available locally and can be added as a CI job once Chromium install time is acceptable for the runners. Unit `deno task test` stays the default gate.

--- a/docs/UI_TESTING.md
+++ b/docs/UI_TESTING.md
@@ -1,6 +1,6 @@
 # UI Testing (v1)
 
-First-cut browser tests for the Web Shell Mapping Editor: prove that **Click-to-Map** (Listening Mode → Example Instance node → Blockly `source_query`) and **Test Run** produce sensible Output Previews.
+First-cut browser tests for the Web Shell Mapping Editor: prove that **Click-to-Map** and **drag-and-drop mapping** produce Blockly `source_query` blocks and sensible **Test Run** Output Previews.
 
 Inspired by kintegrate’s `formTestApi` + browser harness pattern ([CyEmulator / formTestApi](https://deepwiki.com/ErikSundvall/kintegrate)), adapted to Deno + Playwright.
 
@@ -9,7 +9,7 @@ Inspired by kintegrate’s `formTestApi` + browser harness pattern ([CyEmulator 
 | Goal | v1 approach |
 |------|-------------|
 | Avoid fragile file-picker automation | **Workbench Test API** loads OPT / Source Schema / Example Instance from fixture strings |
-| Still exercise real UI | Arm slots via Target value slots rail; bind via Example Instance tree click; **Run Test** button |
+| Still exercise real UI | Arm + click Example Instance (Click-to-Map); HTML5 drag from Example Instance onto Target value slot; **Run Test** |
 | Assert sensible output | Mapping Model expression, Blockly `source_query` block, Test Run slot value, `#test-output` text |
 | Stay Deno-native | `deno task test:ui` builds, serves `dist/`, runs Playwright under Deno |
 
@@ -22,6 +22,7 @@ Enabled only when the shell is opened with `?testMode=1`.
 | `ready()` | Resolves after Blockly inject + first render |
 | `loadTemplate` / `loadSchema` / `addExample` | Fixture setup (no Host file picker) |
 | `armSlot` / `bindFromNode` | Programmatic equivalents of Click-to-Map (available; UI test prefers DOM clicks) |
+| `mapNodeToSlot` | Programmatic equivalent of drag-and-drop (skips Listening Mode) |
 | `runTest` / `setAutoplay` | Drive Conversion Test Run(s) |
 | `getSnapshot()` | Mapping Model, Test Run result, Blockly block summary |
 | `findSlotIdBySuffix` | Stable slot lookup for long OPT slotIds |
@@ -51,12 +52,19 @@ Unit tests remain `deno task test` (no browser).
 | `test/fixtures/ui/bp_source_schema.json` | Source Schema |
 | `test/fixtures/ui/bp_example.json` | Active Example (`systolic: 120`) |
 
-Primary scenario maps systolic (`…/items/at0004/value/value/value`) → `$.systolic` and expects Test Run slot value `120`.
+Primary scenarios map systolic (`…/items/at0004/value/value/value`) → `$.systolic` and expect Test Run slot value `120`:
+
+| Test | Interaction |
+|------|-------------|
+| `test/ui/click_to_map_test.ts` | Listening Mode → click Example Instance node |
+| `test/ui/drag_drop_map_test.ts` | Drag Example Instance node onto Target value slot (no Listening Mode) |
+
+Shared helpers live in `test/ui/helpers.ts` (including `html5DragDrop` for reliable DataTransfer MIME payloads under Playwright).
 
 ## What this does *not* cover yet
 
 - Full Generated Export execution through ehrtslib Composition builders (Test Run is still slot-evaluation preview — see architecture deepening candidates)
-- Drag-and-drop Click-to-Map
+- Drag-and-drop onto the Blockly canvas (slots-rail drop is covered; canvas drop is wired in the shell)
 - Autoplay debounce behaviour
 - VS Code webview host (same Test API should mount there later behind Host Abstraction)
 - openEHR-as-source (future Source Format Handler)

--- a/docs/reviews/architecture-review-openehr-source-dual-builds.html
+++ b/docs/reviews/architecture-review-openehr-source-dual-builds.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>intEHRgrator — Architecture Review</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module">
+    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+    mermaid.initialize({ startOnLoad: true, theme: "neutral", securityLevel: "loose" });
+  </script>
+  <style>
+    :root {
+      --ink: #0f1c1a;
+      --teal: #005C53;
+      --teal-deep: #003B49;
+      --warm: #E87722;
+      --paper: #f3f6f4;
+      --line: #c9d4d0;
+    }
+    body {
+      font-family: "IBM Plex Sans", "Segoe UI", sans-serif;
+      background:
+        radial-gradient(1200px 600px at 10% -10%, #d7ebe6 0%, transparent 55%),
+        radial-gradient(900px 500px at 100% 0%, #fde8d4 0%, transparent 50%),
+        var(--paper);
+      color: var(--ink);
+    }
+    .display { font-family: "IBM Plex Serif", Georgia, serif; }
+    .badge-strong { background: #155e45; color: #ecfdf5; }
+    .badge-explore { background: #854d0e; color: #fef9c3; }
+    .badge-spec { background: #334155; color: #e2e8f0; }
+    .mass {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+    .mass-col {
+      border: 1px solid var(--line);
+      background: rgba(255,255,255,0.72);
+      border-radius: 0.75rem;
+      padding: 1rem;
+      min-height: 220px;
+    }
+    .iface {
+      border: 2px solid var(--teal);
+      border-radius: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      background: #e8f5f2;
+    }
+    .impl {
+      margin-top: 0.5rem;
+      border-left: 3px solid var(--warm);
+      padding: 0.5rem 0.75rem;
+      font-size: 0.78rem;
+      background: #fff8f1;
+      color: #4a3420;
+    }
+    .shallow .iface { border-style: dashed; opacity: 0.9; }
+    .shallow .impl { min-height: 4.5rem; }
+    .deep .impl { min-height: 7.5rem; }
+    .arrow {
+      text-align: center;
+      color: var(--teal-deep);
+      font-size: 0.75rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      margin: 0.35rem 0;
+    }
+    .callout-warn {
+      border-left: 4px solid #b45309;
+      background: #fffbeb;
+      padding: 0.75rem 1rem;
+      border-radius: 0.5rem;
+      font-size: 0.9rem;
+    }
+    .mermaid { background: #fff; border-radius: 0.75rem; padding: 1rem; border: 1px solid var(--line); }
+  </style>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Serif:wght@500;600&display=swap" rel="stylesheet" />
+</head>
+<body class="min-h-screen">
+  <header class="max-w-6xl mx-auto px-6 pt-10 pb-6">
+    <p class="text-sm tracking-wide uppercase text-[color:var(--teal)] font-semibold">Architecture review · deepening opportunities</p>
+    <h1 class="display text-4xl md:text-5xl font-semibold mt-2 leading-tight">intEHRgrator seams for openEHR-as-source & dual builds</h1>
+    <p class="mt-4 max-w-3xl text-lg text-slate-700">
+      Friction surfaced with an eye on merging kintegrate-style openEHR source handling and shipping separate
+      <strong>Web Shell</strong> and <strong>VS Code / Cursor</strong> builds. Vocabulary: <em>module</em>, <em>interface</em>,
+      <em>implementation</em>, <em>depth</em>, <em>seam</em>, <em>adapter</em>, <em>leverage</em>, <em>locality</em>
+      (architecture skill); domain terms from <code>CONTEXT.md</code>.
+    </p>
+  </header>
+
+  <main class="max-w-6xl mx-auto px-6 pb-20 space-y-8">
+
+    <!-- Candidate 1 -->
+    <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
+      <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 class="display text-2xl font-semibold">1. Source Format Handler seam</h2>
+          <p class="text-sm text-slate-600 mt-1">Files: <code>src/core/source/*</code>, <code>src/types/mod.ts</code>, <code>src/core/expression/mod.ts</code>, <code>src/core/codegen/mod.ts</code>, <code>src/workbench/controller.ts</code></p>
+        </div>
+        <span class="badge-strong text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Strong</span>
+      </div>
+      <div class="px-6 py-5 space-y-4">
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Problem</h3>
+          <p class="text-slate-700 mt-1">Source handling is a closed <code>"json" | "xml"</code> union threaded through types, query runtime, codegen, and the workbench. openEHR Composition / FLAT / STRUCTURED as a <em>Source Schema</em> (kintegrate Integration Builder treats openEHR JSON as input) cannot plug in without forking four modules. Deletion test: deleting <code>query_runtime</code> does not vanish complexity — it reappears in every caller — but the format switch itself is shallow branching, not a deep format module.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Solution</h3>
+          <p class="text-slate-700 mt-1">Deepen a <strong>Source Format Handler</strong> module: one small interface (<code>loadSchema</code>, <code>loadInstance</code>, <code>toTree</code>, <code>pathToExpression</code>, <code>createContext</code>, <code>evaluate</code>) with adapters for JSON, XML, and later <code>openehr-composition</code> (and OPT-as-source tree if needed). Mapping Expressions stay format-backed behind that seam; Target Template Skeleton / ehrtslib remain the openEHR <em>target</em> stack.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Benefits</h3>
+          <ul class="list-disc pl-5 text-slate-700 space-y-1 mt-1">
+            <li><strong>Leverage:</strong> callers (Click-to-Map, Test Run, codegen) keep one path language insertion API while formats multiply.</li>
+            <li><strong>Locality:</strong> openEHR path / FLAT quirks live in one adapter, not scattered unions.</li>
+            <li><strong>Tests:</strong> each adapter tested at the Source Format Handler interface; workbench tests stay format-agnostic.</li>
+          </ul>
+        </div>
+        <div class="mass">
+          <div class="mass-col shallow">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">Before — shallow format forks</div>
+            <div class="iface">format: "json" | "xml"</div>
+            <div class="arrow">↓ leaks into</div>
+            <div class="impl">schema_loader · query_runtime · expression builtins · codegen SourceContext · controller.bindFromNode</div>
+            <p class="text-xs text-slate-500 mt-3">Interface nearly as wide as the branching implementation. openEHR-as-source = Nth fork.</p>
+          </div>
+          <div class="mass-col deep">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">After — deep Source Format Handler</div>
+            <div class="iface">SourceFormatHandler { load · tree · path · evaluate }</div>
+            <div class="arrow">↓ adapters</div>
+            <div class="impl">JsonHandler · XmlHandler · OpenEhrCompositionHandler (kintegrate-class input) — RM path / FLAT helpers concentrated here</div>
+            <p class="text-xs text-slate-500 mt-3">Small interface, large behaviour. Second adapter makes the seam real.</p>
+          </div>
+        </div>
+        <pre class="mermaid">
+flowchart LR
+  subgraph callers [Callers]
+    CTM[Click-to-Map]
+    TR[Test Run]
+    CG[Generated Export]
+  end
+  SFH[Source Format Handler interface]
+  J[JSON adapter]
+  X[XML adapter]
+  O[openEHR Composition adapter]
+  CTM --> SFH
+  TR --> SFH
+  CG --> SFH
+  SFH --> J
+  SFH --> X
+  SFH --> O
+        </pre>
+      </div>
+    </article>
+
+    <!-- Candidate 2 -->
+    <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
+      <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 class="display text-2xl font-semibold">2. Host Abstraction + dual build entries</h2>
+          <p class="text-sm text-slate-600 mt-1">Files: <code>src/host/web_adapter.ts</code>, <code>src/core/persistence/mod.ts</code>, <code>web/main.ts</code>, <code>scripts/build.ts</code>, <code>ui/split_pane.ts</code></p>
+        </div>
+        <span class="badge-strong text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Strong</span>
+      </div>
+      <div class="px-6 py-5 space-y-4">
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Problem</h3>
+          <p class="text-slate-700 mt-1">Host Abstraction exists but is browser-shaped (<code>File</code>), co-located with <code>WebHostAdapter</code>, and storage is inverted: IndexedDB helpers live in <code>core/persistence</code> while the host re-exports them. Only one esbuild entry (<code>web/main.ts</code>). A VS Code / Cursor webview build cannot swap storage/FS without dragging IndexedDB or forking persistence. One adapter today ⇒ seam still partly hypothetical.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Solution</h3>
+          <p class="text-slate-700 mt-1">Deepen Host: bytes/text pick API (no DOM <code>File</code>); move IndexedDB behind <code>WebHostAdapter</code>; keep Project Bundle serialize/import as a deep pure module. Add second build entry (<code>extension/</code> host + webview bundle sharing Mapping Editor). Prefer webview = same DOM stack; only Host + packaging differ — same pattern kintegrate is moving toward for Codespaces.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Benefits</h3>
+          <ul class="list-disc pl-5 text-slate-700 space-y-1 mt-1">
+            <li><strong>Leverage:</strong> one workbench + Blockly stack; two thin host adapters.</li>
+            <li><strong>Locality:</strong> storage/FS/AI differences stop leaking into Mapping Model and Test Run.</li>
+            <li><strong>Tests:</strong> Host mocked in unit tests (already starting); UI tests reuse Workbench Test API inside either shell.</li>
+          </ul>
+        </div>
+        <div class="mass">
+          <div class="mass-col shallow">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">Before</div>
+            <div class="iface">HostAdapter + File + IndexedDB-in-core</div>
+            <div class="impl">Single browser bundle · localStorage in split_pane · location.href in AI prompt · confirm/prompt in shell</div>
+          </div>
+          <div class="mass-col deep">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">After</div>
+            <div class="iface">HostAdapter { pickText · storage · clipboard · download · dialogs? }</div>
+            <div class="impl">WebHostAdapter (IndexedDB) · VsCodeHostAdapter (workspace FS) · shared webview Mapping Editor bundle · pure Project Bundle I/O in core</div>
+          </div>
+        </div>
+        <pre class="mermaid">
+flowchart TB
+  CORE[Shared core: Mapping Model · Blockly · Source Format Handler · codegen]
+  WEB[Web Shell adapter + pages build]
+  VSC[VS Code / Cursor adapter + extension package]
+  CORE --> WEB
+  CORE --> VSC
+        </pre>
+      </div>
+    </article>
+
+    <!-- Candidate 3 -->
+    <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
+      <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 class="display text-2xl font-semibold">3. Mapping pipeline depth (Sync Scope → Test Run)</h2>
+          <p class="text-sm text-slate-600 mt-1">Files: <code>src/blockly/*</code>, <code>src/core/mapping_model</code>, <code>src/core/codegen</code>, <code>src/core/test_runner</code>, <code>web/main.ts</code></p>
+        </div>
+        <span class="badge-strong text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Strong</span>
+      </div>
+      <div class="px-6 py-5 space-y-4">
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Problem</h3>
+          <p class="text-slate-700 mt-1">Intended Sync Scope is Blockly ⇄ Mapping Model ⇄ Mapping Specification → Generated Export → Test Run. Actual path: Click-to-Map updates Mapping Model; Blockly canvas edits only <code>markDirty()</code>; Test Run evaluates slot expressions into a stub Composition and ignores Generated Export. Dual codegen (Blockly JS generators vs <code>core/codegen</code>) splits locality. UI tests can assert slot preview today, but not “sensible openEHR Composition” until this deepens.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Solution</h3>
+          <p class="text-slate-700 mt-1">Make Mapping Model the single deep IR: Blockly → Model on change; codegen only from Model; Test Run executes Generated Export (or a Model interpreter that is the same semantic surface). Collapse or demote unused Blockly-only generator path until it is an adapter behind the same interface.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Benefits</h3>
+          <ul class="list-disc pl-5 text-slate-700 space-y-1 mt-1">
+            <li><strong>Locality:</strong> bugs in conversion live in one pipeline, not Model vs Blockly vs stub runner.</li>
+            <li><strong>Leverage:</strong> Workbench Test API / UI tests assert real Composition JSON.</li>
+            <li><strong>Deletion test:</strong> today’s thin <code>test_runner</code> fails — deleting it barely hurts; after deepening, deleting it would force N callers to reimplement ehrtslib execution.</li>
+          </ul>
+        </div>
+        <div class="mass">
+          <div class="mass-col shallow">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">Before</div>
+            <div class="iface">runTest(model, example)</div>
+            <div class="impl">evaluate each slot → { COMPOSITION stub, slots } · _generatedTs unused</div>
+          </div>
+          <div class="mass-col deep">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">After</div>
+            <div class="iface">runTest(model | generatedExport, example) → Composition</div>
+            <div class="impl">Sync Scope guarantees Model freshness · ehrtslib build · validation warnings with locality next to codegen</div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <!-- Candidate 4 -->
+    <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
+      <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 class="display text-2xl font-semibold">4. Collapse pass-through RM attachment catalog</h2>
+          <p class="text-sm text-slate-600 mt-1">Files: <code>src/core/rm_attachment_catalog.ts</code>, <code>src/core/rm_meta.ts</code></p>
+        </div>
+        <span class="badge-explore text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Worth exploring</span>
+      </div>
+      <div class="px-6 py-5 space-y-4">
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Problem</h3>
+          <p class="text-slate-700 mt-1"><code>rm_attachment_catalog.ts</code> is a ~10-line re-export of <code>getValidAttachments</code>. Deletion test: complexity vanishes — it was a pass-through. Optional RM Insertion policy (what to offer in the picker) belongs either inside a deepened attachment module or directly on <code>rm_meta</code>.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Solution</h3>
+          <p class="text-slate-700 mt-1">Either delete the catalog and import <code>rm_meta</code>, or deepen it into the real Optional RM Insertion policy module (OPT context, already-present attrs, product filters) — that would earn depth once openEHR-as-source and dual hosts need consistent attachment rules.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Benefits</h3>
+          <p class="text-slate-700 mt-1">Less AI-navigation noise; or, if deepened, one locality for attachment policy tests.</p>
+        </div>
+        <div class="mass">
+          <div class="mass-col shallow">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">Before</div>
+            <div class="iface">getValidAttachments()</div>
+            <div class="impl">return rm_meta.getValidAttachments(...)</div>
+          </div>
+          <div class="mass-col deep">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">After (pick one)</div>
+            <div class="iface">rm_meta only  —or—  AttachmentPolicy { forNode, filter }</div>
+            <div class="impl">No pass-through · policy depth if picker rules grow with kintegrate merge</div>
+          </div>
+        </div>
+      </div>
+    </article>
+
+    <!-- Candidate 5 -->
+    <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
+      <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 class="display text-2xl font-semibold">5. Workbench view seam (shell vs controller)</h2>
+          <p class="text-sm text-slate-600 mt-1">Files: <code>web/main.ts</code>, <code>src/workbench/controller.ts</code>, <code>tree_views.ts</code>, <code>codemirror_setup.ts</code></p>
+        </div>
+        <span class="badge-explore text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Worth exploring</span>
+      </div>
+      <div class="px-6 py-5 space-y-4">
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Problem</h3>
+          <p class="text-slate-700 mt-1"><code>WorkbenchController</code> is mostly host-agnostic and deep, but <code>web/main.ts</code> owns dialogs, Blockly inject, and render wiring (~500+ LOC). Fine for one Web Shell; painful when a second shell (VS Code webview HTML) must fork that glue. Workbench Test API already peeks through this seam — a good sign the interface wants formalizing.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Solution</h3>
+          <p class="text-slate-700 mt-1">Extract a thin <strong>Workbench Shell</strong> module that mounts Mapping Editor + Source Pane + Output Previews given a Host + DOM roots. Web Pages and VS Code webview become two adapters that only supply roots + Host. Keep Workbench Test API as the test surface of that shell.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Benefits</h3>
+          <p class="text-slate-700 mt-1">Locality for UI wiring; leverage for dual builds without duplicating Click-to-Map / Autoplay glue.</p>
+        </div>
+        <div class="callout-warn">
+          Do this <em>after</em> or alongside Host deepening — extracting a shell that still hard-codes <code>File</code> / IndexedDB only moves the shallow edge.
+        </div>
+      </div>
+    </article>
+
+    <!-- Candidate 6 -->
+    <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
+      <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 class="display text-2xl font-semibold">6. Speculative: Handlebars / kintegrate conversion dialect</h2>
+          <p class="text-sm text-slate-600 mt-1">Roadmap note + kintegrate Integration Builder (DeepWiki)</p>
+        </div>
+        <span class="badge-spec text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Speculative</span>
+      </div>
+      <div class="px-6 py-5 space-y-4">
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Problem</h3>
+          <p class="text-slate-700 mt-1">kintegrate’s middle column is Handlebars conversion scripts over JSON trees (often openEHR compositions). intEHRgrator’s Export Target is TypeScript/Java from Blockly. Merging product surfaces may tempt a third codegen dialect without a deep Export Target module.</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Solution</h3>
+          <p class="text-slate-700 mt-1">Only if product requires it: deepen Export Target as adapters behind Mapping Model (<code>typescript</code> | <code>java</code> | <code>handlebars</code>), never a parallel IR. Prefer absorbing kintegrate’s <em>source</em> strengths first (candidate 1).</p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Benefits</h3>
+          <p class="text-slate-700 mt-1">Avoids a second mapping language; keeps AI / Blockly / spec on one Model.</p>
+        </div>
+      </div>
+    </article>
+
+    <!-- Top recommendation -->
+    <section class="rounded-2xl border-2 border-[color:var(--teal)] bg-gradient-to-br from-[#e8f5f2] to-white px-6 py-6">
+      <h2 class="display text-2xl font-semibold text-[color:var(--teal-deep)]">Top recommendation</h2>
+      <p class="mt-3 text-slate-800 text-lg">
+        Tackle <strong>candidate 1 (Source Format Handler)</strong> and <strong>candidate 2 (Host Abstraction + dual builds)</strong> as a paired foundation:
+        openEHR-as-source (kintegrate merge) needs a real format seam; VS Code / Cursor needs a real host seam with a second adapter.
+        Candidate 3 (pipeline / Test Run depth) should follow immediately so UI tests and informatician Test Run assert real Compositions — otherwise format/host work still lands on a shallow runner.
+      </p>
+      <p class="mt-4 text-slate-600 text-sm">
+        No ADRs exist today; decisions live in CONTEXT / PRD. None of these candidates contradict a recorded ADR.
+        Grounding: DeepWiki <code>ErikSundvall/kintegrate</code> (Integration Builder input JSON / openEHR compositions; formTestApi testing pattern; webview-oriented VS Code direction).
+      </p>
+    </section>
+
+    <section class="text-sm text-slate-600 border-t border-[color:var(--line)] pt-6">
+      <p>Generated for interactive grilling. Next step: pick a candidate to explore — interfaces are intentionally not proposed yet.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/scripts/ui-test.ts
+++ b/scripts/ui-test.ts
@@ -1,0 +1,94 @@
+/**
+ * Build Web Shell, serve dist/, run Playwright UI tests, tear down.
+ *
+ * Env:
+ *   UI_TEST_PORT — default 5173
+ *   UI_TEST_SKIP_BUILD — set to "1" to reuse existing dist/
+ *   PW_DISABLE_TS_ESM — forced to "1" for Deno + Playwright
+ */
+
+import { dirname, fromFileUrl, join } from "@std/path";
+
+const root = join(dirname(fromFileUrl(import.meta.url)), "..");
+const port = Number(Deno.env.get("UI_TEST_PORT") ?? 5173);
+const baseUrl = `http://127.0.0.1:${port}`;
+
+Deno.env.set("PW_DISABLE_TS_ESM", "1");
+Deno.env.set("UI_TEST_BASE_URL", baseUrl);
+
+async function run(cmd: string[], opts: { cwd?: string; env?: Record<string, string> } = {}) {
+  const proc = new Deno.Command(cmd[0]!, {
+    args: cmd.slice(1),
+    cwd: opts.cwd ?? root,
+    env: { ...Deno.env.toObject(), ...opts.env },
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const status = await proc.output();
+  if (!status.success) {
+    throw new Error(`Command failed (${status.code}): ${cmd.join(" ")}`);
+  }
+}
+
+if (Deno.env.get("UI_TEST_SKIP_BUILD") !== "1") {
+  console.log("→ deno task build");
+  await run(["deno", "task", "build"]);
+}
+
+const server = new Deno.Command("deno", {
+  args: ["run", "-A", "scripts/dev-server.ts"],
+  cwd: root,
+  env: { ...Deno.env.toObject(), PORT: String(port) },
+  stdout: "piped",
+  stderr: "piped",
+}).spawn();
+
+async function waitForServer(url: string, attempts = 40): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url);
+      await res.arrayBuffer();
+      if (res.ok || res.status === 404) return;
+    } catch {
+      // not up yet
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(`Server did not become ready at ${url}`);
+}
+
+let exitCode = 1;
+try {
+  console.log(`→ waiting for ${baseUrl}`);
+  await waitForServer(baseUrl);
+
+  // Ensure Chromium is available. Prefer npx — Deno's `npm:playwright install`
+  // has hung on browser extraction in some environments.
+  console.log("→ playwright install chromium (if needed)");
+  try {
+    await run(["npx", "--yes", "playwright@1.51.0", "install", "chromium"]);
+  } catch (err) {
+    console.warn("playwright install warning:", err);
+  }
+
+  console.log("→ deno test test/ui");
+  await run(["deno", "test", "-A", "--no-check", "test/ui"], {
+    env: {
+      PW_DISABLE_TS_ESM: "1",
+      UI_TEST_BASE_URL: baseUrl,
+    },
+  });
+  exitCode = 0;
+} catch (err) {
+  console.error(err);
+  exitCode = 1;
+} finally {
+  try {
+    server.kill("SIGTERM");
+  } catch {
+    // already exited
+  }
+  await server.status;
+}
+
+Deno.exit(exitCode);

--- a/src/ui_test/test_api.ts
+++ b/src/ui_test/test_api.ts
@@ -1,0 +1,58 @@
+/**
+ * Workbench Test API — programmatic seam for UI / E2E tests (kintegrate formTestApi pattern).
+ *
+ * Exposed on `window.intehrgratorTestApi` when the Web Shell is opened with `?testMode=1`.
+ * Setup helpers load fixtures without file pickers; Click-to-Map and Run Test still go through
+ * real DOM / Blockly so the harness proves the Mapping Editor UI path.
+ */
+
+import type { MappingModel, TestResult } from "../types/mod.ts";
+
+export interface BlocklyBlockSummary {
+  id: string;
+  type: string;
+  slotId: string | null;
+}
+
+export interface WorkbenchTestSnapshot {
+  templateId: string;
+  listeningSlotId: string | null;
+  exampleCount: number;
+  activeExampleFilename: string | null;
+  model: MappingModel;
+  testResult: TestResult | null;
+  statusMessage: string;
+  autoplay: boolean;
+  unmappedMandatory: number;
+  blocklyBlocks: BlocklyBlockSummary[];
+}
+
+export interface IntehrgratorTestApi {
+  /** Wait until Blockly inject + first render completed. */
+  ready(): Promise<void>;
+  loadTemplate(filename: string, content: string): void;
+  loadSchema(filename: string, content: string): void;
+  addExample(filename: string, content: string): void;
+  armSlot(slotId: string): void;
+  /** Programmatic bind (same path as Click-to-Map after Listening Mode). */
+  bindFromNode(path: string, format: "json" | "xml"): void;
+  runTest(): void;
+  setAutoplay(on: boolean): void;
+  getSnapshot(): WorkbenchTestSnapshot;
+  /**
+   * Find a Target value slot whose slotId ends with `suffix` (stable for OPT fixtures
+   * where absolute slotIds are long archetype paths).
+   */
+  findSlotIdBySuffix(suffix: string): string | null;
+}
+
+declare global {
+  interface Window {
+    intehrgratorTestApi?: IntehrgratorTestApi;
+  }
+}
+
+export function isTestMode(search = globalThis.location?.search ?? ""): boolean {
+  const params = new URLSearchParams(search.startsWith("?") ? search.slice(1) : search);
+  return params.get("testMode") === "1";
+}

--- a/src/ui_test/test_api.ts
+++ b/src/ui_test/test_api.ts
@@ -36,6 +36,8 @@ export interface IntehrgratorTestApi {
   armSlot(slotId: string): void;
   /** Programmatic bind (same path as Click-to-Map after Listening Mode). */
   bindFromNode(path: string, format: "json" | "xml"): void;
+  /** Programmatic bind to a slot (same path as drag-and-drop; skips Listening Mode). */
+  mapNodeToSlot(slotId: string, path: string, format: "json" | "xml"): void;
   runTest(): void;
   setAutoplay(on: boolean): void;
   getSnapshot(): WorkbenchTestSnapshot;

--- a/src/workbench/controller.ts
+++ b/src/workbench/controller.ts
@@ -253,7 +253,15 @@ export class WorkbenchController {
 
   bindFromNode(path: string, format: "json" | "xml"): void {
     if (!this.listeningSlotId) return;
-    const slot = collectValueSlots(this.skeleton).find((s) => s.slotId === this.listeningSlotId);
+    this.mapNodeToSlot(this.listeningSlotId, path, format);
+  }
+
+  /**
+   * Bind a source tree path to a Target value slot (Click-to-Map after Listening Mode,
+   * or drag-and-drop which skips Listening Mode).
+   */
+  mapNodeToSlot(slotId: string, path: string, format: "json" | "xml"): void {
+    const slot = collectValueSlots(this.skeleton).find((s) => s.slotId === slotId);
     if (!slot) return;
     const xpath = pathToFontoxpath(path, format);
     const expr = buildSourceQueryExpression(xpath, returnTypeForDv(slot.rmType));

--- a/src/workbench/controller.ts
+++ b/src/workbench/controller.ts
@@ -127,8 +127,14 @@ export class WorkbenchController {
   async openTemplate(): Promise<void> {
     const file = await this.host.pickFile(".opt,.opt2,.json,.adl,.adls,.xml");
     if (!file) return;
-    this.templateContent = await this.host.readTextFile(file);
-    this.templateFilename = file.name;
+    const content = await this.host.readTextFile(file);
+    this.loadTemplateContent(file.name, content);
+  }
+
+  /** Load OPT (or other target structure) from in-memory content — used by Workbench Test API and hosts. */
+  loadTemplateContent(filename: string, content: string): void {
+    this.templateContent = content;
+    this.templateFilename = filename;
     const result = generateSkeleton(this.templateContent);
     this.templateId = result.templateId;
     this.skeleton = result.skeleton;
@@ -143,11 +149,16 @@ export class WorkbenchController {
       const file = await this.host.pickFile(".json,application/json");
       if (!file) return;
       const content = await this.host.readTextFile(file);
-      this.applySchemaFile(file.name, content);
+      this.loadSchemaContent(file.name, content);
     } catch (err) {
       this.statusMessage = `Schema load failed: ${err instanceof Error ? err.message : String(err)}`;
       this.notifyChange();
     }
+  }
+
+  /** Load Source Schema from in-memory content — used by Workbench Test API and hosts. */
+  loadSchemaContent(filename: string, content: string): void {
+    this.applySchemaFile(filename, content);
   }
 
   async loadSchemaFromDrop(file: File): Promise<void> {
@@ -169,8 +180,13 @@ export class WorkbenchController {
     const file = await this.host.pickFile(".json,.xml");
     if (!file) return;
     const content = await this.host.readTextFile(file);
-    this.applyExampleFile(file.name, content);
-    this.statusMessage = `Added example ${file.name}`;
+    this.addExampleContent(file.name, content);
+  }
+
+  /** Add an Example Instance from in-memory content — used by Workbench Test API and hosts. */
+  addExampleContent(filename: string, content: string): void {
+    this.applyExampleFile(filename, content);
+    this.statusMessage = `Added example ${filename}`;
     this.markDirty();
     if (this.settings.autoplay) this.scheduleTestRun();
   }

--- a/src/workbench/tree_views.ts
+++ b/src/workbench/tree_views.ts
@@ -4,6 +4,39 @@ import { canonicalSyncPath } from "../core/source/schema_loader.ts";
 
 const SKELETON_INDENT_PX = 10;
 
+/** Custom MIME for Source Pane → value-slot drag-and-drop mapping. */
+export const SOURCE_DRAG_MIME = "application/x-intehrgrator-source";
+
+export interface SourceDragPayload {
+  path: string;
+  format: "json" | "xml";
+  origin: "schema" | "instance";
+}
+
+export function parseSourceDragPayload(dt: DataTransfer | null): SourceDragPayload | null {
+  if (!dt) return null;
+  const raw = dt.getData(SOURCE_DRAG_MIME) || dt.getData("text/plain");
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<SourceDragPayload>;
+    if (parsed.path && (parsed.format === "json" || parsed.format === "xml")) {
+      return {
+        path: parsed.path,
+        format: parsed.format,
+        origin: parsed.origin === "schema" || parsed.origin === "instance"
+          ? parsed.origin
+          : "instance",
+      };
+    }
+  } catch {
+    // plain path fallback (legacy / Playwright text-only drops)
+  }
+  if (raw.startsWith("$") || raw.startsWith("/")) {
+    return { path: raw, format: "json", origin: "instance" };
+  }
+  return null;
+}
+
 export interface TreeHighlightState {
   /** Canonical sync path shared across schema and instance trees. */
   syncPath: string | null;
@@ -51,11 +84,12 @@ export function renderInstanceTree(
   node: SchemaTreeNode,
   onSelect: (path: string) => void,
   options: SchemaTreeRenderOptions = {},
+  format: "json" | "xml" = "json",
 ): void {
   container.classList.add("instance-tree");
   container.classList.remove("schema-tree");
   container.innerHTML = "";
-  container.appendChild(buildInstanceNode(node, onSelect, options, 0));
+  container.appendChild(buildInstanceNode(node, onSelect, options, 0, format));
 }
 
 function buildSchemaNode(
@@ -73,7 +107,7 @@ function buildSchemaNode(
   meta.className = "tree-meta";
   meta.textContent = formatSchemaMeta(node);
   label.append(document.createTextNode(node.name), meta);
-  attachTreeInteractions(label, node.path, syncPath, "schema", onSelect, options);
+  attachTreeInteractions(label, node.path, syncPath, "schema", "json", onSelect, options);
   row.appendChild(label);
 
   const wrap = document.createElement("div");
@@ -89,6 +123,7 @@ function buildInstanceNode(
   onSelect: (path: string) => void,
   options: SchemaTreeRenderOptions,
   depth: number,
+  format: "json" | "xml",
 ): HTMLElement {
   const syncPath = canonicalSyncPath(node.path);
   const row = createTreeRow(node.path, syncPath, depth);
@@ -98,13 +133,13 @@ function buildInstanceNode(
   label.textContent = node.value !== undefined
     ? `${node.name}  ${formatValue(node.value)}`
     : node.name;
-  attachTreeInteractions(label, node.path, syncPath, "instance", onSelect, options);
+  attachTreeInteractions(label, node.path, syncPath, "instance", format, onSelect, options);
   row.appendChild(label);
 
   const wrap = document.createElement("div");
   wrap.appendChild(row);
   for (const child of node.children) {
-    wrap.appendChild(buildInstanceNode(child, onSelect, options, depth + 1));
+    wrap.appendChild(buildInstanceNode(child, onSelect, options, depth + 1, format));
   }
   return wrap;
 }
@@ -123,6 +158,7 @@ function attachTreeInteractions(
   path: string,
   syncPath: string,
   origin: "schema" | "instance",
+  format: "json" | "xml",
   onSelect: (path: string) => void,
   options: SchemaTreeRenderOptions,
 ): void {
@@ -134,7 +170,10 @@ function attachTreeInteractions(
   label.addEventListener("mouseenter", () => options.onHighlight?.(syncPath, origin));
   label.addEventListener("mouseleave", () => options.onHighlight?.(null, origin));
   label.addEventListener("dragstart", (e) => {
-    e.dataTransfer?.setData("text/plain", path);
+    const payload: SourceDragPayload = { path, format, origin };
+    const json = JSON.stringify(payload);
+    e.dataTransfer?.setData(SOURCE_DRAG_MIME, json);
+    e.dataTransfer?.setData("text/plain", json);
     if (e.dataTransfer) e.dataTransfer.effectAllowed = "copy";
   });
 }
@@ -156,12 +195,20 @@ export function renderSkeletonList(
   onArm: (slotId: string) => void,
   listeningSlotId: string | null,
   mappedSlots: Set<string>,
+  onDropSource?: (slotId: string, payload: SourceDragPayload) => void,
 ): void {
   container.innerHTML = "";
   const tree = document.createElement("ul");
   tree.className = "skeleton-tree";
   for (const node of skeleton) {
-    const branch = buildSkeletonBranch(node, onArm, listeningSlotId, mappedSlots, 0);
+    const branch = buildSkeletonBranch(
+      node,
+      onArm,
+      listeningSlotId,
+      mappedSlots,
+      0,
+      onDropSource,
+    );
     if (branch) tree.appendChild(branch);
   }
   if (!tree.childElementCount) {
@@ -177,14 +224,17 @@ function buildSkeletonBranch(
   listeningSlotId: string | null,
   mappedSlots: Set<string>,
   depth: number,
+  onDropSource?: (slotId: string, payload: SourceDragPayload) => void,
 ): HTMLElement | null {
   if (node.kind === "value") {
     if (isAutoFixedValueSlot(node)) return null;
-    return buildValueSlotItem(node, onArm, listeningSlotId, mappedSlots, depth);
+    return buildValueSlotItem(node, onArm, listeningSlotId, mappedSlots, depth, onDropSource);
   }
 
   const childBranches = node.children
-    .map((child) => buildSkeletonBranch(child, onArm, listeningSlotId, mappedSlots, depth + 1))
+    .map((child) =>
+      buildSkeletonBranch(child, onArm, listeningSlotId, mappedSlots, depth + 1, onDropSource)
+    )
     .filter((el): el is HTMLElement => el !== null);
   if (childBranches.length === 0) return null;
 
@@ -215,6 +265,7 @@ function buildValueSlotItem(
   listeningSlotId: string | null,
   mappedSlots: Set<string>,
   depth: number,
+  onDropSource?: (slotId: string, payload: SourceDragPayload) => void,
 ): HTMLElement {
   const li = document.createElement("li");
   li.className = "skeleton-tree-node slot-item";
@@ -241,5 +292,28 @@ function buildValueSlotItem(
   row.append(label, rmType);
   li.appendChild(row);
   li.addEventListener("click", () => onArm(node.slotId));
+
+  if (onDropSource) {
+    li.addEventListener("dragenter", (e) => {
+      e.preventDefault();
+      li.classList.add("drop-target");
+    });
+    li.addEventListener("dragover", (e) => {
+      e.preventDefault();
+      if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+      li.classList.add("drop-target");
+    });
+    li.addEventListener("dragleave", (e) => {
+      if (e.relatedTarget instanceof Node && li.contains(e.relatedTarget)) return;
+      li.classList.remove("drop-target");
+    });
+    li.addEventListener("drop", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      li.classList.remove("drop-target");
+      const payload = parseSourceDragPayload(e.dataTransfer);
+      if (payload) onDropSource(node.slotId, payload);
+    });
+  }
   return li;
 }

--- a/src/workbench/tree_views.ts
+++ b/src/workbench/tree_views.ts
@@ -218,6 +218,7 @@ function buildValueSlotItem(
 ): HTMLElement {
   const li = document.createElement("li");
   li.className = "skeleton-tree-node slot-item";
+  li.dataset.slotId = node.slotId;
   const mapped = mappedSlots.has(node.slotId);
   if (node.mandatory && !mapped) li.classList.add("unmapped-mandatory");
   if (mapped) li.classList.add("mapped");

--- a/tasks/TASKS-intehrgrator-v1.md
+++ b/tasks/TASKS-intehrgrator-v1.md
@@ -39,4 +39,5 @@ Update the file after completing each sub-task, not just after completing an ent
 - [x] Full Blockly skeleton injection from OPT (currently slot rail + spec)
 - [ ] Java Export UI + deeper TS codegen wiring to ehrtslib RM constructors
 - [ ] VS Code extension host adapter
-- [ ] E2E browser tests for click-to-map and Autoplay
+- [x] E2E browser tests for click-to-map (Workbench Test API + Playwright; see `docs/UI_TESTING.md`)
+- [ ] E2E coverage for Autoplay debounce / tab-switch cache

--- a/test/fixtures/ui/bp_example.json
+++ b/test/fixtures/ui/bp_example.json
@@ -1,0 +1,6 @@
+{
+  "patientId": "demo-001",
+  "systolic": 120,
+  "diastolic": 80,
+  "unit": "mm[Hg]"
+}

--- a/test/fixtures/ui/bp_source_schema.json
+++ b/test/fixtures/ui/bp_source_schema.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "properties": {
+    "patientId": { "type": "string" },
+    "systolic": { "type": "number" },
+    "diastolic": { "type": "number" },
+    "unit": { "type": "string" }
+  },
+  "required": ["patientId", "systolic", "diastolic"]
+}

--- a/test/ui/click_to_map_test.ts
+++ b/test/ui/click_to_map_test.ts
@@ -1,0 +1,140 @@
+/**
+ * Browser UI test: Click-to-Map in the Mapping Editor produces a sensible Test Run.
+ *
+ * Requires a built Web Shell on UI_TEST_BASE_URL (default http://127.0.0.1:5173)
+ * with `?testMode=1`. Prefer `deno task test:ui` which builds, serves, and runs this.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { dirname, fromFileUrl, join } from "@std/path";
+import { chromium, type Page } from "npm:playwright@1.51.0";
+import type { IntehrgratorTestApi } from "../../src/ui_test/test_api.ts";
+
+const root = join(dirname(fromFileUrl(import.meta.url)), "../..");
+const baseUrl = Deno.env.get("UI_TEST_BASE_URL") ?? "http://127.0.0.1:5173";
+const systolicSuffix = "items/at0004/value/value/value";
+
+async function fixtureText(rel: string): Promise<string> {
+  return await Deno.readTextFile(join(root, rel));
+}
+
+async function waitForTestApi(page: Page): Promise<void> {
+  await page.waitForFunction(() => {
+    const api = (globalThis as unknown as { intehrgratorTestApi?: IntehrgratorTestApi })
+      .intehrgratorTestApi;
+    return Boolean(api);
+  }, { timeout: 30_000 });
+  await page.evaluate(async () => {
+    await (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+      .intehrgratorTestApi.ready();
+  });
+}
+
+Deno.test({
+  name: "UI: click-to-map systolic → Test Run returns 120",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const opt = await fixtureText("test/fixtures/blood_pressure.opt");
+    const schema = await fixtureText("test/fixtures/ui/bp_source_schema.json");
+    const example = await fixtureText("test/fixtures/ui/bp_example.json");
+
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      await page.goto(`${baseUrl}/?testMode=1`, { waitUntil: "networkidle" });
+      await waitForTestApi(page);
+
+      await page.evaluate(
+        ({ opt, schema, example }) => {
+          const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+            .intehrgratorTestApi;
+          api.loadTemplate("blood_pressure.opt", opt);
+          api.loadSchema("bp_source_schema.json", schema);
+          api.addExample("bp_example.json", example);
+        },
+        { opt, schema, example },
+      );
+
+      // Let render sync Blockly Template Skeleton + trees.
+      await page.waitForTimeout(300);
+
+      const slotId = await page.evaluate((suffix) => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        return api.findSlotIdBySuffix(suffix);
+      }, systolicSuffix);
+      assert(slotId, `expected systolic slot ending with ${systolicSuffix}`);
+
+      // Real UI: arm Target value slot via slots rail (Listening Mode).
+      const slotItem = page.locator(`.slot-item[data-slot-id="${slotId}"]`);
+      await slotItem.waitFor({ timeout: 10_000 });
+      await slotItem.click();
+
+      const listening = await page.evaluate(() => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        return api.getSnapshot().listeningSlotId;
+      });
+      assertEquals(listening, slotId);
+
+      // Real UI: click Example Instance tree node for systolic.
+      await page.click('#example-tree .tree-row[data-path="$.systolic"] .tree-label');
+
+      // Blockly + Mapping Model should now hold the Mapping Expression.
+      await page.waitForFunction((id) => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        const snap = api.getSnapshot();
+        const slot = snap.model.slots.find((s) => s.slotId === id);
+        return Boolean(slot?.expression?.includes("systolic"));
+      }, slotId, { timeout: 10_000 });
+
+      const afterMap = await page.evaluate(() => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        return api.getSnapshot();
+      });
+      const mapped = afterMap.model.slots.find((s) => s.slotId === slotId);
+      assert(mapped?.expression.includes("xpathNumber"), mapped?.expression);
+      assert(mapped?.expression.includes("systolic"), mapped?.expression);
+      assert(
+        afterMap.blocklyBlocks.some((b) => b.type === "source_query"),
+        `expected source_query block after Click-to-Map, got: ${
+          afterMap.blocklyBlocks.map((b) => b.type).join(", ")
+        }`,
+      );
+
+      // Real UI: Run Test in Output Previews.
+      await page.click("#btn-run-test");
+      await page.waitForFunction(() => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        return api.getSnapshot().testResult != null;
+      }, { timeout: 10_000 });
+
+      const result = await page.evaluate((id) => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        const snap = api.getSnapshot();
+        const composition = snap.testResult?.composition as {
+          slots?: Record<string, unknown>;
+        } | undefined;
+        return {
+          ok: snap.testResult?.ok,
+          value: composition?.slots?.[id],
+          warnings: snap.testResult?.warnings ?? [],
+        };
+      }, slotId);
+
+      assertEquals(result.value, 120, `Test Run slots: ${JSON.stringify(result)}`);
+      assertEquals(result.ok, true, `warnings: ${result.warnings.join("; ")}`);
+
+      // Output Previews pane should show the evaluated value in the editor host.
+      const outputText = await page.locator("#test-output").innerText();
+      assert(outputText.includes("120"), outputText);
+    } finally {
+      await browser.close();
+    }
+  },
+});

--- a/test/ui/drag_drop_map_test.ts
+++ b/test/ui/drag_drop_map_test.ts
@@ -1,8 +1,6 @@
 /**
- * Browser UI test: Click-to-Map in the Mapping Editor produces a sensible Test Run.
- *
- * Requires a built Web Shell on UI_TEST_BASE_URL (default http://127.0.0.1:5173)
- * with `?testMode=1`. Prefer `deno task test:ui` which builds, serves, and runs this.
+ * Browser UI test: drag-and-drop mapping (source tree → Target value slot)
+ * skips Listening Mode and produces a sensible Test Run.
  */
 
 import { assert, assertEquals } from "@std/assert";
@@ -11,13 +9,14 @@ import {
   baseUrl,
   findSystolicSlotId,
   getSnapshot,
+  html5DragDrop,
   loadBpFixtures,
   waitForMappedSlot,
   waitForTestApi,
 } from "./helpers.ts";
 
 Deno.test({
-  name: "UI: click-to-map systolic → Test Run returns 120",
+  name: "UI: drag-and-drop systolic onto Target value slot → Test Run returns 120",
   sanitizeResources: false,
   sanitizeOps: false,
   async fn() {
@@ -29,28 +28,33 @@ Deno.test({
       await loadBpFixtures(page);
 
       const slotId = await findSystolicSlotId(page);
+      const slotSelector = `.slot-item[data-slot-id="${slotId}"]`;
+      await page.waitForSelector(slotSelector, { timeout: 10_000 });
 
-      // Real UI: arm Target value slot via slots rail (Listening Mode).
-      const slotItem = page.locator(`.slot-item[data-slot-id="${slotId}"]`);
-      await slotItem.waitFor({ timeout: 10_000 });
-      await slotItem.click();
+      // Must not require Listening Mode for drag-and-drop.
+      assertEquals((await getSnapshot(page)).listeningSlotId, null);
 
-      const listening = (await getSnapshot(page)).listeningSlotId;
-      assertEquals(listening, slotId);
-
-      // Real UI: click Example Instance tree node for systolic.
-      await page.click('#example-tree .tree-row[data-path="$.systolic"] .tree-label');
+      await html5DragDrop(
+        page,
+        '#example-tree .tree-row[data-path="$.systolic"] .tree-label',
+        slotSelector,
+      );
       await waitForMappedSlot(page, slotId);
 
       const afterMap = await getSnapshot(page);
+      assertEquals(afterMap.listeningSlotId, null, "drag-and-drop should not leave Listening Mode armed");
       const mapped = afterMap.model.slots.find((s) => s.slotId === slotId);
       assert(mapped?.expression.includes("xpathNumber"), mapped?.expression);
       assert(mapped?.expression.includes("systolic"), mapped?.expression);
       assert(
         afterMap.blocklyBlocks.some((b) => b.type === "source_query"),
-        `expected source_query block after Click-to-Map, got: ${
+        `expected source_query block after drag-and-drop, got: ${
           afterMap.blocklyBlocks.map((b) => b.type).join(", ")
         }`,
+      );
+      assert(
+        afterMap.statusMessage.toLowerCase().includes("mapped"),
+        afterMap.statusMessage,
       );
 
       await page.click("#btn-run-test");

--- a/test/ui/helpers.ts
+++ b/test/ui/helpers.ts
@@ -1,0 +1,111 @@
+import { dirname, fromFileUrl, join } from "@std/path";
+import type { Page } from "npm:playwright@1.51.0";
+import type { IntehrgratorTestApi, WorkbenchTestSnapshot } from "../../src/ui_test/test_api.ts";
+
+export const root = join(dirname(fromFileUrl(import.meta.url)), "../..");
+export const baseUrl = Deno.env.get("UI_TEST_BASE_URL") ?? "http://127.0.0.1:5173";
+export const systolicSuffix = "items/at0004/value/value/value";
+
+export async function fixtureText(rel: string): Promise<string> {
+  return await Deno.readTextFile(join(root, rel));
+}
+
+export async function waitForTestApi(page: Page): Promise<void> {
+  await page.waitForFunction(() => {
+    const api = (globalThis as unknown as { intehrgratorTestApi?: IntehrgratorTestApi })
+      .intehrgratorTestApi;
+    return Boolean(api);
+  }, { timeout: 30_000 });
+  await page.evaluate(async () => {
+    await (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+      .intehrgratorTestApi.ready();
+  });
+}
+
+export async function loadBpFixtures(page: Page): Promise<void> {
+  const opt = await fixtureText("test/fixtures/blood_pressure.opt");
+  const schema = await fixtureText("test/fixtures/ui/bp_source_schema.json");
+  const example = await fixtureText("test/fixtures/ui/bp_example.json");
+  await page.evaluate(
+    ({ opt, schema, example }) => {
+      const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+        .intehrgratorTestApi;
+      api.loadTemplate("blood_pressure.opt", opt);
+      api.loadSchema("bp_source_schema.json", schema);
+      api.addExample("bp_example.json", example);
+    },
+    { opt, schema, example },
+  );
+  // Let render sync Blockly Template Skeleton + trees.
+  await page.waitForTimeout(300);
+}
+
+export async function findSystolicSlotId(page: Page): Promise<string> {
+  const slotId = await page.evaluate((suffix) => {
+    const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+      .intehrgratorTestApi;
+    return api.findSlotIdBySuffix(suffix);
+  }, systolicSuffix);
+  if (!slotId) throw new Error(`expected systolic slot ending with ${systolicSuffix}`);
+  return slotId;
+}
+
+export async function getSnapshot(page: Page): Promise<WorkbenchTestSnapshot> {
+  return await page.evaluate(() => {
+    const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+      .intehrgratorTestApi;
+    return api.getSnapshot();
+  });
+}
+
+export async function waitForMappedSlot(page: Page, slotId: string): Promise<void> {
+  await page.waitForFunction((id) => {
+    const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+      .intehrgratorTestApi;
+    const snap = api.getSnapshot();
+    const slot = snap.model.slots.find((s) => s.slotId === id);
+    return Boolean(slot?.expression?.includes("systolic"));
+  }, slotId, { timeout: 10_000 });
+}
+
+/**
+ * HTML5 drag-and-drop with DataTransfer payload.
+ * Playwright's locator.dragTo does not reliably populate custom MIME types.
+ */
+export async function html5DragDrop(
+  page: Page,
+  sourceSelector: string,
+  targetSelector: string,
+): Promise<void> {
+  await page.waitForSelector(sourceSelector, { timeout: 10_000 });
+  await page.waitForSelector(targetSelector, { timeout: 10_000 });
+  const ok = await page.evaluate(
+    ({ sourceSelector, targetSelector }) => {
+      const source = document.querySelector(sourceSelector);
+      const target = document.querySelector(targetSelector);
+      if (!(source instanceof HTMLElement) || !(target instanceof HTMLElement)) {
+        return false;
+      }
+
+      const dt = new DataTransfer();
+      source.dispatchEvent(
+        new DragEvent("dragstart", { bubbles: true, cancelable: true, dataTransfer: dt }),
+      );
+      target.dispatchEvent(
+        new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: dt }),
+      );
+      target.dispatchEvent(
+        new DragEvent("dragover", { bubbles: true, cancelable: true, dataTransfer: dt }),
+      );
+      target.dispatchEvent(
+        new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: dt }),
+      );
+      source.dispatchEvent(
+        new DragEvent("dragend", { bubbles: true, cancelable: true, dataTransfer: dt }),
+      );
+      return true;
+    },
+    { sourceSelector, targetSelector },
+  );
+  if (!ok) throw new Error(`html5DragDrop failed: ${sourceSelector} → ${targetSelector}`);
+}

--- a/test/workbench_load_test.ts
+++ b/test/workbench_load_test.ts
@@ -1,0 +1,64 @@
+import { assertEquals, assert } from "@std/assert";
+import { join } from "@std/path";
+import { WorkbenchController } from "@intehrgrator/workbench/controller.ts";
+import { collectValueSlots } from "@intehrgrator/core/skeleton/generate_skeleton.ts";
+import type { HostAdapter } from "@intehrgrator/host/web_adapter.ts";
+import type { ProjectBundle } from "@intehrgrator/types/mod.ts";
+import type { LoadableProjectEntry, StoredProjectRecord } from "@intehrgrator/core/persistence/mod.ts";
+
+function stubHost(): HostAdapter {
+  return {
+    pickFile: async () => null,
+    readTextFile: async () => "",
+    downloadText: () => {},
+    downloadBytes: () => {},
+    copyToClipboard: async () => {},
+    readClipboard: async () => "",
+    saveProject: async () => {},
+    loadProject: async () => null,
+    listProjects: async () => [] as ProjectBundle[],
+    saveAutosave: async () => {},
+    saveManualSave: async () => {},
+    loadStoredProject: async () => null,
+    loadStoredProjectRecord: async () => null as StoredProjectRecord | null,
+    listLoadableProjects: async () => [] as LoadableProjectEntry[],
+  };
+}
+
+Deno.test("controller loads template/schema/example from content", async () => {
+  const opt = await Deno.readTextFile(
+    join(import.meta.dirname!, "fixtures", "blood_pressure.opt"),
+  );
+  const schema = await Deno.readTextFile(
+    join(import.meta.dirname!, "fixtures", "ui", "bp_source_schema.json"),
+  );
+  const example = await Deno.readTextFile(
+    join(import.meta.dirname!, "fixtures", "ui", "bp_example.json"),
+  );
+
+  const controller = new WorkbenchController(stubHost());
+  controller.loadTemplateContent("blood_pressure.opt", opt);
+  controller.loadSchemaContent("bp_source_schema.json", schema);
+  controller.addExampleContent("bp_example.json", example);
+
+  const state = controller.getState();
+  assert(state.templateId.includes("blood_pressure"));
+  assert(state.schemaTree);
+  assertEquals(state.examples.length, 1);
+  assertEquals(state.activeExample?.filename, "bp_example.json");
+
+  const slotId = collectValueSlots(state.skeleton).find((s) =>
+    s.slotId.endsWith("items/at0004/value/value/value")
+  )?.slotId;
+  assert(slotId);
+
+  controller.armSlot(slotId);
+  controller.bindFromNode("$.systolic", "json");
+  controller.runTestNow();
+
+  const after = controller.getState();
+  const composition = after.testResult?.composition as {
+    slots?: Record<string, unknown>;
+  };
+  assertEquals(composition?.slots?.[slotId], 120);
+});

--- a/test/workbench_load_test.ts
+++ b/test/workbench_load_test.ts
@@ -62,3 +62,34 @@ Deno.test("controller loads template/schema/example from content", async () => {
   };
   assertEquals(composition?.slots?.[slotId], 120);
 });
+
+Deno.test("mapNodeToSlot binds without Listening Mode (drag-and-drop path)", async () => {
+  const opt = await Deno.readTextFile(
+    join(import.meta.dirname!, "fixtures", "blood_pressure.opt"),
+  );
+  const example = await Deno.readTextFile(
+    join(import.meta.dirname!, "fixtures", "ui", "bp_example.json"),
+  );
+
+  const controller = new WorkbenchController(stubHost());
+  controller.loadTemplateContent("blood_pressure.opt", opt);
+  controller.addExampleContent("bp_example.json", example);
+
+  const slotId = collectValueSlots(controller.getState().skeleton).find((s) =>
+    s.slotId.endsWith("items/at0004/value/value/value")
+  )?.slotId;
+  assert(slotId);
+  assertEquals(controller.getState().listeningSlotId, null);
+
+  controller.mapNodeToSlot(slotId, "$.systolic", "json");
+  assertEquals(controller.getState().listeningSlotId, null);
+
+  const mapped = controller.getState().model.slots.find((s) => s.slotId === slotId);
+  assert(mapped?.expression.includes("systolic"));
+
+  controller.runTestNow();
+  const composition = controller.getState().testResult?.composition as {
+    slots?: Record<string, unknown>;
+  };
+  assertEquals(composition?.slots?.[slotId], 120);
+});

--- a/web/main.ts
+++ b/web/main.ts
@@ -1,8 +1,15 @@
 import * as Blockly from "blockly/core";
 import { WebHostAdapter } from "../src/host/web_adapter.ts";
 import { WorkbenchController } from "../src/workbench/controller.ts";
-import { renderSchemaTree, renderInstanceTree, renderSkeletonList, applyTreeHighlights } from "../src/workbench/tree_views.ts";
+import {
+  renderSchemaTree,
+  renderInstanceTree,
+  renderSkeletonList,
+  applyTreeHighlights,
+  parseSourceDragPayload,
+} from "../src/workbench/tree_views.ts";
 import type { TreeHighlightState } from "../src/workbench/tree_views.ts";
+import type { BlockSvg } from "blockly/core";
 import { canonicalSyncPath } from "../src/core/source/schema_loader.ts";
 import {
   createReadonlyEditor,
@@ -162,6 +169,7 @@ async function bootBlockly(): Promise<void> {
 
   initSplitPanes(document, () => Blockly.svgResize(workspace));
   controller.setBlocklyStateGetter(() => Blockly.serialization.workspaces.save(workspace));
+  initBlocklySourceDrop();
 
   workspace.addChangeListener((event) => {
     if (event.type === Blockly.Events.CLICK && "blockId" in event) {
@@ -255,6 +263,50 @@ bind("btn-copy-ai", () => controller.copyAiPrompt());
 bind("btn-import-ai", () => controller.importAiSuggestionsFromClipboard());
 
 initFileDropTargets();
+
+/** Drop Source Pane paths onto Blockly value-slot blocks (skips Listening Mode). */
+function initBlocklySourceDrop(): void {
+  const onDragOver = (event: DragEvent) => {
+    if (!event.dataTransfer?.types?.length) return;
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = "copy";
+  };
+  blocklyMount.addEventListener("dragenter", onDragOver);
+  blocklyMount.addEventListener("dragover", onDragOver);
+  blocklyMount.addEventListener("drop", (event) => {
+    event.preventDefault();
+    const payload = parseSourceDragPayload(event.dataTransfer);
+    if (!payload) return;
+    const slotId = findSlotIdAtPoint(event.clientX, event.clientY);
+    if (!slotId) {
+      statusMain.textContent = "Drop onto a value slot block to map.";
+      return;
+    }
+    controller.mapNodeToSlot(slotId, payload.path, payload.format);
+  });
+}
+
+function findSlotIdAtPoint(clientX: number, clientY: number): string | null {
+  let best: { slotId: string; area: number } | null = null;
+  for (const block of workspace.getAllBlocks(false)) {
+    const slotId = slotIdFromBlock(block);
+    if (!slotId) continue;
+    const svg = block as BlockSvg;
+    const root = typeof svg.getSvgRoot === "function" ? svg.getSvgRoot() : null;
+    if (!root) continue;
+    const rect = root.getBoundingClientRect();
+    if (
+      clientX < rect.left || clientX > rect.right ||
+      clientY < rect.top || clientY > rect.bottom
+    ) {
+      continue;
+    }
+    const area = rect.width * rect.height;
+    // Prefer the smallest containing block (leaf value slot over containers).
+    if (!best || area < best.area) best = { slotId, area };
+  }
+  return best?.slotId ?? null;
+}
 
 function initFileDropTargets(): void {
   initFileDrop(schemaTreeEl, {
@@ -436,6 +488,7 @@ function render(): void {
         controller.bindFromNode(path, format);
       },
       treeHighlightOptions(),
+      format,
     );
     applyTreeHighlights(schemaTreeEl, exampleTreeEl, activeTreeHighlight(s));
   } else {
@@ -450,6 +503,9 @@ function render(): void {
     (slotId) => controller.armSlot(slotId),
     s.listeningSlotId,
     new Set(s.model.slots.filter((x) => x.expression).map((x) => x.slotId)),
+    (slotId, payload) => {
+      controller.mapNodeToSlot(slotId, payload.path, payload.format);
+    },
   );
 
   setEditorDoc(specEditor, s.specText || "# Mapping Specification appears after loading a target schema/template");
@@ -562,6 +618,9 @@ function installWorkbenchTestApi(): void {
     },
     bindFromNode(path, format) {
       controller.bindFromNode(path, format);
+    },
+    mapNodeToSlot(slotId, path, format) {
+      controller.mapNodeToSlot(slotId, path, format);
     },
     runTest() {
       controller.runTestNow();

--- a/web/main.ts
+++ b/web/main.ts
@@ -31,9 +31,20 @@ import {
 import { BUILD_ID, BUILD_TIMESTAMP } from "./build_info.ts";
 import { initSplitPanes } from "../src/ui/split_pane.ts";
 import { formatSaveTime } from "../src/core/persistence/mod.ts";
+import { collectValueSlots } from "../src/core/skeleton/generate_skeleton.ts";
+import {
+  isTestMode,
+  type IntehrgratorTestApi,
+  type WorkbenchTestSnapshot,
+} from "../src/ui_test/test_api.ts";
 
 const host = new WebHostAdapter();
 const controller = new WorkbenchController(host);
+const testMode = isTestMode();
+let workbenchReadyResolve!: () => void;
+const workbenchReady = new Promise<void>((resolve) => {
+  workbenchReadyResolve = resolve;
+});
 
 const schemaTreeEl = document.getElementById("schema-tree")!;
 const exampleTabsEl = document.getElementById("example-tabs")!;
@@ -534,10 +545,65 @@ function renderExampleValidation(s: ReturnType<WorkbenchController["getState"]>)
   exampleValidationEl.append(title, list);
 }
 
+function installWorkbenchTestApi(): void {
+  const api: IntehrgratorTestApi = {
+    ready: () => workbenchReady,
+    loadTemplate(filename, content) {
+      controller.loadTemplateContent(filename, content);
+    },
+    loadSchema(filename, content) {
+      controller.loadSchemaContent(filename, content);
+    },
+    addExample(filename, content) {
+      controller.addExampleContent(filename, content);
+    },
+    armSlot(slotId) {
+      controller.armSlot(slotId);
+    },
+    bindFromNode(path, format) {
+      controller.bindFromNode(path, format);
+    },
+    runTest() {
+      controller.runTestNow();
+    },
+    setAutoplay(on) {
+      const s = controller.getState();
+      if (s.settings.autoplay !== on) controller.toggleAutoplay();
+    },
+    getSnapshot(): WorkbenchTestSnapshot {
+      const s = controller.getState();
+      const blocklyBlocks = workspace.getAllBlocks(false).map((block) => ({
+        id: block.id,
+        type: block.type,
+        slotId: slotIdFromBlock(block),
+      }));
+      return {
+        templateId: s.templateId,
+        listeningSlotId: s.listeningSlotId,
+        exampleCount: s.examples.length,
+        activeExampleFilename: s.activeExample?.filename ?? null,
+        model: s.model,
+        testResult: s.testResult,
+        statusMessage: s.statusMessage,
+        autoplay: s.settings.autoplay,
+        unmappedMandatory: s.unmappedMandatory,
+        blocklyBlocks,
+      };
+    },
+    findSlotIdBySuffix(suffix) {
+      const slots = collectValueSlots(controller.getState().skeleton);
+      return slots.find((slot) => slot.slotId.endsWith(suffix))?.slotId ?? null;
+    },
+  };
+  globalThis.window.intehrgratorTestApi = api;
+}
+
 async function main(): Promise<void> {
+  if (testMode) installWorkbenchTestApi();
   await bootBlockly();
   controller.subscribe(render);
   render();
+  workbenchReadyResolve();
 }
 
 void main();

--- a/web/styles.css
+++ b/web/styles.css
@@ -238,6 +238,11 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
 }
 .slot-item:hover .skeleton-tree-row { border-color: var(--primary); }
 .slot-item.listening .skeleton-tree-row { outline: 2px solid var(--accent); outline-offset: -1px; }
+.slot-item.drop-target .skeleton-tree-row {
+  outline: 2px dashed var(--accent);
+  outline-offset: -1px;
+  background: #fff4ea;
+}
 .slot-item.unmapped-mandatory .skeleton-tree-row { border-color: var(--error); }
 .slot-item.unmapped-mandatory .slot-label { color: var(--error); }
 .slot-item.mapped .skeleton-tree-row { border-color: var(--success); }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First-cut **Workbench Test API** + Playwright UI harness so Click-to-Map and drag-and-drop mapping through Blockly can be asserted end-to-end, plus an architecture review aimed at openEHR-as-source (kintegrate merge) and separate Web Shell / VS Code builds.

### UI testing
- `?testMode=1` exposes `window.intehrgratorTestApi` (kintegrate `formTestApi`-style setup seam)
- Controller content loaders for OPT / Source Schema / Example Instance (no file picker)
- **Click-to-Map:** arm Target value slot → click Example Instance `$.systolic` → **Run Test** → expect `120`
- **Drag-and-drop:** drag Example Instance `$.systolic` onto Target value slot (no Listening Mode) → **Run Test** → expect `120`
- Drop also wired onto the Blockly canvas; slots-rail drop is what the Playwright test exercises
- `deno task test:ui` builds, serves `dist/`, installs Chromium via npx, runs `test/ui/`
- Docs: `docs/UI_TESTING.md`; glossary term in `CONTEXT.md`

### Architecture review
Committed report (open in browser):

**[docs/reviews/architecture-review-openehr-source-dual-builds.html](../blob/cursor/ui-testing-and-architecture-eb6c/docs/reviews/architecture-review-openehr-source-dual-builds.html)**

Top candidates: **Source Format Handler** seam, **Host Abstraction + dual builds**, then **Mapping pipeline / Test Run depth**.

## Test plan
- [x] `deno task test` (52 unit tests)
- [x] `deno task test:ui` — Click-to-Map + drag-and-drop UI tests
- [ ] Optional: add `test:ui` as a CI job once Chromium install time is acceptable

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7be08e05-f3a3-46e3-bb5c-cf627f5eeb6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7be08e05-f3a3-46e3-bb5c-cf627f5eeb6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

