### PR TITLE
Source Format Handler seam + context-root decision vs Blockly for_each_source

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,14 @@ _Avoid_: Current instance, selected tab
 XPath or XQuery expression (fontoxpath) identifying a value in the loaded JSON or XML source. Click-to-map inserts the expression; the app picks the typed fontoxpath evaluator (`evaluateXPathToString`, `evaluateXPathToNumber`, etc.) from the target slot's `DV_*` type.
 _Avoid_: JSON path, get_source dot notation
 
+**Source Format Handler**:
+Small adapter interface (`loadSchema`, `loadInstance`, `pathToExpression`, `createContext`, `evaluate`) that isolates JSON / XML (and later openEHR-as-source) quirks from Click-to-Map, Test Run, and codegen. See `docs/SOURCE_FORMATS.md`.
+_Avoid_: Format switch, source parser union
+
+**Source iteration (`for_each_source`)**:
+Blockly loop that binds each node from a multi-valued Source Path to a named variable. Preferred way to map over a substructure — not a Source Pane “context root” framing (kintegrate Handlebars pattern). See `docs/future/source-context-root.md`.
+_Avoid_: Context boundary, frame as context root (unless discussing kintegrate)
+
 **Mapping Editor**:
 The center pane where the user authors mapping logic. Header action **Open target Schema/Template** loads the OPT (or other target structure). Default layout is a vertical split: nested Blockly blocks on top (with **Target value slots** rail), [CodeMirror](https://codemirror.net/) on the bottom, kept in bidirectional sync. A minimap appears when the blockly block canvas exceeds the visible area at the current zoom level.
 _Avoid_: Target pane, center panel, BlockMirror (that is a third-party sync pattern reference, not our editor library)

--- a/docs/BLOCKLY_INTEGRATION.md
+++ b/docs/BLOCKLY_INTEGRATION.md
@@ -69,7 +69,9 @@ categories **Source** and **Data values**. See [Attribution](#attribution).
 - **Source:** `source_query` — XPath/XQuery via [fontoxpath](https://github.com/FontoXML/fontoxpath);
   typed `evaluateXPathTo*` from target slot `DV_*` type (see [SOURCE_QUERY.md](SOURCE_QUERY.md))
 - **Loops (custom):** `for_each_source` — iterate nodes from a multi-valued source path
-  into a named mapping variable (alongside stock `controls_forEach`)
+  into a named mapping variable (alongside stock `controls_forEach`). This is the
+  supported way to scope mapping over a substructure; a kintegrate-style Source Pane
+  “context root” is not required — see [future/source-context-root.md](future/source-context-root.md).
 
 ## Attribution
 

--- a/docs/MAPPING_SPECIFICATION.md
+++ b/docs/MAPPING_SPECIFICATION.md
@@ -99,9 +99,19 @@ element.setValue(new DvQuantity({
 
 The spec holds `xpathNumber("/patient/vitals[1]/systolic")`; the generator wraps it in RM construction code.
 
+## Direction note
+
+Architecture review candidate 3 proposes preferring **Blockly native JSON**
+(`Blockly.serialization.workspaces.save`) as the Mapping Specification /
+interchange surface, with Mapping Model kept as a derived `slotId` → expression
+index — instead of growing this custom DSL. See
+[reviews/architecture-review-openehr-source-dual-builds.html](reviews/architecture-review-openehr-source-dual-builds.html).
+Until that lands, this document describes the current `toSpec` projection.
+
 ## Related
 
 - [BLOCKLY_INTEGRATION.md](BLOCKLY_INTEGRATION.md) — blocks and generators
 - [PROJECT_PERSISTENCE.md](PROJECT_PERSISTENCE.md) — Mapping Model JSON
 - [SOURCE_QUERY.md](SOURCE_QUERY.md) — fontoxpath evaluators
 - [docs/future/text-first-mapping-editor.md](future/text-first-mapping-editor.md)
+- [reviews/architecture-review-openehr-source-dual-builds.html](reviews/architecture-review-openehr-source-dual-builds.html) — candidate 3

--- a/docs/SOURCE_FORMATS.md
+++ b/docs/SOURCE_FORMATS.md
@@ -8,6 +8,29 @@
 | JSON instance | ✓ | `JSON.parse` | fontoxpath (example tabs + Test Run) |
 | XML instance | ✓ | `DOMParser` | fontoxpath (example tabs + Test Run) |
 | XML schema (XSD) | Deferred | — | [future/xml-schema-support.md](future/xml-schema-support.md) |
+| openEHR Composition / FLAT / STRUCTURED as source | Planned | Adapter behind Source Format Handler | Same seam; quirks stay in the adapter |
+
+## Source Format Handler
+
+Callers (Click-to-Map, Test Run, instance validation, schema load) go through a small **Source Format Handler** interface instead of branching on `"json" | "xml"` in every module:
+
+| Method | Role |
+|--------|------|
+| `loadSchema(content, rootName?)` | Schema tree for the Source Pane |
+| `loadInstance(content, rootName?)` | Example-instance tree |
+| `pathToExpression(schemaPath)` | Tree path → fontoxpath string for Mapping Expressions |
+| `createContext(content)` | Runtime context for evaluation |
+| `evaluate(expression, ctx, returnType)` | Run a Mapping Expression against that context |
+
+Built-in adapters: **JSON**, **XML**. Register more with `registerSourceFormatHandler` (e.g. future `openehr-composition`).
+
+| Module | Path |
+|--------|------|
+| Interface + registry | `src/core/source/format_handler.ts` |
+| Public re-exports | `src/core/source/mod.ts` |
+| Format id on bundles | `SourceFormatId` in `src/types/mod.ts` |
+
+Low-level helpers (`schema_loader`, `query_runtime`) remain implementation details of the adapters; new formats should not require forking the workbench controller.
 
 ## Source Pane layout
 
@@ -24,7 +47,11 @@ See [UI_ARCHITECTURE.md](UI_ARCHITECTURE.md) — Source Pane.
 
 All source path expressions use **fontoxpath** (XPath 3.1 / XQuery 3.1) for both JSON and XML. See [SOURCE_QUERY.md](SOURCE_QUERY.md).
 
-Click-to-map works from **either** the schema tree or the **active example tab** tree; both insert fontoxpath expressions into `source_query` blocks.
+Click-to-map works from **either** the schema tree or the **active example tab** tree; both insert fontoxpath expressions into `source_query` blocks via `handler.pathToExpression`.
+
+## Iteration / “context root”
+
+kintegrate’s “Frame this node as context root” is **not** planned as a Source Pane feature. Blockly `for_each_source` (and stock loops) already bind iteration scope. See [future/source-context-root.md](future/source-context-root.md).
 
 ## openEHR XML (ehrtslib alignment)
 
@@ -45,4 +72,5 @@ Converted instance results are displayed. The lower **Conversion Test Run(s)** s
 - [SOURCE_QUERY.md](SOURCE_QUERY.md) — fontoxpath, typed evaluators
 - [UI_ARCHITECTURE.md](UI_ARCHITECTURE.md) — Source Pane, example tabs
 - [PROJECT_PERSISTENCE.md](PROJECT_PERSISTENCE.md) — multiple examples in bundle
+- [future/source-context-root.md](future/source-context-root.md) — context root vs `for_each_source`
 - [CONTEXT.md](../CONTEXT.md) — Source Schema, Example Instance, Active Example

--- a/docs/future/source-context-root.md
+++ b/docs/future/source-context-root.md
@@ -1,0 +1,81 @@
+# Source context root vs Blockly `for_each_source`
+
+## Decision
+
+**Do not port kintegrate’s “Frame this node as context root” as a Source Pane tree feature.**
+
+intEHRgrator already scopes iteration explicitly with Blockly (`for_each_source`, and stock `controls_forEach` / variables). That covers the need that makes context roots essential in Handlebars-based kintegrate.
+
+## What kintegrate’s feature does
+
+In [kintegrate](https://github.com/ErikSundvall/kintegrate) Integration Builder (DeepWiki: JSON Tree Viewer / path generation):
+
+| Concern | Behavior |
+|---------|----------|
+| UI | Right-click tree node → “Set as context boundary” / remove |
+| State | `ExtendedTree.setContextBoundary(nodeId, boolean)` |
+| Path gen | `buildHandlebarsPath` / `buildHandlebarsTree` call `findNearestContextBoundary` and emit paths **relative** to that ancestor |
+| Why | Handlebars `{{#with}}` / `{{#each}}` make inner paths relative to the current context; click-to-insert must match that implicit scope |
+
+Context roots are a **tree-side framing** so relative Handlebars paths stay correct inside those blocks.
+
+## Why Blockly makes tree framing mostly unnecessary
+
+| kintegrate | intEHRgrator |
+|------------|--------------|
+| Implicit Handlebars context | Explicit loop / variable blocks |
+| Relative path strings by default inside `{{#each}}` | `source_query` uses document-rooted fontoxpath (`$…` / `/…`) against `sourceCtx` |
+| Tree menu marks the `{{#with}}` boundary | `for_each_source` binds `VAR` from `PATH` via `evaluateXPathToNodes` and stores the node in `__vars[name]` |
+
+Click-to-Map today always inserts an absolute source path through the [Source Format Handler](../SOURCE_FORMATS.md#source-format-handler). Nested mapping under a loop is authored by:
+
+1. Placing `for_each_source` with an absolute multi-node `PATH`
+2. Using the loop variable (and/or absolute `source_query` paths) inside the body
+
+No separate “frame this node” tree state is required for that workflow.
+
+## Residual gap (optional, Blockly-scoped — not a tree context root)
+
+If Click-to-Map while a listening slot sits **inside** a `for_each_source` body should insert a **relative** path evaluated against the current loop node, that is a Blockly-scope concern:
+
+- Detect nearest enclosing `for_each_source` (or equivalent `with`)
+- Relativize the clicked path against the loop `PATH`
+- Optionally evaluate nested `source_query` with context node = `__vars[VAR]` instead of document root
+
+That is **not** the same as persisting a context-boundary mark on the Source Schema tree. Prefer Blockly ancestry over kintegrate-style tree framing.
+
+### Interface sketch (only if product asks for relative Click-to-Map)
+
+```ts
+/** Resolved when Click-to-Map runs inside a source loop / with block. */
+interface SourceIterationScope {
+  /** Blockly block id of the enclosing for_each_source (or future with_source). */
+  blockId: string;
+  /** Absolute fontoxpath of the iterated nodes (for_each_source PATH). */
+  iterationPath: string;
+  /** Variable name bound to the current node. */
+  varName: string;
+}
+
+interface RelativeSourceBind {
+  /** Absolute path of the clicked tree node. */
+  absolutePath: string;
+  /** Path relative to iterationPath, suitable for eval against the loop node. */
+  relativePath: string;
+  scope: SourceIterationScope;
+}
+
+// Workbench / Source Format Handler extension points (future):
+// findEnclosingSourceIteration(workspace, slotBlockId): SourceIterationScope | null
+// relativizeSourcePath(absolutePath, scope.iterationPath, format): string
+// handler.evaluate(expr, ctx, returnType, { contextNode?: unknown })
+```
+
+Until relative bind is implemented, document absolute paths + `for_each_source` as the supported pattern.
+
+## Related
+
+- [BLOCKLY_INTEGRATION.md](../BLOCKLY_INTEGRATION.md) — `for_each_source`
+- [SOURCE_FORMATS.md](../SOURCE_FORMATS.md) — Source Format Handler
+- [SOURCE_QUERY.md](../SOURCE_QUERY.md) — fontoxpath evaluators
+- Architecture review candidate 1 — `docs/reviews/architecture-review-openehr-source-dual-builds.html`

--- a/docs/reviews/architecture-review-openehr-source-dual-builds.html
+++ b/docs/reviews/architecture-review-openehr-source-dual-builds.html
@@ -102,7 +102,7 @@
           <h2 class="display text-2xl font-semibold">1. Source Format Handler seam</h2>
           <p class="text-sm text-slate-600 mt-1">Files: <code>src/core/source/*</code>, <code>src/types/mod.ts</code>, <code>src/core/expression/mod.ts</code>, <code>src/core/codegen/mod.ts</code>, <code>src/workbench/controller.ts</code></p>
         </div>
-        <span class="badge-strong text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Strong</span>
+        <span class="badge-strong text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">In progress</span>
       </div>
       <div class="px-6 py-5 space-y-4">
         <div>
@@ -211,7 +211,80 @@ flowchart TB
     <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
       <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 class="display text-2xl font-semibold">3. Mapping pipeline depth (Sync Scope → Test Run)</h2>
+          <h2 class="display text-2xl font-semibold">3. Prefer Blockly JSON over a custom Mapping Spec DSL</h2>
+          <p class="text-sm text-slate-600 mt-1">Files: <code>docs/MAPPING_SPECIFICATION.md</code>, <code>src/core/spec/mod.ts</code>, <code>src/core/mapping_model</code>, <code>ProjectBundle.mapping.blocklyState</code>, AI suggestion format</p>
+        </div>
+        <span class="badge-strong text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Strong</span>
+      </div>
+      <div class="px-6 py-5 space-y-4">
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Problem</h3>
+          <p class="text-slate-700 mt-1">
+            Sync Scope today invents a third language: Blockly blocks ⇄ Mapping Model ⇄ custom block-aligned DSL (<code>toSpec</code> / <code>@template composition { … }</code>).
+            That DSL is not known to LLMs, not used by other tools, and duplicates structure already in
+            <code>Blockly.serialization.workspaces.save</code> (persisted as <code>blocklyState</code>).
+            Deletion test: removing <code>core/spec</code> mostly removes projection chrome — Mapping Model + Blockly JSON already carry the mapping.
+            Growing the DSL toward text-first editing doubles maintenance without industry familiarity.
+          </p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Solution</h3>
+          <p class="text-slate-700 mt-1">
+            Treat <strong>Blockly native JSON</strong> as the canonical Mapping Specification / interchange surface
+            (DeepWiki: <code>RaspberryPiFoundation/blockly</code> serialization — documented <code>blocks</code> / <code>fields</code> / <code>inputs</code> / <code>extraState</code> contract; intended for restore <em>and</em> interchange).
+            Keep the slim <strong>Mapping Model</strong> (<code>slotId</code> → expression) as a <em>derived index</em> for AI patch import
+            (<code>intehrgrator-suggestions</code>), validation, and Test Run — not a parallel structural language.
+            Center CodeMirror should show pretty-printed Blockly JSON (optionally stripped of <code>x</code>/<code>y</code> for readability) or the Mapping Model slot list — not a hand-rolled DSL.
+            Informatician expression edits either patch Blockly field JSON paths or the derived <code>slots[]</code>; structural edits stay in Blockly / Optional RM Insertion.
+          </p>
+        </div>
+        <div>
+          <h3 class="font-semibold text-[color:var(--teal-deep)]">Benefits</h3>
+          <ul class="list-disc pl-5 text-slate-700 space-y-1 mt-1">
+            <li><strong>Leverage:</strong> LLMs and tooling already see Blockly serialization in the wild; no need to teach a private DSL.</li>
+            <li><strong>Locality:</strong> one structural truth (<code>blocklyState</code>); Mapping Model regenerates from it; <code>toSpec</code> can shrink or die.</li>
+            <li><strong>AI path:</strong> bulk structure via Blockly JSON; slot fills via existing small suggestion envelope — best of both.</li>
+          </ul>
+        </div>
+        <div class="callout-warn">
+          Caveat: raw workspace JSON includes UI chrome (coordinates, shadows, ids). Persist the full form; for human/LLM <em>review</em> prefer a filtered projection
+          (drop <code>x</code>/<code>y</code>, maybe collapse fixed RM shells) or the Mapping Model slot table — still JSON, still not a new grammar.
+          Blockly major bumps can change serialization; pin Blockly and keep Mapping Model as the migration-friendly index.
+        </div>
+        <div class="mass">
+          <div class="mass-col shallow">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">Before — three languages</div>
+            <div class="iface">custom DSL ⇄ Mapping Model ⇄ Blockly JSON</div>
+            <div class="impl">toSpec projection · expression line parser · AI learns private @template syntax · dual persistence confusion</div>
+          </div>
+          <div class="mass-col deep">
+            <div class="text-xs uppercase tracking-wide text-slate-500 mb-2">After — Blockly JSON + derived index</div>
+            <div class="iface">blocklyState (canonical) → Mapping Model slots[] (derived)</div>
+            <div class="impl">CodeMirror: Blockly JSON or slots JSON · AI: suggestions envelope and/or Blockly JSON patches · codegen/Test Run from Model</div>
+          </div>
+        </div>
+        <pre class="mermaid">
+flowchart LR
+  BW[Blockly workspace]
+  BJ[Blockly serialization JSON]
+  MM[Mapping Model slot index]
+  AI[AI suggestions / LLM edits]
+  CG[Codegen / Test Run]
+  BW --> BJ
+  BJ --> MM
+  AI --> BJ
+  AI --> MM
+  MM --> CG
+  BJ --> BW
+        </pre>
+      </div>
+    </article>
+
+    <!-- Candidate 4 -->
+    <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
+      <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 class="display text-2xl font-semibold">4. Mapping pipeline depth (Sync Scope → Test Run)</h2>
           <p class="text-sm text-slate-600 mt-1">Files: <code>src/blockly/*</code>, <code>src/core/mapping_model</code>, <code>src/core/codegen</code>, <code>src/core/test_runner</code>, <code>web/main.ts</code></p>
         </div>
         <span class="badge-strong text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Strong</span>
@@ -219,11 +292,11 @@ flowchart TB
       <div class="px-6 py-5 space-y-4">
         <div>
           <h3 class="font-semibold text-[color:var(--teal-deep)]">Problem</h3>
-          <p class="text-slate-700 mt-1">Intended Sync Scope is Blockly ⇄ Mapping Model ⇄ Mapping Specification → Generated Export → Test Run. Actual path: Click-to-Map updates Mapping Model; Blockly canvas edits only <code>markDirty()</code>; Test Run evaluates slot expressions into a stub Composition and ignores Generated Export. Dual codegen (Blockly JS generators vs <code>core/codegen</code>) splits locality. UI tests can assert slot preview today, but not “sensible openEHR Composition” until this deepens.</p>
+          <p class="text-slate-700 mt-1">Intended Sync Scope is Blockly ⇄ Mapping Model (⇄ text projection) → Generated Export → Test Run. Actual path: Click-to-Map updates Mapping Model; Blockly canvas edits only <code>markDirty()</code>; Test Run evaluates slot expressions into a stub Composition and ignores Generated Export. Dual codegen (Blockly JS generators vs <code>core/codegen</code>) splits locality. UI tests can assert slot preview today, but not “sensible openEHR Composition” until this deepens. Pair with candidate 3: do not deepen a custom DSL while fixing the pipeline.</p>
         </div>
         <div>
           <h3 class="font-semibold text-[color:var(--teal-deep)]">Solution</h3>
-          <p class="text-slate-700 mt-1">Make Mapping Model the single deep IR: Blockly → Model on change; codegen only from Model; Test Run executes Generated Export (or a Model interpreter that is the same semantic surface). Collapse or demote unused Blockly-only generator path until it is an adapter behind the same interface.</p>
+          <p class="text-slate-700 mt-1">Make Blockly JSON → Mapping Model the sync authority: Blockly → Model on change; codegen only from Model; Test Run executes Generated Export (or a Model interpreter that is the same semantic surface). Collapse or demote unused Blockly-only generator path until it is an adapter behind the same interface. Demote or delete <code>toSpec</code> DSL as the center-pane “language.”</p>
         </div>
         <div>
           <h3 class="font-semibold text-[color:var(--teal-deep)]">Benefits</h3>
@@ -248,11 +321,11 @@ flowchart TB
       </div>
     </article>
 
-    <!-- Candidate 4 -->
+    <!-- Candidate 5 -->
     <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
       <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 class="display text-2xl font-semibold">4. Collapse pass-through RM attachment catalog</h2>
+          <h2 class="display text-2xl font-semibold">5. Collapse pass-through RM attachment catalog</h2>
           <p class="text-sm text-slate-600 mt-1">Files: <code>src/core/rm_attachment_catalog.ts</code>, <code>src/core/rm_meta.ts</code></p>
         </div>
         <span class="badge-explore text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Worth exploring</span>
@@ -285,11 +358,11 @@ flowchart TB
       </div>
     </article>
 
-    <!-- Candidate 5 -->
+    <!-- Candidate 6 -->
     <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
       <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 class="display text-2xl font-semibold">5. Workbench view seam (shell vs controller)</h2>
+          <h2 class="display text-2xl font-semibold">6. Workbench view seam (shell vs controller)</h2>
           <p class="text-sm text-slate-600 mt-1">Files: <code>web/main.ts</code>, <code>src/workbench/controller.ts</code>, <code>tree_views.ts</code>, <code>codemirror_setup.ts</code></p>
         </div>
         <span class="badge-explore text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Worth exploring</span>
@@ -313,11 +386,11 @@ flowchart TB
       </div>
     </article>
 
-    <!-- Candidate 6 -->
+    <!-- Candidate 7 -->
     <article class="bg-white/80 backdrop-blur border border-[color:var(--line)] rounded-2xl shadow-sm overflow-hidden">
       <div class="px-6 py-5 border-b border-[color:var(--line)] flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h2 class="display text-2xl font-semibold">6. Speculative: Handlebars / kintegrate conversion dialect</h2>
+          <h2 class="display text-2xl font-semibold">7. Speculative: Handlebars / kintegrate conversion dialect</h2>
           <p class="text-sm text-slate-600 mt-1">Roadmap note + kintegrate Integration Builder (DeepWiki)</p>
         </div>
         <span class="badge-spec text-xs font-semibold px-3 py-1 rounded-full uppercase tracking-wide">Speculative</span>
@@ -342,18 +415,21 @@ flowchart TB
     <section class="rounded-2xl border-2 border-[color:var(--teal)] bg-gradient-to-br from-[#e8f5f2] to-white px-6 py-6">
       <h2 class="display text-2xl font-semibold text-[color:var(--teal-deep)]">Top recommendation</h2>
       <p class="mt-3 text-slate-800 text-lg">
-        Tackle <strong>candidate 1 (Source Format Handler)</strong> and <strong>candidate 2 (Host Abstraction + dual builds)</strong> as a paired foundation:
-        openEHR-as-source (kintegrate merge) needs a real format seam; VS Code / Cursor needs a real host seam with a second adapter.
-        Candidate 3 (pipeline / Test Run depth) should follow immediately so UI tests and informatician Test Run assert real Compositions — otherwise format/host work still lands on a shallow runner.
+        Candidate <strong>1 (Source Format Handler)</strong> is in progress. Next paired foundation:
+        <strong>2 (Host Abstraction + dual builds)</strong> plus <strong>3 (Blockly JSON as Mapping Spec)</strong> and
+        <strong>4 (pipeline / Test Run depth)</strong>.
+        Prefer Blockly serialization JSON over inventing a private DSL; keep Mapping Model as a derived slot index for AI patches and codegen.
+        Then deepen Test Run so UI tests assert real Compositions — otherwise format/host work still lands on a shallow runner.
       </p>
       <p class="mt-4 text-slate-600 text-sm">
-        No ADRs exist today; decisions live in CONTEXT / PRD. None of these candidates contradict a recorded ADR.
-        Grounding: DeepWiki <code>ErikSundvall/kintegrate</code> (Integration Builder input JSON / openEHR compositions; formTestApi testing pattern; webview-oriented VS Code direction).
+        No ADRs exist today; decisions live in CONTEXT / PRD. Candidate 3 would supersede the PRD’s custom Mapping Specification DSL once accepted.
+        Grounding: DeepWiki <code>ErikSundvall/kintegrate</code> (source / formTestApi); DeepWiki <code>RaspberryPiFoundation/blockly</code>
+        (<code>serialization.workspaces.save/load</code> as restore + interchange).
       </p>
     </section>
 
     <section class="text-sm text-slate-600 border-t border-[color:var(--line)] pt-6">
-      <p>Generated for interactive grilling. Next step: pick a candidate to explore — interfaces are intentionally not proposed yet.</p>
+      <p>Updated after Source Format Handler work and Blockly-JSON-as-spec discussion. Candidate 3 interfaces sketched at solution level; implement when Sync Scope is revisited.</p>
     </section>
   </main>
 </body>

--- a/src/core/codegen/mod.ts
+++ b/src/core/codegen/mod.ts
@@ -13,7 +13,7 @@ export function generateTypeScript(model: MappingModel): string {
     "  evaluateXPathToBoolean,",
     "} from 'fontoxpath';",
     "",
-    "export type SourceContext = { format: 'json' | 'xml'; data: unknown };",
+    "export type SourceContext = { format: string; data: unknown };",
     "",
     "function evalExpr(expr: string, sourceCtx: SourceContext): unknown {",
     "  // Expression dispatch generated per slot at export time",

--- a/src/core/source/format_handler.ts
+++ b/src/core/source/format_handler.ts
@@ -1,0 +1,118 @@
+/**
+ * Source Format Handler seam — adapters for JSON, XML, and (later) openEHR
+ * Composition / FLAT / STRUCTURED as Source Schema.
+ *
+ * Callers (Click-to-Map, Test Run, codegen) go through this interface so new
+ * formats do not fork schema_loader / query_runtime / controller unions.
+ *
+ * See docs/SOURCE_FORMATS.md and architecture review candidate 1.
+ */
+
+import type { SchemaTreeNode, SourceFormatId } from "../../types/mod.ts";
+import {
+  inferSchemaFromInstance,
+  loadJsonSchema,
+  loadXmlSchemaFromInstance,
+  pathToFontoxpath,
+} from "./schema_loader.ts";
+import {
+  createSourceContext,
+  evaluate,
+  type SourceContext,
+} from "./query_runtime.ts";
+
+export type { SourceFormatId };
+
+export interface SourceFormatHandler {
+  /** Format id (`json`, `xml`, or a registered extension such as `openehr-composition`). */
+  readonly id: string;
+
+  /** Parse schema content (or infer structure from a document-shaped payload). */
+  loadSchema(content: string, rootName?: string): SchemaTreeNode;
+
+  /** Parse an example instance into a tree for the Source Pane. */
+  loadInstance(content: string, rootName?: string): SchemaTreeNode;
+
+  /** Convert a tree node path into a Mapping Expression path (fontoxpath). */
+  pathToExpression(schemaPath: string): string;
+
+  /** Build a runtime context for evaluating mapping expressions. */
+  createContext(content: string): SourceContext;
+
+  /** Evaluate a mapping expression against a context. */
+  evaluate(expression: string, ctx: SourceContext, returnType: string): unknown;
+}
+
+const jsonHandler: SourceFormatHandler = {
+  id: "json",
+  loadSchema(content, rootName = "root") {
+    return loadJsonSchema(content, rootName);
+  },
+  loadInstance(content, rootName = "root") {
+    return inferSchemaFromInstance(content, rootName);
+  },
+  pathToExpression(schemaPath) {
+    return pathToFontoxpath(schemaPath, "json");
+  },
+  createContext(content) {
+    return createSourceContext(content, "json");
+  },
+  evaluate(expression, ctx, returnType) {
+    return evaluate(expression, ctx, returnType);
+  },
+};
+
+const xmlHandler: SourceFormatHandler = {
+  id: "xml",
+  loadSchema(content, rootName = "root") {
+    // v1: XSD deferred — infer structural tree from an XML document sample.
+    return loadXmlSchemaFromInstance(content, rootName);
+  },
+  loadInstance(content, rootName = "root") {
+    return loadXmlSchemaFromInstance(content, rootName);
+  },
+  pathToExpression(schemaPath) {
+    return pathToFontoxpath(schemaPath, "xml");
+  },
+  createContext(content) {
+    return createSourceContext(content, "xml");
+  },
+  evaluate(expression, ctx, returnType) {
+    return evaluate(expression, ctx, returnType);
+  },
+};
+
+const handlers = new Map<string, SourceFormatHandler>([
+  [jsonHandler.id, jsonHandler],
+  [xmlHandler.id, xmlHandler],
+]);
+
+/** Register or replace a format adapter (e.g. future `openehr-composition`). */
+export function registerSourceFormatHandler(handler: SourceFormatHandler): void {
+  handlers.set(handler.id, handler);
+}
+
+export function getSourceFormatHandler(format: SourceFormatId | string): SourceFormatHandler {
+  const handler = handlers.get(format);
+  if (!handler) {
+    throw new Error(`Unsupported source format: ${format}`);
+  }
+  return handler;
+}
+
+export function listSourceFormatIds(): string[] {
+  return [...handlers.keys()];
+}
+
+export function isSourceFormatId(value: string): value is SourceFormatId {
+  return handlers.has(value);
+}
+
+/** Infer format from filename extension; defaults to JSON. */
+export function detectSourceFormat(filename: string): SourceFormatId {
+  const lower = filename.toLowerCase();
+  if (lower.endsWith(".xml") || lower.endsWith(".xsd")) return "xml";
+  return "json";
+}
+
+export type { SourceContext };

--- a/src/core/source/instance_validation.ts
+++ b/src/core/source/instance_validation.ts
@@ -1,10 +1,9 @@
-import type { SchemaTreeNode } from "../../types/mod.ts";
+import type { SchemaTreeNode, SourceFormatId } from "../../types/mod.ts";
 import {
   canonicalSyncPath,
   findNodeBySyncPath,
-  inferSchemaFromInstance,
-  loadXmlSchemaFromInstance,
 } from "./schema_loader.ts";
+import { getSourceFormatHandler } from "./format_handler.ts";
 
 export interface InstanceValidationIssue {
   path: string;
@@ -13,14 +12,12 @@ export interface InstanceValidationIssue {
 
 export function validateInstanceAgainstSchema(
   content: string,
-  format: "json" | "xml",
+  format: SourceFormatId,
   schema: SchemaTreeNode,
 ): InstanceValidationIssue[] {
   let instanceTree: SchemaTreeNode;
   try {
-    instanceTree = format === "json"
-      ? inferSchemaFromInstance(content, schema.name)
-      : loadXmlSchemaFromInstance(content, schema.name);
+    instanceTree = getSourceFormatHandler(format).loadInstance(content, schema.name);
   } catch (err) {
     return [{
       path: "$",

--- a/src/core/source/mod.ts
+++ b/src/core/source/mod.ts
@@ -1,0 +1,30 @@
+/**
+ * Source Format Handler public surface.
+ * Prefer these exports over reaching into schema_loader / query_runtime directly.
+ */
+
+export {
+  type SourceFormatHandler,
+  type SourceFormatId,
+  type SourceContext,
+  registerSourceFormatHandler,
+  getSourceFormatHandler,
+  listSourceFormatIds,
+  isSourceFormatId,
+  detectSourceFormat,
+} from "./format_handler.ts";
+
+export {
+  canonicalSyncPath,
+  findNodeBySyncPath,
+  pathToFontoxpath,
+} from "./schema_loader.ts";
+
+export { evaluate, createSourceContext } from "./query_runtime.ts";
+
+export { ExampleInstanceManager } from "./example_manager.ts";
+
+export {
+  type InstanceValidationIssue,
+  validateInstanceAgainstSchema,
+} from "./instance_validation.ts";

--- a/src/core/source/query_runtime.ts
+++ b/src/core/source/query_runtime.ts
@@ -1,14 +1,15 @@
 import fontoxpath from "fontoxpath";
+import type { SourceFormatId } from "../../types/mod.ts";
 import type { ExprAst } from "../expression/mod.ts";
 import { parseExpression } from "../expression/mod.ts";
 
 export interface SourceContext {
-  format: "json" | "xml";
+  format: SourceFormatId;
   json?: unknown;
   xmlDocument?: Document;
 }
 
-export function createSourceContext(content: string, format: "json" | "xml"): SourceContext {
+export function createSourceContext(content: string, format: SourceFormatId): SourceContext {
   if (format === "json") {
     return { format, json: JSON.parse(content) };
   }

--- a/src/core/source/schema_loader.ts
+++ b/src/core/source/schema_loader.ts
@@ -1,4 +1,4 @@
-import type { SchemaTreeNode } from "../../types/mod.ts";
+import type { SchemaTreeNode, SourceFormatId } from "../../types/mod.ts";
 
 type JsonSchemaObject = Record<string, unknown>;
 
@@ -195,7 +195,7 @@ function xmlNodeToSchema(el: Element, name: string, path: string): SchemaTreeNod
   };
 }
 
-export function pathToFontoxpath(schemaPath: string, format: "json" | "xml"): string {
+export function pathToFontoxpath(schemaPath: string, format: SourceFormatId): string {
   if (format === "xml") {
     return schemaPath.startsWith("/") ? schemaPath : `/${schemaPath}`;
   }

--- a/src/core/test_runner/mod.ts
+++ b/src/core/test_runner/mod.ts
@@ -1,22 +1,22 @@
-import type { MappingModel } from "../../types/mod.ts";
-import type { TestResult } from "../../types/mod.ts";
-import { evaluate, createSourceContext } from "../source/query_runtime.ts";
+import type { MappingModel, SourceFormatId, TestResult } from "../../types/mod.ts";
+import { getSourceFormatHandler } from "../source/format_handler.ts";
 import { generateTypeScript } from "../codegen/mod.ts";
 
 export function runTest(
   model: MappingModel,
   exampleContent: string,
-  format: "json" | "xml",
+  format: SourceFormatId,
   _generatedTs?: string,
 ): TestResult {
   const warnings: string[] = [];
   try {
-    const ctx = createSourceContext(exampleContent, format);
+    const handler = getSourceFormatHandler(format);
+    const ctx = handler.createContext(exampleContent);
     const slotValues: Record<string, unknown> = {};
 
     for (const slot of model.slots) {
       try {
-        slotValues[slot.slotId] = evaluate(slot.expression, ctx, slot.returnType);
+        slotValues[slot.slotId] = handler.evaluate(slot.expression, ctx, slot.returnType);
       } catch (e) {
         warnings.push(
           `${slot.slotId}: ${e instanceof Error ? e.message : String(e)}`,

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -67,10 +67,16 @@ export interface SchemaTreeNode {
   children: SchemaTreeNode[];
 }
 
+/**
+ * Source payload format id. Built-ins are `json` | `xml`; adapters may register
+ * more via `registerSourceFormatHandler` (see `core/source/format_handler.ts`).
+ */
+export type SourceFormatId = "json" | "xml";
+
 export interface ExampleInstance {
   id: string;
   filename: string;
-  format: "json" | "xml";
+  format: SourceFormatId;
   content: string;
 }
 

--- a/src/ui_test/test_api.ts
+++ b/src/ui_test/test_api.ts
@@ -6,7 +6,7 @@
  * real DOM / Blockly so the harness proves the Mapping Editor UI path.
  */
 
-import type { MappingModel, TestResult } from "../types/mod.ts";
+import type { MappingModel, SourceFormatId, TestResult } from "../types/mod.ts";
 
 export interface BlocklyBlockSummary {
   id: string;
@@ -35,9 +35,9 @@ export interface IntehrgratorTestApi {
   addExample(filename: string, content: string): void;
   armSlot(slotId: string): void;
   /** Programmatic bind (same path as Click-to-Map after Listening Mode). */
-  bindFromNode(path: string, format: "json" | "xml"): void;
+  bindFromNode(path: string, format: SourceFormatId): void;
   /** Programmatic bind to a slot (same path as drag-and-drop; skips Listening Mode). */
-  mapNodeToSlot(slotId: string, path: string, format: "json" | "xml"): void;
+  mapNodeToSlot(slotId: string, path: string, format: SourceFormatId): void;
   runTest(): void;
   setAutoplay(on: boolean): void;
   getSnapshot(): WorkbenchTestSnapshot;

--- a/src/workbench/controller.ts
+++ b/src/workbench/controller.ts
@@ -1,10 +1,10 @@
 import type {
-  ExampleInstance,
   MappingModel,
   ProjectBundle,
   ProjectSettings,
   SchemaTreeNode,
   SkeletonNode,
+  SourceFormatId,
   TestResult,
 } from "../types/mod.ts";
 import {
@@ -27,17 +27,13 @@ import {
 import { toSpec } from "../core/spec/mod.ts";
 import { generate } from "../core/codegen/mod.ts";
 import { runTest } from "../core/test_runner/mod.ts";
-import { ExampleInstanceManager } from "../core/source/example_manager.ts";
 import {
-  inferSchemaFromInstance,
-  loadJsonSchema,
-  loadXmlSchemaFromInstance,
-  pathToFontoxpath,
-} from "../core/source/schema_loader.ts";
-import {
+  detectSourceFormat,
+  ExampleInstanceManager,
+  getSourceFormatHandler,
   type InstanceValidationIssue,
   validateInstanceAgainstSchema,
-} from "../core/source/instance_validation.ts";
+} from "../core/source/mod.ts";
 import { buildSourceQueryExpression } from "../core/expression/mod.ts";
 import { returnTypeForDv } from "../core/rm_mandatory.ts";
 import { buildPrompt, importSuggestions, parseSuggestionsPayload } from "../core/ai/mod.ts";
@@ -251,7 +247,7 @@ export class WorkbenchController {
     this.treeHighlight = { syncPath: null, origin: null };
   }
 
-  bindFromNode(path: string, format: "json" | "xml"): void {
+  bindFromNode(path: string, format: SourceFormatId): void {
     if (!this.listeningSlotId) return;
     this.mapNodeToSlot(this.listeningSlotId, path, format);
   }
@@ -260,10 +256,10 @@ export class WorkbenchController {
    * Bind a source tree path to a Target value slot (Click-to-Map after Listening Mode,
    * or drag-and-drop which skips Listening Mode).
    */
-  mapNodeToSlot(slotId: string, path: string, format: "json" | "xml"): void {
+  mapNodeToSlot(slotId: string, path: string, format: SourceFormatId): void {
     const slot = collectValueSlots(this.skeleton).find((s) => s.slotId === slotId);
     if (!slot) return;
-    const xpath = pathToFontoxpath(path, format);
+    const xpath = getSourceFormatHandler(format).pathToExpression(path);
     const expr = buildSourceQueryExpression(xpath, returnTypeForDv(slot.rmType));
     this.model = applyExpressionEdit(this.model, slot.slotId, expr, {
       rmType: slot.rmType,
@@ -459,9 +455,7 @@ export class WorkbenchController {
     const active = this.examples.getActive();
     if (!active) return null;
     const rootName = active.filename.replace(/\.[^.]+$/, "");
-    return active.format === "json"
-      ? inferSchemaFromInstance(active.content, rootName)
-      : loadXmlSchemaFromInstance(active.content, rootName);
+    return getSourceFormatHandler(active.format).loadInstance(active.content, rootName);
   }
 
   private buildExampleValidations(): Record<string, InstanceValidationIssue[]> {
@@ -489,13 +483,17 @@ export class WorkbenchController {
 
   private applySchemaFile(filename: string, content: string): void {
     this.schemaFilename = filename;
-    this.schemaTree = loadJsonSchema(content, filename.replace(/\.[^.]+$/, ""));
+    const format = detectSourceFormat(filename);
+    this.schemaTree = getSourceFormatHandler(format).loadSchema(
+      content,
+      filename.replace(/\.[^.]+$/, ""),
+    );
     this.statusMessage = `Loaded schema ${filename}`;
     this.markDirty();
   }
 
   private applyExampleFile(filename: string, content: string): void {
-    const format = filename.endsWith(".xml") ? "xml" : "json";
+    const format = detectSourceFormat(filename);
     const id = crypto.randomUUID();
     this.examples.addExample({ id, filename, format, content });
   }

--- a/src/workbench/tree_views.ts
+++ b/src/workbench/tree_views.ts
@@ -1,6 +1,6 @@
-import type { SchemaTreeNode, SkeletonNode } from "../types/mod.ts";
+import type { SchemaTreeNode, SkeletonNode, SourceFormatId } from "../types/mod.ts";
 import { isAutoFixedValueSlot } from "../core/rm_mandatory.ts";
-import { canonicalSyncPath } from "../core/source/schema_loader.ts";
+import { canonicalSyncPath, isSourceFormatId } from "../core/source/mod.ts";
 
 const SKELETON_INDENT_PX = 10;
 
@@ -9,7 +9,7 @@ export const SOURCE_DRAG_MIME = "application/x-intehrgrator-source";
 
 export interface SourceDragPayload {
   path: string;
-  format: "json" | "xml";
+  format: SourceFormatId;
   origin: "schema" | "instance";
 }
 
@@ -19,7 +19,7 @@ export function parseSourceDragPayload(dt: DataTransfer | null): SourceDragPaylo
   if (!raw) return null;
   try {
     const parsed = JSON.parse(raw) as Partial<SourceDragPayload>;
-    if (parsed.path && (parsed.format === "json" || parsed.format === "xml")) {
+    if (parsed.path && typeof parsed.format === "string" && isSourceFormatId(parsed.format)) {
       return {
         path: parsed.path,
         format: parsed.format,
@@ -84,7 +84,7 @@ export function renderInstanceTree(
   node: SchemaTreeNode,
   onSelect: (path: string) => void,
   options: SchemaTreeRenderOptions = {},
-  format: "json" | "xml" = "json",
+  format: SourceFormatId = "json",
 ): void {
   container.classList.add("instance-tree");
   container.classList.remove("schema-tree");
@@ -123,7 +123,7 @@ function buildInstanceNode(
   onSelect: (path: string) => void,
   options: SchemaTreeRenderOptions,
   depth: number,
-  format: "json" | "xml",
+  format: SourceFormatId,
 ): HTMLElement {
   const syncPath = canonicalSyncPath(node.path);
   const row = createTreeRow(node.path, syncPath, depth);
@@ -158,7 +158,7 @@ function attachTreeInteractions(
   path: string,
   syncPath: string,
   origin: "schema" | "instance",
-  format: "json" | "xml",
+  format: SourceFormatId,
   onSelect: (path: string) => void,
   options: SchemaTreeRenderOptions,
 ): void {

--- a/test/source_format_handler_test.ts
+++ b/test/source_format_handler_test.ts
@@ -1,0 +1,96 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  detectSourceFormat,
+  getSourceFormatHandler,
+  isSourceFormatId,
+  listSourceFormatIds,
+  registerSourceFormatHandler,
+  type SourceFormatHandler,
+} from "@intehrgrator/core/source/mod.ts";
+import { runTest } from "@intehrgrator/core/test_runner/mod.ts";
+import { createEmptyModel, applyExpressionEdit } from "@intehrgrator/core/mapping_model/mod.ts";
+
+Deno.test("built-in format handlers are registered", () => {
+  const ids = listSourceFormatIds();
+  assertEquals(ids.includes("json"), true);
+  assertEquals(ids.includes("xml"), true);
+  assertEquals(isSourceFormatId("json"), true);
+  assertEquals(isSourceFormatId("openehr-composition"), false);
+});
+
+Deno.test("detectSourceFormat from filename", () => {
+  assertEquals(detectSourceFormat("vitals.json"), "json");
+  assertEquals(detectSourceFormat("vitals.XML"), "xml");
+  assertEquals(detectSourceFormat("schema.xsd"), "xml");
+  assertEquals(detectSourceFormat("unknown.bin"), "json");
+});
+
+Deno.test("json handler loadSchema / pathToExpression / evaluate", () => {
+  const handler = getSourceFormatHandler("json");
+  const tree = handler.loadSchema(JSON.stringify({ vitals: { systolic: 120 } }), "root");
+  assertEquals(tree.children[0].name, "vitals");
+
+  const exprPath = handler.pathToExpression("$.vitals.systolic");
+  assertEquals(exprPath, "$.vitals.systolic");
+
+  const ctx = handler.createContext(JSON.stringify({ vitals: { systolic: 120 } }));
+  const value = handler.evaluate('xpathNumber("$.vitals.systolic")', ctx, "number");
+  assertEquals(value, 120);
+});
+
+Deno.test("xml handler pathToExpression", () => {
+  const handler = getSourceFormatHandler("xml");
+  assertEquals(handler.pathToExpression("/patient/id"), "/patient/id");
+  assertEquals(handler.pathToExpression("patient/id"), "/patient/id");
+});
+
+Deno.test({
+  name: "xml handler loadInstance / evaluate (requires DOMParser)",
+  ignore: typeof globalThis.DOMParser === "undefined",
+  fn() {
+    const handler = getSourceFormatHandler("xml");
+    const xml = "<patient><id>abc</id></patient>";
+    const tree = handler.loadInstance(xml, "patient");
+    assertEquals(tree.children[0].name, "id");
+
+    const ctx = handler.createContext(xml);
+    const value = handler.evaluate('xpathString("/patient/id")', ctx, "string");
+    assertEquals(value, "abc");
+  },
+});
+
+Deno.test("unknown format throws at the handler seam", () => {
+  assertThrows(
+    () => getSourceFormatHandler("openehr-composition"),
+    Error,
+    "Unsupported source format",
+  );
+});
+
+Deno.test("registerSourceFormatHandler plugs a new adapter", () => {
+  const extId = "test-custom-format";
+  const custom: SourceFormatHandler = {
+    id: extId,
+    loadSchema: () => ({ path: "$", name: "stub", type: "object", children: [] }),
+    loadInstance: () => ({ path: "$", name: "stub", type: "object", children: [] }),
+    pathToExpression: (p) => `STUB:${p}`,
+    createContext: (content) => ({ format: "json", json: JSON.parse(content) }),
+    evaluate: () => "stubbed",
+  };
+  registerSourceFormatHandler(custom);
+  assertEquals(isSourceFormatId(extId), true);
+  assertEquals(getSourceFormatHandler(extId).pathToExpression("a.b"), "STUB:a.b");
+  assertEquals(getSourceFormatHandler(extId).evaluate("x", custom.createContext("{}"), "string"), "stubbed");
+});
+
+Deno.test("Test Run goes through Source Format Handler", () => {
+  let model = createEmptyModel("tmpl");
+  model = applyExpressionEdit(model, "slot/systolic", 'xpathNumber("$.systolic")', {
+    rmType: "DV_QUANTITY",
+    returnType: "number",
+  });
+  const result = runTest(model, JSON.stringify({ systolic: 118 }), "json");
+  assertEquals(result.ok, true);
+  const composition = result.composition as { slots: Record<string, unknown> };
+  assertEquals(composition.slots["slot/systolic"], 118);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements architecture review **candidate 1** (Source Format Handler), documents why kintegrate’s “Frame this node as context root” is largely unnecessary given Blockly `for_each_source`, and updates the architecture review to prefer **Blockly native JSON** over inventing a Mapping Spec DSL.

### Source Format Handler
- New interface in `src/core/source/format_handler.ts`: `loadSchema`, `loadInstance`, `pathToExpression`, `createContext`, `evaluate`
- Built-in JSON and XML adapters; `registerSourceFormatHandler` for future formats
- Workbench Click-to-Map, Test Run, schema/example load, and instance validation go through the handler
- Public surface: `src/core/source/mod.ts`; `SourceFormatId` on `ExampleInstance`

### Context root vs `for_each_source`
- Decision in `docs/future/source-context-root.md`: **do not** port kintegrate tree framing
- Optional residual interface only for Blockly-scoped relative Click-to-Map

### Architecture review update
- New **candidate 3**: prefer `Blockly.serialization` JSON as Mapping Spec / LLM interchange; Mapping Model stays as derived `slotId` → expression index; demote custom `toSpec` DSL
- Renumbered pipeline / catalog / shell / Handlebars candidates; top recommendation updated
- Direction note in `docs/MAPPING_SPECIFICATION.md`

### Tests
- `deno task test` — 59 passed
- `deno task test:ui` — Click-to-Map + drag-and-drop OK
- `deno task build` — OK
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fbd01-ba32-7e4f-a538-30dc0e80c32d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fbd01-ba32-7e4f-a538-30dc0e80c32d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

