### PR TITLE
Mapping Spec download/upload of full Blockly JSON; constraint warnings and EVENT subtypes

### DIFF
--- a/docs/MAPPING_SPECIFICATION.md
+++ b/docs/MAPPING_SPECIFICATION.md
@@ -4,11 +4,12 @@ The canonical Mapping Specification is Blockly workspace JSON from
 `Blockly.serialization.workspaces.save`. It is persisted in
 `ProjectBundle.mapping.blocklyState`.
 
-The Mapping Editor **Mapping Spec** tab shows a dense, line-numbered
-**projection** of that JSON: recurring constructs become CodeMirror widgets
-(containers, value slots, `DV_*` shells, `source_query`). Layout chrome such as
-`x`/`y` is omitted from the view; an ⓘ control reveals those details. Only safe
-fields are editable in the Spec (v1: `source_query` expression and return type);
+The Mapping Editor **Mapping Spec** tab stores the **full Blockly workspace
+JSON** as the CodeMirror document (`JSON.stringify(blocklyState, null, 2)`).
+Visual widgets overlay each block `"type"` line and hide layout chrome such as
+`x`/`y`; an ⓘ control still reveals those details. Download/Upload round-trip
+that same JSON so a mapping can be reproduced exactly. Only safe fields are
+editable in the Spec widgets (v1: `source_query` expression and return type);
 structure changes stay in Blockly.
 
 The former private `@template ...` DSL has been removed. It duplicated Blockly

--- a/scripts/map-bp-series-ui.ts
+++ b/scripts/map-bp-series-ui.ts
@@ -406,7 +406,7 @@ try {
   note(`UI loops: ${JSON.stringify(uiSnap.model.loops ?? [])}`);
   await saveDownload(page, "#btn-export-project", "ui-mapping.intehrgrator.zip");
   await saveDownload(page, "#btn-download-blockly", "ui-mapping.blockly.json");
-  await saveDownload(page, "#btn-download-spec", "ui-mapping.mapping-spec.txt");
+  await saveDownload(page, "#btn-download-spec", "ui-mapping-spec.blockly.json");
   note("Saved UI mapping exports");
 
   // --- 2. Fresh load → Copy AI Prompt → import suggestions ---
@@ -443,7 +443,7 @@ try {
   const aiSnap = await runTestAndSnapshot("05-ai-mapping-snapshot.json");
   await saveDownload(page, "#btn-export-project", "ai-mapping.intehrgrator.zip");
   await saveDownload(page, "#btn-download-blockly", "ai-mapping.blockly.json");
-  await saveDownload(page, "#btn-download-spec", "ai-mapping.mapping-spec.txt");
+  await saveDownload(page, "#btn-download-spec", "ai-mapping-spec.blockly.json");
   note("Saved AI mapping exports");
 
   const uiPulse = summarizePulse(uiSnap.testResult?.output);

--- a/src/blockly/block_constraints.ts
+++ b/src/blockly/block_constraints.ts
@@ -1,0 +1,161 @@
+/**
+ * Live constraint decorations on RM Blockly blocks.
+ *
+ * Warning triangles fire when a contained constraint is unmet (unmapped
+ * mandatory value, abstract EVENT, empty required slot). They do **not**
+ * light up merely because a node is template/RM-mandatory.
+ */
+import type { Block, Workspace } from "blockly/core";
+import { Blockly } from "./blockly_core.ts";
+import { TERM_PICK_NONE } from "../core/openehr_term_catalog.ts";
+import { isAbstractType } from "../core/rm_meta.ts";
+import { isGenericValueBlockType } from "./blocks/target_blocks.ts";
+import {
+  expressionBlockFromDataValueShell,
+  isDataValueBlock,
+  isEventFamilyType,
+  presentAttributeNames,
+  RM_ATTR_INPUT_PREFIX,
+  OPTIONAL_INPUT_PREFIX,
+} from "./blocks/rm_blocks.ts";
+import { isTermPickBlock } from "./blocks/term_pick.ts";
+import {
+  cardinalityFieldOnInput,
+  formatSlotCardinality,
+  isCardinalityMet,
+  type SlotCardinality,
+} from "./slot_cardinality.ts";
+
+export const ABSTRACT_EVENT_WARNING =
+  "EVENT is abstract. Choose POINT_EVENT or INTERVAL_EVENT — runtime instances cannot be the abstract EVENT class.";
+
+const STATEMENT_INPUT_TYPE = 3;
+
+export function refreshWorkspaceConstraints(workspace: Workspace): void {
+  for (const block of workspace.getAllBlocks(false)) {
+    if (typeof block.isShadow === "function" && block.isShadow()) continue;
+    refreshSlotCardinalityState(block);
+    const messages = blockConstraintMessages(block);
+    block.setWarningText(messages.length ? messages.join("\n") : null);
+  }
+}
+
+export function blockConstraintMessages(block: Block): string[] {
+  const messages: string[] = [];
+  const rmType = (block.getFieldValue("RM_TYPE") || "").toUpperCase();
+  if (rmType === "EVENT") {
+    messages.push(ABSTRACT_EVENT_WARNING);
+  }
+
+  if (isMandatoryFlag(block) && isUnmappedValueBlock(block)) {
+    messages.push("Unmapped mandatory value");
+  }
+
+  for (const unmet of unmetSlotCards(block)) {
+    messages.push(
+      `${unmet.attr} needs ${formatSlotCardinality(unmet.card)} (has ${unmet.count})`,
+    );
+  }
+  return messages;
+}
+
+export function warningTextOf(block: Block): string | null {
+  const iconsApi = Blockly.icons as
+    | { WarningIcon?: { TYPE?: unknown } }
+    | undefined;
+  const type = iconsApi?.WarningIcon?.TYPE;
+  const getIcon = (block as unknown as {
+    getIcon?: (iconType: unknown) => { getText?: () => string } | null;
+  }).getIcon;
+  if (type && typeof getIcon === "function") {
+    const text = getIcon.call(block, type)?.getText?.() ?? "";
+    if (text) return text;
+  }
+  const legacy = block as unknown as { getWarningText?: () => string | null };
+  if (typeof legacy.getWarningText === "function") {
+    return legacy.getWarningText() || null;
+  }
+  return null;
+}
+
+export function isAbstractEventBlock(block: Block): boolean {
+  const rmType = (block.getFieldValue("RM_TYPE") || "").toUpperCase();
+  return rmType === "EVENT" && (isEventFamilyType(rmType) || isAbstractType("EVENT"));
+}
+
+function refreshSlotCardinalityState(block: Block): void {
+  for (const input of block.inputList) {
+    const field = cardinalityFieldOnInput(input);
+    if (!field) continue;
+    const count = countInputChildren(block, input.name);
+    field.setUnmet(!isCardinalityMet(count, { min: field.min, max: field.max }));
+  }
+}
+
+function unmetSlotCards(
+  block: Block,
+): Array<{ attr: string; card: SlotCardinality; count: number }> {
+  const out: Array<{ attr: string; card: SlotCardinality; count: number }> = [];
+  for (const input of block.inputList) {
+    const field = cardinalityFieldOnInput(input);
+    if (!field) continue;
+    const card = { min: field.min, max: field.max };
+    const count = countInputChildren(block, input.name);
+    if (isCardinalityMet(count, card)) continue;
+    const attr = input.name.startsWith(RM_ATTR_INPUT_PREFIX)
+      ? input.name.slice(RM_ATTR_INPUT_PREFIX.length)
+      : input.name.startsWith(OPTIONAL_INPUT_PREFIX)
+      ? input.name.slice(OPTIONAL_INPUT_PREFIX.length)
+      : input.name.toLowerCase();
+    out.push({ attr, card, count });
+  }
+  return out;
+}
+
+export function countInputChildren(block: Block, inputName: string): number {
+  const input = block.getInput(inputName);
+  if (!input?.connection) return 0;
+  const first = input.connection.targetBlock();
+  if (!first) return 0;
+  if (input.type !== STATEMENT_INPUT_TYPE) return 1;
+  let n = 0;
+  let current: Block | null = first;
+  while (current) {
+    n++;
+    current = current.getNextBlock();
+  }
+  return n;
+}
+
+function isMandatoryFlag(block: Block): boolean {
+  const raw = block.getFieldValue("MANDATORY");
+  return raw === "1" || raw === "true";
+}
+
+function isUnmappedValueBlock(block: Block): boolean {
+  if (isTermPickBlock(block)) {
+    const code = block.getFieldValue("CODE");
+    return !code || code === TERM_PICK_NONE;
+  }
+  if (block.type === "element" || isGenericValueBlockType(block.type)) {
+    const value = block.getInput("VALUE")?.connection?.targetBlock();
+    if (!value) return true;
+    if (isDataValueBlock(value)) {
+      return !expressionBlockFromDataValueShell(value);
+    }
+    return false;
+  }
+  if (isDataValueBlock(block)) {
+    return !expressionBlockFromDataValueShell(block);
+  }
+  return false;
+}
+
+/** Used by tests and optional RM to know which ATTR_/OPT_ mouths exist. */
+export function connectedAttributeNames(block: Block): string[] {
+  return presentAttributeNames(block).filter((name) => {
+    const input = block.getInput(`${RM_ATTR_INPUT_PREFIX}${name}`) ??
+      block.getInput(`${OPTIONAL_INPUT_PREFIX}${name}`);
+    return Boolean(input?.connection?.targetBlock());
+  });
+}

--- a/src/blockly/blocks/rm_blocks.ts
+++ b/src/blockly/blocks/rm_blocks.ts
@@ -22,9 +22,23 @@ import { blocklyCheckForDv } from "../block_checks.ts";
 import {
   appendBlockOutputEmoji,
   appendSlotTypeEmoji,
+  isRmTypeEmojiField,
+  BLOCK_OUT_EMOJI_FIELD,
   slotRmTypeForAttr,
 } from "../rm_type_emoji.ts";
+import {
+  appendSlotCardinality,
+  parseSlotCardinality,
+  rmAttributeCardinality,
+  type SlotCardinality,
+} from "../slot_cardinality.ts";
 import { registerTermPickBlock } from "./term_pick.ts";
+
+export const EVENT_KIND_OPTIONS: Array<[string, string]> = [
+  ["EVENT", "EVENT"],
+  ["POINT_EVENT", "POINT_EVENT"],
+  ["INTERVAL_EVENT", "INTERVAL_EVENT"],
+];
 
 export const OPTIONAL_INPUT_PREFIX = "OPT_";
 const OPTIONAL_DV_FIELD_PREFIX = "OPTFLD_";
@@ -63,6 +77,11 @@ const EXTRA_RM_CONTAINERS = [
   "ARCHETYPED",
   "GENERIC_ENTRY",
 ];
+
+export function isEventFamilyType(rmType: string): boolean {
+  const name = (rmType || "").toUpperCase();
+  return name === "EVENT" || isSubtypeOf(name, "EVENT");
+}
 
 export function isRmContainerBlockType(type: string): boolean {
   if (RM_CONTAINER_TYPES.has(type) || type === "element") return true;
@@ -269,16 +288,161 @@ export function syncRmAttributeInputs(
   block: Blockly.Block,
   rmType: string,
   attributes: string[],
+  cardinalities?: Record<string, SlotCardinality>,
 ): void {
+  const saved = snapshotAttributeConnections(block);
   for (const input of [...block.inputList]) {
     if (input.name.startsWith(RM_ATTR_INPUT_PREFIX)) {
       block.removeInput(input.name);
     }
   }
   for (const attr of orderedRmAttributes(rmType, attributes)) {
-    appendRmAttributeInput(block, rmType, attr);
+    appendRmAttributeInput(
+      block,
+      rmType,
+      attr,
+      undefined,
+      cardinalities?.[attr] ?? slotCardinalityFor(block, rmType, attr),
+    );
   }
+  restoreAttributeConnections(block, saved);
   ensurePlusButton(block);
+}
+
+/**
+ * Switch an EVENT-family block between EVENT / POINT_EVENT / INTERVAL_EVENT
+ * without dropping already-attached children. Extra INTERVAL_EVENT fields
+ * appear when needed; filled extras are kept if the user switches away.
+ */
+export function applyEventRmType(block: Blockly.Block, newType: string): void {
+  const next = (newType || "").toUpperCase();
+  if (!isEventFamilyType(next)) return;
+
+  const current = String(block.getFieldValue("RM_TYPE") || "").toUpperCase();
+  if (current !== next && block.getField("RM_TYPE")) {
+    block.setFieldValue(next, "RM_TYPE");
+  }
+
+  const emoji = block.getField(BLOCK_OUT_EMOJI_FIELD);
+  if (isRmTypeEmojiField(emoji)) emoji.setRmType(next);
+
+  const connected = presentAttributeNames(block).filter((name) =>
+    Boolean(
+      block.getInput(rmAttributeInputName(name))?.connection?.targetBlock() ||
+        block.getInput(optionalRmInputName(name))?.connection?.targetBlock(),
+    )
+  );
+  const show = eventAttributesToShow(next, connected);
+  const cards = { ...(block.slotCardinalities_ ?? {}) };
+  syncRmAttributeInputs(block, next, show, cards);
+  if (typeof block.render === "function" && typeof document !== "undefined") {
+    block.render();
+  }
+}
+
+function eventAttributesToShow(rmType: string, connected: string[]): string[] {
+  const names = new Set<string>(connected);
+  for (const attr of ["time", "data"]) names.add(attr);
+  if (rmType === "INTERVAL_EVENT") {
+    names.add("width");
+    names.add("math_function");
+    names.add("sample_count");
+  }
+  return [...names];
+}
+
+function slotCardinalityFor(
+  block: Blockly.Block,
+  rmType: string,
+  attr: string,
+): SlotCardinality | undefined {
+  return block.slotCardinalities_?.[attr] ??
+    rmAttributeCardinality(rmType, attr) ??
+    parseSlotCardinality("0..1");
+}
+
+function snapshotAttributeConnections(
+  block: Blockly.Block,
+): Record<string, Blockly.Block[]> {
+  const saved: Record<string, Blockly.Block[]> = {};
+  for (const input of [...block.inputList]) {
+    if (!input.name.startsWith(RM_ATTR_INPUT_PREFIX)) continue;
+    const attr = input.name.slice(RM_ATTR_INPUT_PREFIX.length);
+    const first = input.connection?.targetBlock();
+    if (!first) continue;
+    const chain: Blockly.Block[] = [];
+    if (first.outputConnection && !first.previousConnection) {
+      first.outputConnection.disconnect();
+      chain.push(first);
+    } else {
+      let current: Blockly.Block | null = first;
+      while (current) {
+        const next = current.getNextBlock();
+        if (current.nextConnection?.isConnected()) current.nextConnection.disconnect();
+        if (current.previousConnection?.isConnected()) {
+          current.previousConnection.disconnect();
+        }
+        chain.push(current);
+        current = next;
+      }
+    }
+    saved[attr] = chain;
+  }
+  return saved;
+}
+
+function restoreAttributeConnections(
+  block: Blockly.Block,
+  saved: Record<string, Blockly.Block[]>,
+): void {
+  for (const [attr, blocks] of Object.entries(saved)) {
+    const input = block.getInput(rmAttributeInputName(attr)) ??
+      block.getInput(optionalRmInputName(attr));
+    if (!input?.connection || !blocks.length) continue;
+    const head = blocks[0]!;
+    const headConn = head.outputConnection && !head.previousConnection
+      ? head.outputConnection
+      : head.previousConnection;
+    if (headConn) tryConnect(input, headConn);
+    let previous = head;
+    for (const child of blocks.slice(1)) {
+      if (previous.nextConnection && child.previousConnection) {
+        try {
+          previous.nextConnection.connect(child.previousConnection);
+        } catch {
+          /* type mismatch */
+        }
+      }
+      previous = child;
+    }
+  }
+}
+
+function tryConnect(
+  input: Blockly.Input,
+  childConn: Blockly.Connection,
+): void {
+  const parentConn = input.connection;
+  if (!parentConn) return;
+  const attempt = (): void => {
+    if (parentConn.isConnected()) parentConn.disconnect();
+    parentConn.connect(childConn);
+  };
+  try {
+    attempt();
+  } catch {
+    /* type check rejected */
+  }
+  if (parentConn.targetConnection === childConn) return;
+  const prevCheck = parentConn.getCheck();
+  input.setCheck(null);
+  try {
+    attempt();
+  } catch {
+    /* still incompatible */
+  } finally {
+    if (prevCheck) input.setCheck(prevCheck);
+  }
 }
 
 function appendRmAttributeInput(
@@ -286,13 +450,16 @@ function appendRmAttributeInput(
   rmType: string,
   attr: string,
   checkOverride?: string | string[] | null,
+  cardinality?: SlotCardinality,
 ): void {
   const slotType = slotRmTypeForAttr(rmType, attr);
+  const card = cardinality ?? slotCardinalityFor(block, rmType, attr);
   if (isRmValueAttribute(rmType, attr) || isPartyProxyType(slotType)) {
     const input = block.appendValueInput(rmAttributeInputName(attr))
       .appendField(attr);
     const check = checkOverride ?? puzzleCheckForAttr(rmType, attr, slotType);
     if (check) input.setCheck(check);
+    appendSlotCardinality(input, card);
     appendSlotTypeEmoji(input, slotType);
     return;
   }
@@ -300,6 +467,7 @@ function appendRmAttributeInput(
     .appendField(attr);
   const check = checkOverride ?? statementCheckForAttr(rmType, attr);
   if (check) stmt.setCheck(check);
+  appendSlotCardinality(stmt, card);
   appendSlotTypeEmoji(stmt, slotType);
 }
 
@@ -320,11 +488,9 @@ function statementCheckForAttr(
   rmType: string,
   attr: string,
 ): string | string[] | null {
-  const meta = attributesFor(rmType).find((a) => a.name === attr);
-  if (!meta) return null;
-  const base = baseRmTypeName(meta.typeName);
-  if (isPrimitiveRmType(base) || isDataValueType(base)) return null;
-  return base;
+  const slotType = slotRmTypeForAttr(rmType, attr);
+  if (!slotType || isPrimitiveRmType(slotType) || isDataValueType(slotType)) return null;
+  return nestCheckFor(slotType) ?? slotType;
 }
 
 export function rmTypeOfBlock(block: Blockly.Block): string {
@@ -358,6 +524,7 @@ export function configureElementValueSlot(block: Blockly.Block, rmType: string):
   if (!input) return;
   const check = blocklyCheckForDv(rmType);
   input.setCheck(check);
+  appendSlotCardinality(input, { min: 1, max: 1 });
   appendSlotTypeEmoji(input, rmType);
 }
 
@@ -542,8 +709,13 @@ function defineContainerBlock(
     init: function (this: Blockly.Block) {
       const header = this.appendDummyInput("HEADER");
       appendBlockOutputEmoji(header, options.rmType);
+      if (isEventFamilyType(options.rmType)) {
+        header.appendField(new Blockly.FieldDropdown(EVENT_KIND_OPTIONS), "RM_TYPE");
+        this.setFieldValue(options.rmType, "RM_TYPE");
+      } else {
+        header.appendField(label, "RM_CLASS");
+      }
       header
-        .appendField(label)
         .appendField(new Blockly.FieldLabel(""), "NAME")
         .appendField(new Blockly.FieldLabel("", undefined, { class: "blockly-at-code" }), "AT_CODE");
       if (options.expandable) {
@@ -560,9 +732,12 @@ function defineContainerBlock(
       this.appendDummyInput()
         .appendField(new Blockly.FieldLabelSerializable(""), "SLOT_ID");
       this.getField("SLOT_ID")!.setVisible(false);
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldLabelSerializable(options.rmType), "RM_TYPE");
-      this.getField("RM_TYPE")!.setVisible(false);
+      if (!isEventFamilyType(options.rmType)) {
+        this.appendDummyInput()
+          .appendField(new Blockly.FieldLabelSerializable(options.rmType), "RM_TYPE");
+        this.getField("RM_TYPE")!.setVisible(false);
+      }
+      appendHiddenLabel(this, "MANDATORY", "");
       this.appendDummyInput()
         .appendField(new Blockly.FieldTextInput(""), "ARCHETYPE_NODE_ID");
       this.getField("ARCHETYPE_NODE_ID")!.setVisible(false);
@@ -599,10 +774,12 @@ function defineValueElementBlock(): void {
       const value = this.appendValueInput("VALUE")
         .setCheck(null)
         .appendField("value");
+      appendSlotCardinality(value, { min: 1, max: 1 });
       appendSlotTypeEmoji(value, slotRmTypeForAttr("ELEMENT", "value"));
       this.appendDummyInput()
         .appendField(new Blockly.FieldLabelSerializable("ELEMENT"), "RM_TYPE");
       this.getField("RM_TYPE")!.setVisible(false);
+      appendHiddenLabel(this, "MANDATORY", "");
       this.appendDummyInput()
         .appendField(new Blockly.FieldTextInput(""), "SLOT_ID");
       this.getField("SLOT_ID")!.setVisible(false);
@@ -643,6 +820,7 @@ function defineDataValueBlock(rmType: string): void {
       this.appendDummyInput()
         .appendField(new Blockly.FieldLabelSerializable(rmType), "RM_TYPE");
       this.getField("RM_TYPE")!.setVisible(false);
+      appendHiddenLabel(this, "MANDATORY", "");
 
       const mandatory = mandatoryAttributes(rmType).filter((a) =>
         isMappableField(a)
@@ -801,6 +979,37 @@ function appendPlusFieldsButton(block: Blockly.Block): void {
     ));
 }
 
+function parseMutatorExtraState(
+  state: { extras?: string[]; attrs?: string[] } | string | null,
+): { extras: string[]; attrs: string[] } {
+  if (state == null || state === "") return { extras: [], attrs: [] };
+  const obj = typeof state === "string"
+    ? JSON.parse(state) as { extras?: string[]; attrs?: string[] }
+    : state;
+  return {
+    extras: Array.isArray(obj.extras) ? obj.extras : [],
+    attrs: Array.isArray(obj.attrs) ? obj.attrs : [],
+  };
+}
+
+function restoreMutatorAttributes(
+  block: Blockly.Block,
+  extras: string[],
+  attrs: string[],
+): void {
+  block.extraInputs_ = extras;
+  const rm = rmTypeOfBlock(block);
+  if (isEventFamilyType(rm) && (attrs.length || extras.length)) {
+    syncRmAttributeInputs(
+      block,
+      rm,
+      eventAttributesToShow(rm, attrs),
+      block.slotCardinalities_,
+    );
+  }
+  block.updateShape_?.();
+}
+
 let optionalRmMutatorRegistered = false;
 
 function registerOptionalRmMutator(): void {
@@ -811,12 +1020,28 @@ function registerOptionalRmMutator(): void {
       const container = Blockly.utils.xml.createElement("mutation");
       const extras = this.extraInputs_ ?? [];
       container.setAttribute("extras", JSON.stringify(extras));
+      container.setAttribute("attrs", JSON.stringify(presentAttributeNames(this)));
       return container;
     },
     domToMutation: function (this: Blockly.Block, xmlElement: Element) {
       const extras = JSON.parse(xmlElement.getAttribute("extras") || "[]") as string[];
       this.extraInputs_ = extras;
-      this.updateShape_?.();
+      const attrs = JSON.parse(xmlElement.getAttribute("attrs") || "[]") as string[];
+      restoreMutatorAttributes(this, extras, attrs);
+    },
+    saveExtraState: function (this: Blockly.Block) {
+      return {
+        extras: this.extraInputs_ ?? [],
+        attrs: presentAttributeNames(this),
+      };
+    },
+    loadExtraState: function (
+      this: Blockly.Block,
+      state: { extras?: string[]; attrs?: string[] } | string | null,
+    ) {
+      const parsed = parseMutatorExtraState(state);
+      this.extraInputs_ = parsed.extras;
+      restoreMutatorAttributes(this, parsed.extras, parsed.attrs);
     },
     addInput_: function (this: Blockly.Block, name: string) {
       this.extraInputs_ = this.extraInputs_ ?? [];
@@ -841,17 +1066,27 @@ function registerOptionalRmMutator(): void {
             ? slotType
             : (slotType ? blocklyCheckForDv(slotType) : null);
           if (check) input.setCheck(check);
+          appendSlotCardinality(
+            input,
+            this.slotCardinalities_?.[name] ?? rmAttributeCardinality(parentRm, name),
+          );
           appendSlotTypeEmoji(input, slotType);
           continue;
         }
         const stmt = this.appendStatementInput(`${OPTIONAL_INPUT_PREFIX}${name}`)
           .appendField(name);
+        appendSlotCardinality(
+          stmt,
+          this.slotCardinalities_?.[name] ?? rmAttributeCardinality(parentRm, name),
+        );
         appendSlotTypeEmoji(stmt, slotType);
       }
     },
   } as Blockly.Mutator & {
     addInput_?: (name: string) => void;
     updateShape_?: () => void;
+    saveExtraState?: () => { extras: string[]; attrs: string[] };
+    loadExtraState?: (state: { extras?: string[]; attrs?: string[] } | string | null) => void;
   });
 }
 
@@ -891,12 +1126,20 @@ declare module "blockly/core" {
   interface Block {
     extraInputs_?: string[];
     extraDvFields_?: string[];
+    slotCardinalities_?: Record<string, SlotCardinality>;
     firePlusClick?: () => void;
     firePlusFieldsClick?: () => void;
     addInput_?: (name: string) => void;
     updateShape_?: () => void;
     updateDvFields_?: () => void;
   }
+}
+
+function appendHiddenLabel(block: Blockly.Block, name: string, value: string): void {
+  if (block.getField(name)) return;
+  block.appendDummyInput()
+    .appendField(new Blockly.FieldLabelSerializable(value), name);
+  block.getField(name)?.setVisible(false);
 }
 
 function plusSvg(): string {

--- a/src/blockly/blocks/rm_blocks.ts
+++ b/src/blockly/blocks/rm_blocks.ts
@@ -998,12 +998,11 @@ function restoreMutatorAttributes(
   attrs: string[],
 ): void {
   block.extraInputs_ = extras;
-  const rm = rmTypeOfBlock(block);
-  if (isEventFamilyType(rm) && (attrs.length || extras.length)) {
+  if (attrs.length) {
     syncRmAttributeInputs(
       block,
-      rm,
-      eventAttributesToShow(rm, attrs),
+      rmTypeOfBlock(block),
+      attrs,
       block.slotCardinalities_,
     );
   }

--- a/src/blockly/blocks/target_blocks.ts
+++ b/src/blockly/blocks/target_blocks.ts
@@ -72,6 +72,7 @@ function defineValueBlock(
       this.appendDummyInput()
         .appendField(new Blockly.FieldTextInput(""), "SLOT_ID");
       this.getField("SLOT_ID")?.setVisible(false);
+      appendHiddenTargetMandatory(this);
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setColour(colour);
@@ -79,6 +80,13 @@ function defineValueBlock(
       this.setInputsInline(true);
     },
   };
+}
+
+function appendHiddenTargetMandatory(block: Block): void {
+  if (block.getField("MANDATORY")) return;
+  block.appendDummyInput()
+    .appendField(new Blockly.FieldLabelSerializable(""), "MANDATORY");
+  block.getField("MANDATORY")?.setVisible(false);
 }
 
 export function syncTargetChildInputs(

--- a/src/blockly/blocks/term_pick.ts
+++ b/src/blockly/blocks/term_pick.ts
@@ -50,6 +50,11 @@ export function registerTermPickBlock(): void {
       this.appendDummyInput()
         .appendField(new Blockly.FieldLabelSerializable("CODE_PHRASE"), "RM_TYPE");
       this.getField("RM_TYPE")!.setVisible(false);
+      if (!this.getField("MANDATORY")) {
+        this.appendDummyInput()
+          .appendField(new Blockly.FieldLabelSerializable(""), "MANDATORY");
+        this.getField("MANDATORY")!.setVisible(false);
+      }
 
       this.setOutput(true, ["CODE_PHRASE", "DV_CODED_TEXT"]);
       this.setColour(TERM_COLOUR);

--- a/src/blockly/compact_renderer.ts
+++ b/src/blockly/compact_renderer.ts
@@ -1,5 +1,6 @@
 import { Blockly } from "./blockly_core.ts";
 import { isRmTypeEmojiField } from "./rm_type_emoji.ts";
+import { isSlotCardinalityField } from "./slot_cardinality.ts";
 
 export const COMPACT_RENDERER_NAME = "thrasos-compact";
 
@@ -19,7 +20,7 @@ export function registerCompactThrasosRenderer(): string {
     // deno-lint-ignore no-explicit-any
     getInRowSpacing_(prev: any, next: any) {
       const spacing = super.getInRowSpacing_(prev, next);
-      if (isRmEmojiMeasurable(prev) || isRmEmojiMeasurable(next)) {
+      if (isRmEmojiMeasurable(prev) || isRmEmojiMeasurable(next) || isSlotCardMeasurable(prev) || isSlotCardMeasurable(next)) {
         return Math.min(spacing, 1);
       }
       return spacing;
@@ -67,4 +68,8 @@ export function registerCompactThrasosRenderer(): string {
 // deno-lint-ignore no-explicit-any
 function isRmEmojiMeasurable(elem: any): boolean {
   return isRmTypeEmojiField(elem?.field ?? null);
+}
+
+function isSlotCardMeasurable(elem: any): boolean {
+  return isSlotCardinalityField(elem?.field ?? null);
 }

--- a/src/blockly/mod.ts
+++ b/src/blockly/mod.ts
@@ -25,6 +25,7 @@ export {
   setAllBlocksCollapsed,
   slotIdFromBlock,
 } from "./skeleton_loader.ts";
+export { refreshWorkspaceConstraints, ABSTRACT_EVENT_WARNING, warningTextOf } from "./block_constraints.ts";
 export { blockToExpression } from "./expression_serialize.ts";
 export {
   createSourceQueryBlock,
@@ -44,7 +45,7 @@ export {
   openWorkspaceSnapshotWindow,
   workspaceToStandaloneSvg,
 } from "./workspace_snapshot.ts";
-export { setOptionalRmPickHandler } from "./blocks/rm_blocks.ts";
+export { setOptionalRmPickHandler, applyEventRmType, isEventFamilyType } from "./blocks/rm_blocks.ts";
 export { dataValueLeafTypes, blockTypeForRm, getValidAttachments } from "../core/rm_meta.ts";
 export { isRmContainerBlockType } from "./blocks/rm_blocks.ts";
 export { buildDemoToolbox, type ToolboxContext } from "./toolbox_demo.ts";

--- a/src/blockly/rm_type_emoji.ts
+++ b/src/blockly/rm_type_emoji.ts
@@ -12,6 +12,7 @@ import {
   attributesFor,
   baseRmTypeName,
   isAbstractType,
+  resolveGenericSlotType,
   subtypesOf,
 } from "../core/rm_meta.ts";
 
@@ -43,7 +44,7 @@ export function slotRmTypeForAttr(
   check?: string | string[] | null,
 ): string | undefined {
   const meta = attributesFor(parentRmType).find((a) => a.name === attrName);
-  if (meta) return baseRmTypeName(meta.typeName);
+  if (meta) return resolveGenericSlotType(parentRmType, meta.typeName);
   if (typeof check === "string") return check;
   if (Array.isArray(check)) {
     for (const t of check) {

--- a/src/blockly/skeleton_loader.ts
+++ b/src/blockly/skeleton_loader.ts
@@ -13,7 +13,6 @@ import {
   connectExpressionToDataValueShell,
   ensureElementDataValueShell,
   ensureRmBlockType,
-  expressionBlockFromDataValueShell,
   isDataValueBlock,
   optionalRmInputName,
   rmAttributeInputName,
@@ -27,6 +26,12 @@ import {
   syncTargetChildInputs,
   targetChildInputName,
 } from "./blocks/target_blocks.ts";
+import { refreshWorkspaceConstraints } from "./block_constraints.ts";
+import {
+  parseSlotCardinality,
+  rmAttributeCardinality,
+  type SlotCardinality,
+} from "./slot_cardinality.ts";
 
 export function loadSkeletonIntoWorkspace(
   workspace: WorkspaceSvg,
@@ -51,6 +56,7 @@ export function loadSkeletonIntoWorkspace(
     setAllBlocksCollapsed(workspace, false);
     highlightListeningSlot(workspace, listeningSlotId);
     refreshWorkspaceLayout(workspace);
+    refreshWorkspaceConstraints(workspace);
   } finally {
     Blockly.Events.enable();
   }
@@ -244,6 +250,7 @@ export function attachOptionalRmChild(
     : optionalRmInputName(insertion.attributeName);
   connectAttributeChildren(parent, inputName, [child]);
   refreshBlockLayout(parent as BlockSvg);
+  refreshWorkspaceConstraints(workspace);
   return child;
 }
 
@@ -325,7 +332,7 @@ function buildTargetValueBlock(
     block.setPreviousStatement(true);
     block.setNextStatement(true);
   }
-  if (node.mandatory) block.setWarningText("Unmapped mandatory value");
+  setMandatoryFlag(block, node.mandatory);
   return finalizeBlock(block);
 }
 
@@ -398,16 +405,23 @@ function buildContainerBlock(
         .filter((attr): attr is string => Boolean(attr)),
     ),
   ];
-  syncRmAttributeInputs(block, node.rmType, attributes);
+  const cards: Record<string, SlotCardinality> = {};
+  for (const attr of attributes) {
+    const kids = visibleChildren.filter((child) => child.rmAttribute === attr);
+    const raw = kids[0]?.slotCardinality ?? kids[0]?.multiplicity;
+    const parsed = parseSlotCardinality(raw) ??
+      rmAttributeCardinality(node.rmType, attr);
+    if (parsed) cards[attr] = parsed;
+  }
+  block.slotCardinalities_ = cards;
+  syncRmAttributeInputs(block, node.rmType, attributes, cards);
 
   if (!isRoot && !block.outputConnection) {
     block.setPreviousStatement(true);
     block.setNextStatement(true);
   }
 
-  if (node.mandatory) {
-    block.setWarningText(node.silentMandatory ? "Mandatory (RM)" : "Mandatory");
-  }
+  setMandatoryFlag(block, node.mandatory);
 
   // Initialise SVG before nesting children so puzzle-tab sockets measure correctly.
   finalizeBlock(block);
@@ -446,16 +460,14 @@ function buildElementBlock(
     block.setNextStatement(true);
   }
 
-  if (node.mandatory && primary && !hasMappedExpression(block)) {
-    block.setWarningText("Unmapped mandatory value");
-  }
+  const valueMandatory = Boolean(
+    (primary?.mandatory ?? false) || Boolean(node.mandatory && primary),
+  );
+  setMandatoryFlag(block, valueMandatory);
 
   // Render the ELEMENT shell before attaching the typed DATA_VALUE child.
   finalizeBlock(block);
 
-  const valueMandatory = Boolean(
-    (primary?.mandatory ?? false) || (node.mandatory && primary),
-  );
   if (valueMandatory && primary && isDataValueType(dvType)) {
     const shell = ensureElementDataValueShell(workspace, block, dvType);
     if (shell) applyFixedFieldsToDataValueShell(workspace, shell, primary.fixedFields ?? node.fixedFields);
@@ -477,9 +489,7 @@ function buildTypedValueBlock(
   if (termSet) {
     const code = node.fixedFields?.code_string ?? node.fixedFields?.defining_code;
     const block = createTermPickBlock(workspace, termSet, code, node.slotId);
-    if (node.mandatory && !code) {
-      block.setWarningText(node.silentMandatory ? "Mandatory (RM)" : "Mandatory");
-    }
+    setMandatoryFlag(block, node.mandatory);
     return finalizeBlock(block);
   }
 
@@ -491,9 +501,7 @@ function buildTypedValueBlock(
   setFieldIfPresent(block, "RM_TYPE", node.rmType);
   setFieldIfPresent(block, "SLOT_ID", node.slotId);
   applySkeletonBlockLabels(block, node);
-  if (node.mandatory) {
-    block.setWarningText(node.silentMandatory ? "Mandatory (RM)" : "Mandatory");
-  }
+  setMandatoryFlag(block, node.mandatory);
   finalizeBlock(block);
   applyFixedFieldsToDataValueShell(workspace, block, node.fixedFields);
   refreshBlockLayout(block);
@@ -660,11 +668,6 @@ function setFieldIfPresent(block: Blockly.Block, name: string, value: string): v
   if (field) field.setValue(value);
 }
 
-function hasMappedExpression(block: Blockly.Block): boolean {
-  const valueBlock = block.getInput("VALUE")?.connection?.targetBlock();
-  if (!valueBlock) return false;
-  if (isDataValueBlock(valueBlock)) {
-    return Boolean(expressionBlockFromDataValueShell(valueBlock));
-  }
-  return true;
+function setMandatoryFlag(block: Blockly.Block, mandatory: boolean): void {
+  setFieldIfPresent(block, "MANDATORY", mandatory ? "1" : "");
 }

--- a/src/blockly/slot_cardinality.ts
+++ b/src/blockly/slot_cardinality.ts
@@ -1,0 +1,126 @@
+/**
+ * Compact `[min..max]` labels on Blockly slots, bold when the live count
+ * is outside the allowed range.
+ */
+import type { Field, Input } from "blockly/core";
+import { Blockly } from "./blockly_core.ts";
+import { attributesFor } from "../core/rm_meta.ts";
+
+export const SLOT_CARD_FIELD_PREFIX = "SLOT_CARD_";
+
+export interface SlotCardinality {
+  min: number;
+  max: number | null;
+}
+
+// deno-lint-ignore no-explicit-any
+const FieldLabelBase = Blockly.FieldLabel as any;
+
+export class FieldSlotCardinality extends FieldLabelBase {
+  readonly isSlotCardinalityField = true;
+  EDITABLE = false;
+  SERIALIZABLE = false;
+  min = 0;
+  max: number | null = 1;
+  unmet = false;
+
+  constructor(card: SlotCardinality) {
+    super(formatSlotCardinality(card), cssClass(false));
+    this.min = card.min;
+    this.max = card.max;
+  }
+
+  setCardinality(card: SlotCardinality): void {
+    this.min = card.min;
+    this.max = card.max;
+    this.setValue(formatSlotCardinality(card));
+    this.syncUnmetClass_();
+  }
+
+  setUnmet(unmet: boolean): void {
+    if (this.unmet === unmet) return;
+    this.unmet = unmet;
+    this.syncUnmetClass_();
+  }
+
+  private syncUnmetClass_(): void {
+    this.setClass?.(cssClass(this.unmet));
+  }
+}
+
+export function isSlotCardinalityField(
+  field: Field | null | undefined,
+): field is FieldSlotCardinality {
+  return Boolean(field && (field as FieldSlotCardinality).isSlotCardinalityField);
+}
+
+export function slotCardinalityFieldName(inputName: string): string {
+  return `${SLOT_CARD_FIELD_PREFIX}${inputName}`;
+}
+
+/** Always `[n..m]` / `[n..*]`, including `[1..1]` rather than a bare `1`. */
+export function formatSlotCardinality(card: SlotCardinality): string {
+  const upper = card.max == null ? "*" : String(card.max);
+  return `[${card.min}..${upper}]`;
+}
+
+export function parseSlotCardinality(raw?: string | null): SlotCardinality | undefined {
+  if (!raw) return undefined;
+  const text = raw.trim().replace(/^\[/, "").replace(/\]$/, "");
+  if (text === "1") return { min: 1, max: 1 };
+  const star = /^(\d+)\.\.\*$/.exec(text);
+  if (star) return { min: Number(star[1]), max: null };
+  const range = /^(\d+)\.\.(\d+)$/.exec(text);
+  if (range) return { min: Number(range[1]), max: Number(range[2]) };
+  return undefined;
+}
+
+export function rmAttributeCardinality(
+  rmType: string,
+  attrName: string,
+): SlotCardinality | undefined {
+  const meta = attributesFor(rmType).find((a) => a.name === attrName);
+  if (!meta?.multiplicity) return undefined;
+  return {
+    min: Number(meta.multiplicity.min ?? 0),
+    max: meta.multiplicity.max == null ? null : Number(meta.multiplicity.max),
+  };
+}
+
+export function isCardinalityMet(count: number, card: SlotCardinality): boolean {
+  if (count < card.min) return false;
+  if (card.max != null && count > card.max) return false;
+  return true;
+}
+
+/**
+ * Last-but-one field on a value/statement input (ZipEHR emoji stays last,
+ * against the socket).
+ */
+export function appendSlotCardinality(
+  input: Input,
+  card: SlotCardinality | undefined,
+): void {
+  if (!card) return;
+  const name = slotCardinalityFieldName(input.name);
+  const existing = input.fieldRow.find((field) => field.name === name);
+  if (existing && isSlotCardinalityField(existing)) {
+    existing.setCardinality(card);
+    return;
+  }
+  if (existing) {
+    existing.setValue(formatSlotCardinality(card));
+    return;
+  }
+  input.appendField(new FieldSlotCardinality(card), name);
+}
+
+export function cardinalityFieldOnInput(input: Input | null): FieldSlotCardinality | null {
+  if (!input) return null;
+  const field = input.fieldRow.find((item) => isSlotCardinalityField(item));
+  return field && isSlotCardinalityField(field) ? field : null;
+}
+
+function cssClass(unmet: boolean): string {
+  return unmet ? "blockly-slot-card blockly-slot-card--unmet" : "blockly-slot-card";
+}

--- a/src/core/rm_meta.ts
+++ b/src/core/rm_meta.ts
@@ -44,6 +44,19 @@ export function baseRmTypeName(typeName: string): string {
   return typeName;
 }
 
+/**
+ * Resolve a BMM type parameter (e.g. EVENT.data is `T`) to its
+ * `conforms_to_type` bound. EVENT&lt;T&gt; locks T to ITEM_STRUCTURE
+ * (`openehr://spec/type/RM/EVENT`).
+ */
+export function resolveGenericSlotType(parentRmType: string, typeName: string): string {
+  const base = baseRmTypeName(typeName);
+  if (base === "T" && (parentRmType === "EVENT" || isSubtypeOf(parentRmType, "EVENT"))) {
+    return "ITEM_STRUCTURE";
+  }
+  return base;
+}
+
 export function isPrimitiveRmType(typeName: string): boolean {
   return PRIMITIVE_RM_TYPES.has(baseRmTypeName(typeName));
 }

--- a/src/core/skeleton/generate_skeleton.ts
+++ b/src/core/skeleton/generate_skeleton.ts
@@ -173,6 +173,7 @@ function walkComplex(
     const attrName = attr.rm_attribute_name as string | undefined;
     if (!attrName) continue;
     presentAttrs.add(attrName);
+    const slotCard = multiplicityOfAttribute(attr);
     const childNodes = walkAttribute(
       attr,
       templateId,
@@ -183,6 +184,7 @@ function walkComplex(
     );
     for (const child of childNodes) {
       child.rmAttribute = attrName;
+      child.slotCardinality = slotCard ?? child.multiplicity;
       applyRmConstrainedFields(child, rmType);
       children.push(child);
     }
@@ -200,6 +202,7 @@ function walkComplex(
     );
     if (silent) {
       silent.rmAttribute = attrName;
+      silent.slotCardinality = silent.slotCardinality ?? silent.multiplicity;
       children.push(silent);
     }
   }
@@ -313,6 +316,7 @@ function buildSilentMandatoryNode(
   node.rmAttribute = attrName;
   node.mandatory = true;
   node.silentMandatory = true;
+  node.slotCardinality = node.slotCardinality ?? node.multiplicity;
   applyRmConstrainedFields(node, parentRmType);
   return node;
 }
@@ -492,6 +496,19 @@ export function multiplicityOfAm(cObj: AmObject): string | undefined {
   }
   if (upper === 1) return lower > 0 ? "1" : "0..1";
   return `${lower}..${upper}`;
+}
+
+function multiplicityOfAttribute(attr: AmObject): string | undefined {
+  if (!attr) return undefined;
+  const card = attr.cardinality;
+  if (card) {
+    const interval = card.interval ?? card;
+    return multiplicityOfAm({ occurrences: interval });
+  }
+  if (attr.existence) {
+    return multiplicityOfAm({ occurrences: attr.existence });
+  }
+  return undefined;
 }
 
 export function isRepeatingMultiplicity(multiplicity?: string): boolean {

--- a/src/host/file_picker.ts
+++ b/src/host/file_picker.ts
@@ -1,7 +1,7 @@
 import type { UrlHistoryKind } from "./url_history.ts";
 
 /** Distinct remembered folders for file pickers (schema vs examples vs target). */
-export type FilePickerKind = UrlHistoryKind | "project";
+export type FilePickerKind = UrlHistoryKind | "project" | "mapping";
 
 export function filePickerId(kind?: FilePickerKind): string | undefined {
   return kind ? `intehrgrator-${kind}` : undefined;

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -68,6 +68,8 @@ export interface SkeletonNode {
   targetPath?: string;
   /** Compact target cardinality, e.g. `1`, `0..1`, `0..*`, `1..*`. */
   multiplicity?: string;
+  /** Cardinality of the parent attribute slot this node occupies. */
+  slotCardinality?: string;
   children: SkeletonNode[];
   attachmentPoint?: string;
 }

--- a/src/ui_test/test_api.ts
+++ b/src/ui_test/test_api.ts
@@ -50,6 +50,10 @@ export interface IntehrgratorTestApi {
    * where absolute slotIds are long archetype paths).
    */
   findSlotIdBySuffix(suffix: string): string | null;
+  /** CodeMirror Mapping Spec document (full Blockly workspace JSON). */
+  getMappingSpecDocument(): string;
+  /** Load a Blockly workspace JSON file (same path as Mapping Spec Upload). */
+  loadBlocklyJson(filename: string, content: string): void;
 }
 
 declare global {

--- a/src/workbench/controller.ts
+++ b/src/workbench/controller.ts
@@ -63,7 +63,6 @@ import {
   type GitHubClinicalModelLoadResult,
 } from "../core/clinical_model/github_template.ts";
 import { loadGitHubExampleDirectory } from "../core/source/github_examples.ts";
-import { projectBlocklyState } from "./mapping_spec/project.ts";
 import { isTemplateJson } from "ehrtslib/parser/mod.ts";
 import {
   snapshotUrlHistory,
@@ -117,6 +116,7 @@ export class WorkbenchController {
     origin: null,
   };
   private blocklyState: unknown = null;
+  private blocklyReloadToken = 0;
   private getBlocklyState: (() => unknown) | null = null;
   private debounceTimer: number | null = null;
   private autosaveTimer: number | null = null;
@@ -172,6 +172,7 @@ export class WorkbenchController {
       activeExampleValidation: this.buildActiveExampleValidation(),
       specText: formatBlocklyState(this.getBlocklyState?.() ?? this.blocklyState),
       blocklyState: this.blocklyState,
+      blocklyReloadToken: this.blocklyReloadToken,
       handlebarsTemplate: this.handlebarsTemplate,
       generatedCode: this.generatedCode,
       testResult: this.testResult,
@@ -249,6 +250,7 @@ export class WorkbenchController {
       this.handlebarsTemplate = content;
     }
     this.blocklyState = null;
+    this.blocklyReloadToken += 1;
     this.refreshDerived();
     this.statusMessage = `Loaded ${format} target ${this.templateId}`;
     this.markDirty();
@@ -574,10 +576,7 @@ export class WorkbenchController {
   }
 
   exportMappingSpec(): void {
-    const state = this.getBlocklyState?.() ?? this.blocklyState;
-    const text = projectBlocklyState(state).text;
-    const base = safeFilename(this.templateId || this.projectId || "mapping");
-    void this.host.downloadText(`${base}.mapping-spec.txt`, text, "text/plain");
+    this.exportBlocklyDefinition();
   }
 
   /** Full Blockly workspace JSON (canonical mapping definition, includes x/y). */
@@ -586,6 +585,35 @@ export class WorkbenchController {
     const text = formatBlocklyState(state) || "{}";
     const base = safeFilename(this.templateId || this.projectId || "mapping");
     void this.host.downloadText(`${base}.blockly.json`, text, "application/json");
+  }
+
+  /** Load a previously downloaded Blockly workspace JSON onto the canvas. */
+  async importBlocklyDefinition(): Promise<void> {
+    const file = await this.host.pickTextFile(".json,.blockly.json", "mapping");
+    if (!file) return;
+    this.loadBlocklyDefinition(file.name, file.text);
+  }
+
+  loadBlocklyDefinition(filename: string, content: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch (err) {
+      this.statusMessage =
+        `Blockly JSON parse failed: ${err instanceof Error ? err.message : String(err)}`;
+      this.notifyChange();
+      return;
+    }
+    if (!parsed || typeof parsed !== "object") {
+      this.statusMessage = "Blockly JSON must be an object";
+      this.notifyChange();
+      return;
+    }
+    this.blocklyState = parsed;
+    this.blocklyReloadToken += 1;
+    this.statusMessage = `Loaded Blockly mapping ${filename}`;
+    this.markDirty();
+    this.notifyChange();
   }
 
   async saveProjectAs(displayName: string): Promise<void> {
@@ -899,7 +927,7 @@ export class WorkbenchController {
   }
 
   private refreshDerived(): void {
-    // Spec view is a projected Mapping Spec (widgets); keep pretty JSON for diagnostics/AI copy.
+    // Spec view is widgets over the pretty Blockly JSON document.
     this.specText = formatBlocklyState(this.getBlocklyState?.() ?? this.blocklyState);
     this.generatedCode = this.model.templateId
       ? generate(this.model, this.settings.exportTarget, {
@@ -968,6 +996,7 @@ export class WorkbenchController {
     this.listeningSlotId = null;
     this.treeHighlight = { syncPath: null, origin: null };
     this.blocklyState = null;
+    this.blocklyReloadToken += 1;
     this.dirty = false;
     this.lastAutosaveAt = null;
     if (this.autosaveTimer !== null) {
@@ -1109,6 +1138,7 @@ export class WorkbenchController {
     this.model = createEmptyModel(this.templateId);
     this.model.targetFormat = "openehr-template";
     this.blocklyState = null;
+    this.blocklyReloadToken += 1;
     this.refreshDerived();
     const extra = loaded.warnings.length ? ` (${loaded.warnings.length} warnings)` : "";
     this.statusMessage =

--- a/src/workbench/mapping_spec/editor.ts
+++ b/src/workbench/mapping_spec/editor.ts
@@ -4,22 +4,27 @@ import {
   Decoration,
   EditorView,
   ViewPlugin,
+  WidgetType,
   keymap,
   lineNumbers,
   type ViewUpdate,
 } from "@codemirror/view";
-import { projectBlocklyState, type SpecLine, type SpecProjection } from "./project.ts";
+import {
+  blocklyJsonDocument,
+  type BlocklyJsonDocument,
+  type SpecLine,
+} from "./project.ts";
 import { MappingSpecWidget, SPEC_LINE_HEIGHT, type SpecFieldEditHandler } from "./widgets.ts";
 
-const setProjectionEffect = StateEffect.define<SpecProjection>();
+const setJsonDocEffect = StateEffect.define<BlocklyJsonDocument>();
 
-const projectionField = StateField.define<SpecProjection>({
+const jsonDocField = StateField.define<BlocklyJsonDocument>({
   create() {
-    return projectBlocklyState(null);
+    return blocklyJsonDocument(null);
   },
   update(value, tr) {
     for (const effect of tr.effects) {
-      if (effect.is(setProjectionEffect)) return effect.value;
+      if (effect.is(setJsonDocEffect)) return effect.value;
     }
     return value;
   },
@@ -34,18 +39,53 @@ const editFacet = Facet.define<
   },
 });
 
+class HiddenJsonWidget extends WidgetType {
+  override get estimatedHeight(): number {
+    return 0;
+  }
+
+  override toDOM(): HTMLElement {
+    const span = document.createElement("span");
+    span.className = "cm-spec-json-chrome";
+    span.hidden = true;
+    return span;
+  }
+
+  override eq(): boolean {
+    return true;
+  }
+}
+
 function buildDecorations(view: EditorView): Decoration {
-  const projection = view.state.field(projectionField);
+  const doc = view.state.field(jsonDocField);
   const onEdit = view.state.facet(editFacet);
   const ranges = [];
-  for (let i = 0; i < projection.lines.length; i++) {
-    const line = view.state.doc.line(i + 1);
-    const meta = projection.lines[i]!;
+  const text = view.state.doc.toString();
+  if (!doc.widgets.length) {
+    return Decoration.none;
+  }
+
+  let cursor = 0;
+  for (const widget of doc.widgets) {
+    if (widget.from > cursor) {
+      ranges.push(
+        Decoration.replace({ widget: new HiddenJsonWidget(), inclusive: true })
+          .range(cursor, widget.from),
+      );
+    }
     ranges.push(
       Decoration.replace({
-        widget: new MappingSpecWidget(meta, onEdit),
+        widget: new MappingSpecWidget(widget.line, onEdit),
         inclusive: true,
-      }).range(line.from, line.to),
+      }).range(widget.from, widget.to),
+    );
+    cursor = widget.to;
+    if (text[cursor] === "\n") cursor++;
+  }
+  if (cursor < text.length) {
+    ranges.push(
+      Decoration.replace({ widget: new HiddenJsonWidget(), inclusive: true })
+        .range(cursor, text.length),
     );
   }
   return Decoration.set(ranges, true);
@@ -62,7 +102,7 @@ const widgetPlugin = ViewPlugin.fromClass(
         update.docChanged ||
         update.viewportChanged ||
         update.transactions.some((tr) =>
-          tr.effects.some((effect) => effect.is(setProjectionEffect))
+          tr.effects.some((effect) => effect.is(setJsonDocEffect))
         )
       ) {
         this.decorations = buildDecorations(update.view);
@@ -190,7 +230,7 @@ export function createMappingSpecEditor(
   parent: HTMLElement,
   options: MappingSpecEditorOptions = {},
 ): EditorView {
-  const empty = projectBlocklyState(null);
+  const empty = blocklyJsonDocument(null);
   return new EditorView({
     parent,
     state: EditorState.create({
@@ -199,7 +239,7 @@ export function createMappingSpecEditor(
         lineNumbers(),
         history(),
         keymap.of([...defaultKeymap, ...historyKeymap]),
-        projectionField.init(() => empty),
+        jsonDocField.init(() => empty),
         editFacet.of(options.onFieldEdit),
         widgetPlugin,
         EditorView.editable.of(false),
@@ -212,32 +252,18 @@ export function createMappingSpecEditor(
 
 /** Replace the Spec view from canonical Blockly workspace JSON. */
 export function setMappingSpecFromBlockly(view: EditorView, blocklyState: unknown): void {
-  const projection = projectBlocklyState(blocklyState);
+  const next = blocklyJsonDocument(blocklyState);
   const current = view.state.doc.toString();
-  if (
-    current === projection.text &&
-    sameLines(view.state.field(projectionField).lines, projection.lines)
-  ) {
-    return;
-  }
+  if (current === next.text) return;
   view.dispatch({
-    changes: { from: 0, to: view.state.doc.length, insert: projection.text },
-    effects: setProjectionEffect.of(projection),
+    changes: { from: 0, to: view.state.doc.length, insert: next.text },
+    effects: setJsonDocEffect.of(next),
   });
 }
 
-function sameLines(a: SpecLine[], b: SpecLine[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) {
-    if (
-      a[i]!.blockId !== b[i]!.blockId ||
-      a[i]!.summary !== b[i]!.summary ||
-      JSON.stringify(a[i]!.editable) !== JSON.stringify(b[i]!.editable)
-    ) {
-      return false;
-    }
-  }
-  return true;
+/** The editor document is the full Blockly workspace JSON. */
+export function mappingSpecDocumentText(view: EditorView): string {
+  return view.state.doc.toString();
 }
 
-export type { SpecFieldEditHandler, SpecProjection, SpecLine };
+export type { SpecFieldEditHandler, SpecLine };

--- a/src/workbench/mapping_spec/editor.ts
+++ b/src/workbench/mapping_spec/editor.ts
@@ -3,11 +3,10 @@ import { EditorState, Facet, StateEffect, StateField } from "@codemirror/state";
 import {
   Decoration,
   EditorView,
-  ViewPlugin,
   WidgetType,
   keymap,
   lineNumbers,
-  type ViewUpdate,
+  type DecorationSet,
 } from "@codemirror/view";
 import {
   blocklyJsonDocument,
@@ -56,21 +55,26 @@ class HiddenJsonWidget extends WidgetType {
   }
 }
 
-function buildDecorations(view: EditorView): Decoration {
-  const doc = view.state.field(jsonDocField);
-  const onEdit = view.state.facet(editFacet);
-  const ranges = [];
-  const text = view.state.doc.toString();
-  if (!doc.widgets.length) {
-    return Decoration.none;
-  }
+/**
+ * Replace decorations that span line breaks must come from a StateField,
+ * not a ViewPlugin (CodeMirror: "may not be specified via plugins").
+ */
+function buildDecorations(state: EditorState): DecorationSet {
+  const doc = state.field(jsonDocField);
+  const onEdit = state.facet(editFacet);
+  if (!doc.widgets.length) return Decoration.none;
 
+  const ranges = [];
+  const text = state.doc.toString();
   let cursor = 0;
   for (const widget of doc.widgets) {
     if (widget.from > cursor) {
       ranges.push(
-        Decoration.replace({ widget: new HiddenJsonWidget(), inclusive: true })
-          .range(cursor, widget.from),
+        Decoration.replace({
+          widget: new HiddenJsonWidget(),
+          block: true,
+          inclusive: true,
+        }).range(cursor, widget.from),
       );
     }
     ranges.push(
@@ -84,33 +88,31 @@ function buildDecorations(view: EditorView): Decoration {
   }
   if (cursor < text.length) {
     ranges.push(
-      Decoration.replace({ widget: new HiddenJsonWidget(), inclusive: true })
-        .range(cursor, text.length),
+      Decoration.replace({
+        widget: new HiddenJsonWidget(),
+        block: true,
+        inclusive: true,
+      }).range(cursor, text.length),
     );
   }
   return Decoration.set(ranges, true);
 }
 
-const widgetPlugin = ViewPlugin.fromClass(
-  class {
-    decorations: Decoration;
-    constructor(view: EditorView) {
-      this.decorations = buildDecorations(view);
-    }
-    update(update: ViewUpdate) {
-      if (
-        update.docChanged ||
-        update.viewportChanged ||
-        update.transactions.some((tr) =>
-          tr.effects.some((effect) => effect.is(setJsonDocEffect))
-        )
-      ) {
-        this.decorations = buildDecorations(update.view);
-      }
-    }
+const jsonDecorations = StateField.define<DecorationSet>({
+  create(state) {
+    return buildDecorations(state);
   },
-  { decorations: (value) => value.decorations },
-);
+  update(value, tr) {
+    if (
+      tr.docChanged ||
+      tr.effects.some((effect) => effect.is(setJsonDocEffect))
+    ) {
+      return buildDecorations(tr.state);
+    }
+    return value;
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
 
 const specTheme = EditorView.theme({
   "&": { height: "100%", fontSize: "12px" },
@@ -241,7 +243,7 @@ export function createMappingSpecEditor(
         keymap.of([...defaultKeymap, ...historyKeymap]),
         jsonDocField.init(() => empty),
         editFacet.of(options.onFieldEdit),
-        widgetPlugin,
+        jsonDecorations,
         EditorView.editable.of(false),
         EditorState.readOnly.of(true),
         specTheme,

--- a/src/workbench/mapping_spec/mod.ts
+++ b/src/workbench/mapping_spec/mod.ts
@@ -1,5 +1,7 @@
 export {
+  blocklyJsonDocument,
   projectBlocklyState,
+  type BlocklyJsonDocument,
   type SpecEditableField,
   type SpecLine,
   type SpecLineKind,
@@ -8,6 +10,7 @@ export {
 
 export {
   createMappingSpecEditor,
+  mappingSpecDocumentText,
   setMappingSpecFromBlockly,
   type MappingSpecEditorOptions,
   type SpecFieldEditHandler,

--- a/src/workbench/mapping_spec/project.ts
+++ b/src/workbench/mapping_spec/project.ts
@@ -244,6 +244,37 @@ function collectInfo(block: BlocklyBlockJson): Record<string, unknown> {
   return info;
 }
 
+export interface BlocklyJsonDocument {
+  text: string;
+  widgets: Array<{ from: number; to: number; line: SpecLine }>;
+}
+
+/** Pretty-printed Blockly JSON plus widget ranges on each block `"type"` line. */
+export function blocklyJsonDocument(state: unknown): BlocklyJsonDocument {
+  const text = state == null ? "{}" : JSON.stringify(state, null, 2);
+  const specBlocks = projectBlocklyState(state).lines.filter(
+    (line) => line.kind !== "header" && line.type !== "empty",
+  );
+  const widgets: BlocklyJsonDocument["widgets"] = [];
+  const jsonLines = text.split("\n");
+  let offset = 0;
+  let specIdx = 0;
+  for (let i = 0; i < jsonLines.length; i++) {
+    const line = jsonLines[i]!;
+    const from = offset;
+    const to = from + line.length;
+    offset = to + (i < jsonLines.length - 1 ? 1 : 0);
+    if (specIdx < specBlocks.length && /^\s*"type": /.test(line)) {
+      widgets.push({ from, to, line: specBlocks[specIdx]! });
+      specIdx++;
+    }
+  }
+  if (specIdx !== specBlocks.length) {
+    return { text, widgets: [] };
+  }
+  return { text, widgets };
+}
+
 function toProjection(lines: SpecLine[]): SpecProjection {
   const text = lines
     .map((line) => {

--- a/test/blockly_rm_blocks_test.ts
+++ b/test/blockly_rm_blocks_test.ts
@@ -16,6 +16,7 @@ import {
   RM_SPECIALIZATION_INPUT,
   rmAttributeInputName,
   syncRmAttributeInputs,
+  applyEventRmType,
 } from "@intehrgrator/blockly/blocks/rm_blocks.ts";
 import { registerExpressionBlocks } from "@intehrgrator/blockly/blocks/expression_blocks.ts";
 import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
@@ -30,6 +31,16 @@ import {
   slotEmojiFieldName,
 } from "@intehrgrator/blockly/rm_type_emoji.ts";
 import { loadSkeletonIntoWorkspace, setAllBlocksCollapsed, attachOptionalRmChild } from "@intehrgrator/blockly/skeleton_loader.ts";
+import {
+  ABSTRACT_EVENT_WARNING,
+  blockConstraintMessages,
+  refreshWorkspaceConstraints,
+  warningTextOf,
+} from "@intehrgrator/blockly/block_constraints.ts";
+import {
+  formatSlotCardinality,
+  isSlotCardinalityField,
+} from "@intehrgrator/blockly/slot_cardinality.ts";
 import { createTermPickBlock } from "@intehrgrator/blockly/blocks/term_pick.ts";
 import { termSetById } from "@intehrgrator/core/openehr_term_catalog.ts";
 import { createEmptyModel } from "@intehrgrator/core/mapping_model/mod.ts";
@@ -531,3 +542,93 @@ Deno.test("applyFixedFieldsToDataValueShell fills CODE_PHRASE terminology", () =
   assertEquals(term?.getFieldValue("TEXT"), "ISO_639-1");
   workspace.dispose();
 });
+
+Deno.test("mandatory containers do not get a warning triangle just for being mandatory", () => {
+  ensureBlocks();
+  const { skeleton } = generateSkeleton(fixture);
+  const workspace = new Blockly.Workspace();
+  loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
+  const composition = workspace.getTopBlocks(false)[0];
+  assert(composition);
+  const warning = (warningTextOf(composition) ?? blockConstraintMessages(composition).join("\n"));
+  assertEquals(warning.includes("Mandatory"), false);
+  const observation = workspace.getAllBlocks(false).find(
+    (b) => b.getFieldValue("RM_TYPE") === "OBSERVATION",
+  );
+  assert(observation);
+  assertEquals(
+    (warningTextOf(observation) ?? blockConstraintMessages(observation).join("\n")).includes("Mandatory"),
+    false,
+  );
+  workspace.dispose();
+});
+
+Deno.test("slots show [min..max] cardinality left of the ZipEHR emoji", () => {
+  ensureBlocks();
+  const workspace = new Blockly.Workspace();
+  const observation = workspace.newBlock("observation");
+  syncRmAttributeInputs(observation, "OBSERVATION", ["data"]);
+  const data = observation.getInput(rmAttributeInputName("data"));
+  assert(data);
+  const card = data.fieldRow.find((field) => isSlotCardinalityField(field));
+  assert(card);
+  assertEquals(card.getText(), formatSlotCardinality({ min: 1, max: 1 }));
+  assertEquals(data.fieldRow.at(-1)?.name?.startsWith("SLOT_EMOJI_"), true);
+  workspace.dispose();
+});
+
+Deno.test("unmapped mandatory ELEMENT shows a constraint warning", () => {
+  ensureBlocks();
+  const { skeleton } = generateSkeleton(fixture);
+  const workspace = new Blockly.Workspace();
+  loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
+  const systolic = workspace.getAllBlocks(false).find(
+    (b) => b.getFieldValue("NAME") === "Systolic" && b.type === "element",
+  );
+  assert(systolic, "expected systolic element");
+  assertEquals(systolic.getFieldValue("MANDATORY"), "1");
+  const text = warningTextOf(systolic) ?? blockConstraintMessages(systolic).join("\n");
+  assertEquals(text.includes("Unmapped mandatory value"), true);
+  workspace.dispose();
+});
+
+Deno.test("EVENT.data slot accepts ITEM_STRUCTURE (generic T bound)", () => {
+  ensureBlocks();
+  const workspace = new Blockly.Workspace();
+  const event = workspace.newBlock("event");
+  syncRmAttributeInputs(event, "EVENT", ["time", "data"]);
+  const dataInput = event.getInput(rmAttributeInputName("data"));
+  const check = dataInput?.connection?.getCheck() ?? [];
+  assertEquals(check.includes("ITEM_STRUCTURE"), true);
+  assertEquals(check.includes("ITEM_TREE"), true);
+  workspace.dispose();
+});
+
+Deno.test("EVENT block warns while abstract and can switch subtype without dropping children", () => {
+  ensureBlocks();
+  const workspace = new Blockly.Workspace();
+  const event = workspace.newBlock("event");
+  event.setFieldValue("EVENT", "RM_TYPE");
+  syncRmAttributeInputs(event, "EVENT", ["time", "data"]);
+  const data = workspace.newBlock("item_tree");
+  const dataInput = event.getInput(rmAttributeInputName("data"));
+  assert(dataInput?.connection && data.previousConnection);
+  dataInput.connection.connect(data.previousConnection);
+  assertEquals(event.getInputTargetBlock(rmAttributeInputName("data"))?.id, data.id);
+  refreshWorkspaceConstraints(workspace);
+  assertEquals(blockConstraintMessages(event).includes(ABSTRACT_EVENT_WARNING), true);
+
+  applyEventRmType(event, "POINT_EVENT");
+  refreshWorkspaceConstraints(workspace);
+  assertEquals(event.getFieldValue("RM_TYPE"), "POINT_EVENT");
+  assertEquals(event.getInputTargetBlock(rmAttributeInputName("data"))?.id, data.id);
+  assertEquals(blockConstraintMessages(event).includes(ABSTRACT_EVENT_WARNING), false);
+
+  applyEventRmType(event, "INTERVAL_EVENT");
+  assertEquals(event.getFieldValue("RM_TYPE"), "INTERVAL_EVENT");
+  assertEquals(event.getInputTargetBlock(rmAttributeInputName("data"))?.id, data.id);
+  assert(event.getInput(rmAttributeInputName("width")), "INTERVAL_EVENT.width should appear");
+  assert(event.getInput(rmAttributeInputName("math_function")), "INTERVAL_EVENT.math_function should appear");
+  workspace.dispose();
+});
+

--- a/test/blockly_rm_blocks_test.ts
+++ b/test/blockly_rm_blocks_test.ts
@@ -632,3 +632,27 @@ Deno.test("EVENT block warns while abstract and can switch subtype without dropp
   workspace.dispose();
 });
 
+Deno.test("Blockly JSON extraState restores dynamic ATTR_ sockets including EVENT extras", () => {
+  ensureBlocks();
+  const workspace = new Blockly.Workspace();
+  const observation = workspace.newBlock("observation");
+  syncRmAttributeInputs(observation, "OBSERVATION", ["data", "encoding"]);
+  const event = workspace.newBlock("event");
+  applyEventRmType(event, "INTERVAL_EVENT");
+  const tree = workspace.newBlock("item_tree");
+  event.getInput(rmAttributeInputName("data"))!.connection!.connect(tree.previousConnection!);
+
+  const saved = Blockly.serialization.workspaces.save(workspace);
+  workspace.dispose();
+
+  const loaded = new Blockly.Workspace();
+  Blockly.serialization.workspaces.load(saved, loaded);
+  const obs2 = loaded.getAllBlocks(false).find((b) => b.type === "observation");
+  const ev2 = loaded.getAllBlocks(false).find((b) => b.type === "event");
+  assert(obs2?.getInput(rmAttributeInputName("encoding")), "ATTR_encoding must round-trip");
+  assertEquals(ev2?.getFieldValue("RM_TYPE"), "INTERVAL_EVENT");
+  assert(ev2?.getInput(rmAttributeInputName("width")), "INTERVAL width must round-trip");
+  assertEquals(ev2?.getInputTargetBlock(rmAttributeInputName("data"))?.type, "item_tree");
+  loaded.dispose();
+});
+

--- a/test/examples_bulk_test.ts
+++ b/test/examples_bulk_test.ts
@@ -78,17 +78,50 @@ Deno.test("addExamplesFromGitHubDirectory bulk-loads instances and remembers URL
   assertEquals(controller.getState().urlHistory?.example.includes(url), true);
 });
 
-Deno.test("exportMappingSpec downloads projected spec text", () => {
+Deno.test("exportMappingSpec downloads full Blockly workspace JSON", () => {
+  let filename = "";
   let downloaded = "";
   const host = stubHost({
-    downloadText: (_name, content) => {
+    downloadText: (name, content) => {
+      filename = name;
       downloaded = content;
     },
   });
+  const blocklyState = {
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: "source_query_number",
+        id: "q1",
+        x: 120,
+        y: 48,
+        fields: { EXPRESSION: "/vitals/systolic" },
+      }],
+    },
+  };
   const controller = new WorkbenchController(host);
+  controller.setBlocklyStateGetter(() => blocklyState);
   controller.exportMappingSpec();
-  assertStringIncludes(downloaded, "Blockly projection");
-  assertStringIncludes(downloaded, "empty workspace");
+  assertStringIncludes(filename, ".blockly.json");
+  assertStringIncludes(downloaded, '"x": 120');
+  assertStringIncludes(downloaded, '"y": 48');
+  assertEquals(JSON.parse(downloaded).blocks.blocks[0].type, "source_query_number");
+});
+
+Deno.test("loadBlocklyDefinition stores workspace JSON for canvas restore", () => {
+  const host = stubHost();
+  const controller = new WorkbenchController(host);
+  const blocklyState = {
+    blocks: {
+      languageVersion: 0,
+      blocks: [{ type: "composition", id: "c1", x: 8, y: 16, fields: { RM_TYPE: "COMPOSITION" } }],
+    },
+  };
+  controller.loadBlocklyDefinition("bp.blockly.json", JSON.stringify(blocklyState));
+  const state = controller.getState();
+  assertEquals(state.blocklyReloadToken > 0, true);
+  assertEquals((state.blocklyState as { blocks?: { blocks?: Array<{ id?: string }> } })?.blocks?.blocks?.[0]?.id, "c1");
+  assertStringIncludes(state.specText, '"x": 8');
 });
 
 Deno.test("exportBlocklyDefinition downloads full workspace JSON with coordinates", () => {

--- a/test/mapping_spec_project_test.ts
+++ b/test/mapping_spec_project_test.ts
@@ -1,5 +1,5 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
-import { projectBlocklyState } from "@intehrgrator/workbench/mapping_spec/mod.ts";
+import { blocklyJsonDocument, projectBlocklyState } from "@intehrgrator/workbench/mapping_spec/mod.ts";
 
 Deno.test("projectBlocklyState compresses nested blocks and omits x/y from text", () => {
   const state = {
@@ -78,4 +78,46 @@ Deno.test("projectBlocklyState classifies typed source_query_number as source", 
   assertEquals(source?.type, "source_query_number");
   assertEquals(source?.summary, "number · $.systolic");
   assertEquals(source?.editable?.map((f) => f.field), ["EXPRESSION"]);
+});
+
+Deno.test("blocklyJsonDocument keeps full workspace JSON including coordinates", () => {
+  const state = {
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: "element",
+        id: "el1",
+        x: 40,
+        y: 80,
+        fields: { NAME: "systolic", RM_TYPE: "ELEMENT" },
+      }],
+    },
+  };
+  const doc = blocklyJsonDocument(state);
+  const parsed = JSON.parse(doc.text);
+  assertEquals(parsed.blocks.blocks[0].x, 40);
+  assertEquals(parsed.blocks.blocks[0].y, 80);
+  assertEquals(doc.text.includes('"x": 40'), true);
+  assertEquals(doc.widgets.some((w) => w.line.blockId === "el1"), true);
+});
+
+Deno.test("blocklyJsonDocument widget overlay keeps extraState and coordinates in the document", () => {
+  const state = {
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: "event",
+        id: "ev1",
+        x: 24,
+        y: 36,
+        fields: { RM_TYPE: "EVENT" },
+        extraState: { extras: [], attrs: ["time", "data"] },
+      }],
+    },
+  };
+  const doc = blocklyJsonDocument(state);
+  assertEquals(JSON.parse(doc.text).blocks.blocks[0].x, 24);
+  assertStringIncludes(doc.text, '"RM_TYPE": "EVENT"');
+  assertStringIncludes(doc.text, '"extraState"');
+  assertEquals(doc.widgets.length > 0, true);
 });

--- a/test/slot_cardinality_test.ts
+++ b/test/slot_cardinality_test.ts
@@ -1,0 +1,28 @@
+import { assertEquals } from "@std/assert";
+import {
+  formatSlotCardinality,
+  isCardinalityMet,
+  parseSlotCardinality,
+} from "@intehrgrator/blockly/slot_cardinality.ts";
+
+Deno.test("formatSlotCardinality always uses [min..max] including [1..1]", () => {
+  assertEquals(formatSlotCardinality({ min: 1, max: 1 }), "[1..1]");
+  assertEquals(formatSlotCardinality({ min: 0, max: 1 }), "[0..1]");
+  assertEquals(formatSlotCardinality({ min: 0, max: null }), "[0..*]");
+  assertEquals(formatSlotCardinality({ min: 1, max: null }), "[1..*]");
+  assertEquals(formatSlotCardinality({ min: 1, max: 3 }), "[1..3]");
+});
+
+Deno.test("parseSlotCardinality accepts compact and bracket forms", () => {
+  assertEquals(parseSlotCardinality("1"), { min: 1, max: 1 });
+  assertEquals(parseSlotCardinality("[1..1]"), { min: 1, max: 1 });
+  assertEquals(parseSlotCardinality("0..*"), { min: 0, max: null });
+  assertEquals(parseSlotCardinality("[1..*]"), { min: 1, max: null });
+});
+
+Deno.test("isCardinalityMet enforces min and optional max", () => {
+  assertEquals(isCardinalityMet(0, { min: 0, max: null }), true);
+  assertEquals(isCardinalityMet(0, { min: 1, max: null }), false);
+  assertEquals(isCardinalityMet(1, { min: 1, max: 1 }), true);
+  assertEquals(isCardinalityMet(2, { min: 1, max: 1 }), false);
+});

--- a/test/ui/mapping_spec_json_test.ts
+++ b/test/ui/mapping_spec_json_test.ts
@@ -1,0 +1,89 @@
+/**
+ * Mapping Spec pane stores full Blockly workspace JSON in CodeMirror
+ * and Download saves that same JSON (including x/y).
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { chromium } from "npm:playwright@1.51.0";
+import {
+  baseUrl,
+  loadBpFixtures,
+  waitForTestApi,
+} from "./helpers.ts";
+import type { IntehrgratorTestApi } from "../../src/ui_test/test_api.ts";
+
+Deno.test({
+  name: "UI: Mapping Spec document and Download are full Blockly JSON",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      await page.goto(`${baseUrl}/?testMode=1`, { waitUntil: "networkidle" });
+      await waitForTestApi(page);
+      await loadBpFixtures(page);
+      await page.waitForTimeout(500);
+
+      const downloadBtn = page.locator("#btn-download-spec");
+      const uploadBtn = page.locator("#btn-upload-spec");
+      await downloadBtn.waitFor({ timeout: 10_000 });
+      assertEquals(await downloadBtn.isVisible(), true);
+      assertEquals(await uploadBtn.isVisible(), true);
+      assertEquals(await downloadBtn.textContent().then((t) => t?.includes("Download")), true);
+      assertEquals(await uploadBtn.textContent().then((t) => t?.includes("Upload")), true);
+
+      const doc = await page.evaluate(() => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        return api.getMappingSpecDocument();
+      });
+      const parsed = JSON.parse(doc) as {
+        blocks?: { blocks?: Array<{ type?: string; x?: number; y?: number; fields?: Record<string, unknown> }> };
+      };
+      const roots = parsed.blocks?.blocks ?? [];
+      assert(roots.length > 0, "expected Blockly root blocks in Mapping Spec document");
+      assert(typeof roots[0]?.x === "number", "document must keep block x");
+      assert(typeof roots[0]?.y === "number", "document must keep block y");
+      assertStringIncludes(doc, '"type":');
+
+      const [download] = await Promise.all([
+        page.waitForEvent("download", { timeout: 10_000 }),
+        downloadBtn.click(),
+      ]);
+      const filename = download.suggestedFilename();
+      assert(filename.endsWith(".blockly.json"), filename);
+      const downloadPath = await download.path();
+      assert(downloadPath, "expected downloaded file path");
+      const downloaded = await Deno.readTextFile(downloadPath);
+      const downloadedJson = JSON.parse(downloaded) as typeof parsed;
+      assertEquals(
+        downloadedJson.blocks?.blocks?.[0]?.type,
+        parsed.blocks?.blocks?.[0]?.type,
+      );
+      assertEquals(downloadedJson.blocks?.blocks?.[0]?.x, parsed.blocks?.blocks?.[0]?.x);
+
+      const tweaked = JSON.parse(downloaded) as {
+        blocks: { languageVersion?: number; blocks: Array<Record<string, unknown>> };
+      };
+      tweaked.blocks.blocks[0]!.id = "uploaded-root";
+      tweaked.blocks.blocks[0]!.x = 99;
+      await page.evaluate((text) => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        api.loadBlocklyJson("roundtrip.blockly.json", text);
+      }, JSON.stringify(tweaked));
+      await page.waitForTimeout(400);
+
+      const after = await page.evaluate(() => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        return api.getMappingSpecDocument();
+      });
+      assertStringIncludes(after, '"id": "uploaded-root"');
+      assertStringIncludes(after, '"x": 99');
+    } finally {
+      await browser.close();
+    }
+  },
+});

--- a/web/index.html
+++ b/web/index.html
@@ -169,12 +169,23 @@
               id="btn-download-spec"
               class="pane-btn pane-btn-icon mapping-spec-download"
               type="button"
-              title="Download mapping specification"
+              title="Download the full Blockly workspace JSON"
             >
               <svg focusable="false" aria-hidden="true" viewBox="0 0 24 24">
                 <path d="M18 15v3H6v-3H4v3c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2v-3zm-1-4-1.41-1.41L13 12.17V4h-2v8.17L8.41 9.59 7 11l5 5z"></path>
               </svg>
               Download
+            </button>
+            <button
+              id="btn-upload-spec"
+              class="pane-btn pane-btn-icon mapping-spec-upload"
+              type="button"
+              title="Upload a Blockly workspace JSON file"
+            >
+              <svg focusable="false" aria-hidden="true" viewBox="0 0 24 24">
+                <path d="M6 18h12v-3h2v3c0 1.1-.9 2-2 2H6c-1.1 0-2-.9-2-2v-3h2v3zM7 9l1.41 1.41L11 7.83V16h2V7.83l2.59 2.58L17 9l-5-5z"></path>
+              </svg>
+              Upload
             </button>
           </div>
           <div id="handlebars-insert-toolbar" class="handlebars-insert-toolbar" hidden>

--- a/web/main.ts
+++ b/web/main.ts
@@ -38,10 +38,13 @@ import {
   workspaceToModelJson,
   placeSourceQueryBlock,
   sourceReturnTypeFromSchemaType,
+  applyEventRmType,
+  isEventFamilyType,
   workspacePositionFromClient,
   registerCompactThrasosRenderer,
   openWorkspaceSnapshotWindow,
 } from "../src/blockly/mod.ts";
+import { refreshWorkspaceConstraints } from "../src/blockly/block_constraints.ts";
 import {
   presentAttributeNames,
   rmTypeOfBlock,
@@ -102,6 +105,7 @@ const exportTargetSelect = document.getElementById("export-target") as HTMLSelec
 const mappingJsonTab = document.getElementById("tab-mapping-json") as HTMLButtonElement;
 const handlebarsTab = document.getElementById("tab-handlebars") as HTMLButtonElement;
 const downloadSpecBtn = document.getElementById("btn-download-spec") as HTMLButtonElement;
+const uploadSpecBtn = document.getElementById("btn-upload-spec") as HTMLButtonElement;
 const mappingJsonHost = document.getElementById("spec-editor")!;
 const handlebarsHost = document.getElementById("handlebars-editor")!;
 
@@ -157,11 +161,13 @@ function showTextView(view: "mapping-json" | "handlebars"): void {
   handlebarsTab.classList.toggle("active", showHandlebars);
   if (handlebarsInsertToolbar) handlebarsInsertToolbar.hidden = !showHandlebars;
   downloadSpecBtn.hidden = showHandlebars;
+  if (uploadSpecBtn) uploadSpecBtn.hidden = showHandlebars;
 }
 
 mappingJsonTab.addEventListener("click", () => showTextView("mapping-json"));
 handlebarsTab.addEventListener("click", () => showTextView("handlebars"));
-downloadSpecBtn.addEventListener("click", () => controller.exportMappingSpec());
+downloadSpecBtn.addEventListener("click", () => controller.exportBlocklyDefinition());
+uploadSpecBtn?.addEventListener("click", () => void controller.importBlocklyDefinition());
 exportTargetSelect.addEventListener("change", () => {
   const target = exportTargetSelect.value as
     | "typescript"
@@ -269,6 +275,22 @@ async function bootBlockly(): Promise<void> {
       if (slotId) controller.armSlot(slotId);
       return;
     }
+    if (
+      event.type === Blockly.Events.BLOCK_CHANGE &&
+      "name" in event &&
+      event.name === "RM_TYPE" &&
+      "blockId" in event &&
+      typeof event.blockId === "string"
+    ) {
+      const block = workspace.getBlockById(event.blockId);
+      const next = String((event as { newValue?: unknown }).newValue ?? "");
+      if (block && (isEventFamilyType(next) || next === "EVENT")) {
+        applyEventRmType(block, next);
+      }
+    }
+    if (event.type !== Blockly.Events.FINISHED_LOADING && !event.isUiEvent) {
+      refreshWorkspaceConstraints(workspace);
+    }
     if (event.type === Blockly.Events.FINISHED_LOADING || event.isUiEvent) return;
     const derived = workspaceToModelJson(workspace);
     controller.syncFromBlockly(
@@ -356,13 +378,20 @@ function syncToolbox(s: ReturnType<WorkbenchController["getState"]>): void {
 function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): void {
   if (!workspace) return;
   syncToolbox(s);
-  if (!s.templateId || !s.skeleton.length) {
+  if (!s.templateId && !s.blocklyState) {
     blocklySkeletonKey = "";
     blocklySlotSignature = "";
     return;
   }
+  if (!s.templateId || !s.skeleton.length) {
+    if (!(s.blocklyState && typeof s.blocklyState === "object" && s.blocklyReloadToken)) {
+      blocklySkeletonKey = "";
+      blocklySlotSignature = "";
+      return;
+    }
+  }
 
-  const skeletonKey = `${s.projectId}|${s.templateId}|${s.skeleton.length}`;
+  const skeletonKey = `${s.projectId}|${s.templateId}|${s.skeleton.length}|${s.blocklyReloadToken}`;
   const slotSignature = [
     ...s.model.slots.map((slot) => `${slot.slotId}=${slot.expression}`),
     ...(s.model.loops ?? []).map((loop) =>
@@ -377,10 +406,22 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
         workspace.clear();
         Blockly.serialization.workspaces.load(s.blocklyState, workspace);
         applyModelLoops(workspace, s.model);
+        refreshWorkspaceConstraints(workspace);
       } finally {
         Blockly.Events.enable();
       }
       lockWorkspaceRootsExpanded(workspace);
+      blocklySkeletonKey = skeletonKey;
+      blocklySlotSignature = slotSignature;
+      const derived = workspaceToModelJson(workspace);
+      if (s.blocklyReloadToken > 0) {
+        controller.syncFromBlockly(
+          Blockly.serialization.workspaces.save(workspace),
+          derived.slots,
+          derived.loops,
+        );
+      }
+      return;
     } else {
       loadSkeletonIntoWorkspace(workspace, s.skeleton, s.model, s.listeningSlotId);
     }

--- a/web/main.ts
+++ b/web/main.ts
@@ -20,6 +20,7 @@ import {
 } from "../src/workbench/codemirror_setup.ts";
 import {
   createMappingSpecEditor,
+  mappingSpecDocumentText,
   setMappingSpecFromBlockly,
 } from "../src/workbench/mapping_spec/mod.ts";
 import {
@@ -1160,6 +1161,12 @@ function installWorkbenchTestApi(): void {
     findSlotIdBySuffix(suffix) {
       const slots = collectValueSlots(controller.getState().skeleton);
       return slots.find((slot) => slot.slotId.endsWith(suffix))?.slotId ?? null;
+    },
+    getMappingSpecDocument() {
+      return mappingSpecDocumentText(specEditor);
+    },
+    loadBlocklyJson(filename, content) {
+      controller.loadBlocklyDefinition(filename, content);
     },
   };
   // Some test helpers look for `globalThis.intehrgratorTestApi` rather than

--- a/web/styles.css
+++ b/web/styles.css
@@ -282,7 +282,9 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
 .mapping-bottom { min-height: 0; display: flex; flex-direction: column; padding: 8px; }
 .mapping-editor-tabs { display: flex; align-items: center; gap: 4px; margin-bottom: 6px; }
 .mapping-editor-tab-group { display: flex; gap: 4px; }
-.mapping-spec-download { margin-left: auto; font-size: 11px; padding: 3px 8px; }
+.mapping-spec-download,
+.mapping-spec-upload { margin-left: 4px; font-size: 11px; padding: 3px 8px; }
+.mapping-spec-download { margin-left: auto; }
 .mapping-editor-tab {
   border: 1px solid var(--border); border-radius: 4px; background: #fff;
   color: var(--text-secondary); padding: 3px 7px; font-size: 11px; cursor: pointer;
@@ -382,6 +384,24 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
 .blockly-mount .blocklyText.blockly-at-code {
   font-size: 10px !important;
   opacity: 0.8;
+}
+
+.blockly-mount .blocklyText.blockly-slot-card {
+  font-size: 11px !important;
+  font-variant-numeric: tabular-nums;
+  font-weight: 400 !important;
+}
+.blockly-mount .blocklyText.blockly-slot-card--unmet {
+  font-weight: 700 !important;
+}
+
+.blockly-icon-warning .blocklyIconShape {
+  fill: #F9A825 !important;
+  stroke: #E65100 !important;
+  stroke-width: 1.25px !important;
+}
+.blockly-icon-warning .blocklyIconSymbol {
+  fill: #3E2723 !important;
 }
 
 /* ZipEHR RM-type glyphs on output tabs and slots (~50% larger than 12px body).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Mapping Spec pane now downloads and uploads the **canonical Blockly workspace JSON** (including block coordinates and extraState), not a simplified projection. The CodeMirror document is that same JSON; visual widgets overlay `"type"` lines and hide layout chrome without changing the stored text.

Related canvas fixes in this branch:

- Warning triangles fire only for **unmet constraints** (unmapped mandatory values, abstract EVENT, empty required slots), not because a container is template-mandatory. Icons are yellow/orange.
- Slots show `[min..max]` cardinality immediately left of the ZipEHR emoji, bold when unmet.
- EVENT-family blocks switch among EVENT / POINT_EVENT / INTERVAL_EVENT without dropping attached children. Extra INTERVAL fields (`width`, `math_function`, `sample_count`) appear when needed. Abstract EVENT still shows a warning.

## Technical notes

- `EVENT.data` is BMM type parameter `T` with `conforms_to_type` `ITEM_STRUCTURE` (`openehr://spec/type/RM/EVENT`). Connection checks now use that bound so ITEM_TREE reconnects after a subtype switch.
- ELEMENT wrappers are often `mandatory: false` while their primary DATA_VALUE is mandatory; the unmapped-value warning uses the value child's flag.
- Dynamic `ATTR_*` sockets (template-present RM attributes, INTERVAL extras) are persisted in Blockly `extraState` so Upload can reproduce the full mapping.
- CodeMirror replace decorations that span JSON newlines are provided by a `StateField` (ViewPlugin replacements cannot cover line breaks).
- Upload uses the existing file picker (`kind: "mapping"`) and reloads the canvas via `blocklyReloadToken`.

## Tests

- `test/blockly_rm_blocks_test.ts` — mandatory ELEMENT warning, EVENT.data ITEM_STRUCTURE check, subtype switch keeps children, extraState round-trip
- `test/mapping_spec_project_test.ts` / `test/examples_bulk_test.ts` — JSON document keeps x/y; download/upload round-trip
- `test/slot_cardinality_test.ts` — `[min..max]` formatting
- `test/ui/mapping_spec_json_test.ts` — Mapping Spec CodeMirror document is full Blockly JSON; Download filename ends with `.blockly.json`; reload keeps coordinates

Full `deno task test` still reports 10 pre-existing failures from missing `test/fixtures/legacy-simulated/*` files (fixture rearrange on `main`); they are unrelated to this change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-90066163-5a09-4716-9561-cc4e5dc46dc1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-90066163-5a09-4716-9561-cc4e5dc46dc1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

