### PR TITLE
De-uglify map blocks with field keys and right-edge values

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,6 +16,7 @@
 
 ## Add support for map structures
 - [x] Model blockly support for maps in the style of the blockly list blocks, check for already available implementations based on blockly, - i know such exist. Key/value pairs share a row (Blockly 11 `appendEndRowInput`), so the Defaults Map nested constructor stays compact.
+- [x] De-uglify the maps implementation to look more like App Inventor / BlockPy: keys in a column of text fields, values as right-edge connectors that take ordinary Blockly blocks (`text`, `math_number`, source queries, nested maps). Layout follows App Inventor `dictionaries_create_with` (stacked, not inline, `Align.RIGHT`) plus Blockly JSON-object members (`FieldTextInput` + `:` + value socket). Legacy `KEY{n}` input JSON is migrated on load.
 - [ ] Make it possible to digest CSV tables for setting up mappings, preferably multi column to get both label and code for terminology bound texts - that could mean that the resulting map target is a DV_CODED_TEXT
 - [ ] Make it possible to digest FHIR terminology mappings for setting up mappings
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -15,7 +15,7 @@
 - [ ] Synk highlight mellan mappning och conversion test run (ev conversion script)
 
 ## Add support for map structures
-- [x] Model blockly support for maps in the style of the blockly list blocks, check for already available implementations based on blockly, - i know such exist.
+- [x] Model blockly support for maps in the style of the blockly list blocks, check for already available implementations based on blockly, - i know such exist. Key/value pairs share a row (Blockly 11 `appendEndRowInput`), so the Defaults Map nested constructor stays compact.
 - [ ] Make it possible to digest CSV tables for setting up mappings, preferably multi column to get both label and code for terminology bound texts - that could mean that the resulting map target is a DV_CODED_TEXT
 - [ ] Make it possible to digest FHIR terminology mappings for setting up mappings
 

--- a/examples/dummy-json-vitals/defaults.map.json
+++ b/examples/dummy-json-vitals/defaults.map.json
@@ -1,16 +1,18 @@
 {
   "type": "maps_create_with",
   "extraState": { "itemCount": 5 },
+  "fields": {
+    "KEY0": "language",
+    "KEY1": "territory",
+    "KEY2": "time",
+    "KEY3": "composer_name",
+    "KEY4": "health_care_facility"
+  },
   "inputs": {
-    "KEY0": { "shadow": { "type": "text", "fields": { "TEXT": "language" } } },
     "VAL0": { "shadow": { "type": "text", "fields": { "TEXT": "sv" } } },
-    "KEY1": { "shadow": { "type": "text", "fields": { "TEXT": "territory" } } },
     "VAL1": { "shadow": { "type": "text", "fields": { "TEXT": "SE" } } },
-    "KEY2": { "shadow": { "type": "text", "fields": { "TEXT": "time" } } },
     "VAL2": { "shadow": { "type": "text", "fields": { "TEXT": "" } } },
-    "KEY3": { "shadow": { "type": "text", "fields": { "TEXT": "composer_name" } } },
     "VAL3": { "shadow": { "type": "text", "fields": { "TEXT": "" } } },
-    "KEY4": { "shadow": { "type": "text", "fields": { "TEXT": "health_care_facility" } } },
     "VAL4": { "shadow": { "type": "text", "fields": { "TEXT": "St. Dummy Demo Hospital" } } }
   }
 }

--- a/src/blockly/blocks/map_blocks.ts
+++ b/src/blockly/blocks/map_blocks.ts
@@ -90,7 +90,11 @@ function updateMapCreateShape(block: MapCreateBlock): void {
         .setAlign(inputAlignRight())
         .appendField(keyField(""), `KEY${n}`)
         .appendField(":");
-      if (input.connection && typeof input.connection.setShadowState === "function") {
+      if (
+        input.connection &&
+        typeof input.connection.setShadowState === "function" &&
+        Blockly.Blocks["text"]
+      ) {
         input.connection.setShadowState({
           type: "text",
           fields: { TEXT: "" },

--- a/src/blockly/blocks/map_blocks.ts
+++ b/src/blockly/blocks/map_blocks.ts
@@ -8,19 +8,21 @@ import {
 
 const MAP_COLOUR = "#7E57C2";
 const DEFAULTS_COLOUR = "#5C6BC0";
+const DEFAULTS_TOOLTIP = [
+  "Conversion-time openEHR context values for Better/EHRbase simplified formats.",
+  "Standard keys: language, territory, time, composer_name, and health_care_facility.",
+  'Use manage to load or save a set; maps_get("defaults", key) retrieves a value.',
+].join(" ");
 
-const PLUS_SVG =
-  "data:image/svg+xml," +
+const PLUS_SVG = "data:image/svg+xml," +
   encodeURIComponent(
     '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="8" fill="#fff" stroke="#5f6368"/><path d="M9 5v8M5 9h8" stroke="#5f6368" stroke-width="1.6" fill="none"/></svg>',
   );
-const MINUS_SVG =
-  "data:image/svg+xml," +
+const MINUS_SVG = "data:image/svg+xml," +
   encodeURIComponent(
     '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="8" fill="#fff" stroke="#5f6368"/><path d="M5 9h8" stroke="#5f6368" stroke-width="1.6" fill="none"/></svg>',
   );
-const FOLDER_SVG =
-  "data:image/svg+xml," +
+const FOLDER_SVG = "data:image/svg+xml," +
   encodeURIComponent(
     '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18"><path d="M2 5h5l1 1.5H16v8.5H2z" fill="#fff" stroke="#5f6368"/><path d="M2 6.5h14" stroke="#5f6368"/></svg>',
   );
@@ -67,7 +69,10 @@ export function registerMapBlocks(): void {
     saveExtraState: function (this: MapCreateBlock) {
       return { itemCount: this.itemCount_ };
     },
-    loadExtraState: function (this: MapCreateBlock, state: { itemCount?: number }) {
+    loadExtraState: function (
+      this: MapCreateBlock,
+      state: { itemCount?: number },
+    ) {
       this.itemCount_ = Number(state?.itemCount ?? 0);
       this.updateShape_();
     },
@@ -153,19 +158,27 @@ export function registerMapBlocks(): void {
   Blockly.Blocks[DEFAULTS_BLOCK_TYPE] = {
     init: function (this: Blockly.Block) {
       this.appendDummyInput("HEADER")
-        .appendField("Defaults Map")
+        .appendField("openEHR CTX defaults", "TITLE")
         .appendField(
-          new Blockly.FieldImage(FOLDER_SVG, 18, 18, "Load/save", () => {
-            defaultsMapPickHandler?.();
-          }),
-        );
+          new Blockly.FieldImage(
+            FOLDER_SVG,
+            18,
+            18,
+            "Load or save CTX defaults",
+            () => {
+              defaultsMapPickHandler?.();
+            },
+          ),
+          "MANAGE_ICON",
+        )
+        .appendField("manage", "MANAGE_LABEL");
+      this.appendDummyInput("CONTEXT")
+        .appendField("Better / EHRbase conversion context");
       this.appendValueInput("MAP")
         .setCheck("Map")
-        .appendField("map");
+        .appendField("values");
       this.setColour(DEFAULTS_COLOUR);
-      this.setTooltip(
-        "Binds a Map as the named defaults table. Lookups use maps_get by name, not a wire.",
-      );
+      this.setTooltip(DEFAULTS_TOOLTIP);
       this.setDeletable(false);
       this.setMovable(true);
     },
@@ -185,7 +198,9 @@ export function createMapsGetBlock(
     if (existing) existing.dispose(false);
     const text = workspace.newBlock("text");
     text.setFieldValue(key, "TEXT");
-    if (text.outputConnection) keyInput.connection.connect(text.outputConnection);
+    if (text.outputConnection) {
+      keyInput.connection.connect(text.outputConnection);
+    }
   }
   return block;
 }

--- a/src/blockly/blocks/map_blocks.ts
+++ b/src/blockly/blocks/map_blocks.ts
@@ -38,28 +38,38 @@ function inputAlignRight(): number {
   return (Blockly.inputs?.Align?.RIGHT ?? Blockly.ALIGN_RIGHT ?? 1) as number;
 }
 
-function pairInputNames(index: number): [string, string, string] {
-  return [`KEY${index}`, `VAL${index}`, `ROW${index}`];
+function keyField(defaultText = ""): Blockly.FieldTextInput {
+  return new Blockly.FieldTextInput(defaultText, undefined, { spellcheck: false });
 }
 
-/** Keep HEADER, then each key:value pair, on their own rows (Blockly 11 EndRowInput). */
+function removePairInputs(block: MapCreateBlock, index: number): void {
+  block.removeInput(`VAL${index}`, true);
+  block.removeInput(`KEY${index}`, true);
+  block.removeInput(`ROW${index}`, true);
+}
+
+function hasPairInput(block: MapCreateBlock, index: number): boolean {
+  return !!(
+    block.getInput(`VAL${index}`) ||
+    block.getInput(`KEY${index}`) ||
+    block.getInput(`ROW${index}`)
+  );
+}
+
+/**
+ * App Inventor `dictionaries_create_with` stacks value sockets on the right
+ * (`setInputsInline` left false, `Align.RIGHT`). Blockly JSON-object members
+ * put the key in a `FieldTextInput` on that same row, with `:` before the
+ * value connector. Keys stay editable fields in a column; values are ordinary
+ * blocks (`text`, `math_number`, source queries, nested maps, …).
+ */
 function updateMapCreateShape(block: MapCreateBlock): void {
-  if (
-    !block.getInput("HEADER_END") &&
-    typeof block.appendEndRowInput === "function"
-  ) {
-    block.appendEndRowInput("HEADER_END");
-  }
+  if (block.getInput("HEADER_END")) block.removeInput("HEADER_END", true);
 
   if (block.itemCount_ === 0) {
     let i = 0;
-    while (
-      block.getInput(`KEY${i}`) || block.getInput(`VAL${i}`) ||
-      block.getInput(`ROW${i}`)
-    ) {
-      block.removeInput(`KEY${i}`, true);
-      block.removeInput(`VAL${i}`, true);
-      block.removeInput(`ROW${i}`, true);
+    while (hasPairInput(block, i)) {
+      removePairInputs(block, i);
       i++;
     }
     if (!block.getInput("EMPTY")) {
@@ -68,39 +78,29 @@ function updateMapCreateShape(block: MapCreateBlock): void {
   } else {
     if (block.getInput("EMPTY")) block.removeInput("EMPTY");
     let i = block.itemCount_;
-    while (
-      block.getInput(`KEY${i}`) || block.getInput(`VAL${i}`) ||
-      block.getInput(`ROW${i}`)
-    ) {
-      block.removeInput(`KEY${i}`, true);
-      block.removeInput(`VAL${i}`, true);
-      block.removeInput(`ROW${i}`, true);
+    while (hasPairInput(block, i)) {
+      removePairInputs(block, i);
       i++;
     }
     for (let n = 0; n < block.itemCount_; n++) {
-      const [keyName, valName, rowName] = pairInputNames(n);
-      if (!block.getInput(keyName)) {
-        block.appendValueInput(keyName)
-          .setCheck("String")
-          .setAlign(inputAlignRight())
-          .appendField("key");
-      }
-      if (!block.getInput(valName)) {
-        block.appendValueInput(valName).appendField(":");
-      }
-      if (
-        !block.getInput(rowName) &&
-        typeof block.appendEndRowInput === "function"
-      ) {
-        block.appendEndRowInput(rowName);
+      if (block.getInput(`KEY${n}`)) block.removeInput(`KEY${n}`, true);
+      if (block.getInput(`ROW${n}`)) block.removeInput(`ROW${n}`, true);
+      if (block.getInput(`VAL${n}`)) continue;
+      const input = block.appendValueInput(`VAL${n}`)
+        .setAlign(inputAlignRight())
+        .appendField(keyField(""), `KEY${n}`)
+        .appendField(":");
+      if (input.connection && typeof input.connection.setShadowState === "function") {
+        input.connection.setShadowState({
+          type: "text",
+          fields: { TEXT: "" },
+        });
       }
     }
   }
 
-  const order = ["HEADER", "HEADER_END"];
-  for (let n = 0; n < block.itemCount_; n++) {
-    order.push(...pairInputNames(n));
-  }
+  const order = ["HEADER"];
+  for (let n = 0; n < block.itemCount_; n++) order.push(`VAL${n}`);
   if (block.getInput("EMPTY")) order.push("EMPTY");
   for (const name of order) {
     if (block.getInput(name)) block.moveInputBefore(name, null);
@@ -108,8 +108,6 @@ function updateMapCreateShape(block: MapCreateBlock): void {
 }
 
 export function registerMapBlocks(): void {
-  if (Blockly.Blocks[MAPS_CREATE_WITH]) return;
-
   Blockly.Blocks[MAPS_CREATE_WITH] = {
     init: function (this: MapCreateBlock) {
       this.itemCount_ = 2;
@@ -131,7 +129,7 @@ export function registerMapBlocks(): void {
       this.setOutput(true, "Map");
       this.setColour(MAP_COLOUR);
       this.setTooltip("Create a Map of key/value pairs");
-      this.setInputsInline(true);
+      this.setInputsInline(false);
       this.updateShape_();
     },
     saveExtraState: function (this: MapCreateBlock) {
@@ -148,6 +146,8 @@ export function registerMapBlocks(): void {
       updateMapCreateShape(this);
     },
   };
+
+  if (Blockly.Blocks[MAPS_GET]) return;
 
   Blockly.Blocks["maps_create_empty"] = {
     init: function (this: Blockly.Block) {

--- a/src/blockly/blocks/map_blocks.ts
+++ b/src/blockly/blocks/map_blocks.ts
@@ -8,11 +8,6 @@ import {
 
 const MAP_COLOUR = "#7E57C2";
 const DEFAULTS_COLOUR = "#5C6BC0";
-const DEFAULTS_TOOLTIP = [
-  "Conversion-time openEHR context values for Better/EHRbase simplified formats.",
-  "Standard keys: language, territory, time, composer_name, and health_care_facility.",
-  'Use manage to load or save a set; maps_get("defaults", key) retrieves a value.',
-].join(" ");
 
 const PLUS_SVG = "data:image/svg+xml," +
   encodeURIComponent(
@@ -39,6 +34,79 @@ type MapCreateBlock = Blockly.Block & {
   updateShape_: () => void;
 };
 
+function inputAlignRight(): number {
+  return (Blockly.inputs?.Align?.RIGHT ?? Blockly.ALIGN_RIGHT ?? 1) as number;
+}
+
+function pairInputNames(index: number): [string, string, string] {
+  return [`KEY${index}`, `VAL${index}`, `ROW${index}`];
+}
+
+/** Keep HEADER, then each key:value pair, on their own rows (Blockly 11 EndRowInput). */
+function updateMapCreateShape(block: MapCreateBlock): void {
+  if (
+    !block.getInput("HEADER_END") &&
+    typeof block.appendEndRowInput === "function"
+  ) {
+    block.appendEndRowInput("HEADER_END");
+  }
+
+  if (block.itemCount_ === 0) {
+    let i = 0;
+    while (
+      block.getInput(`KEY${i}`) || block.getInput(`VAL${i}`) ||
+      block.getInput(`ROW${i}`)
+    ) {
+      block.removeInput(`KEY${i}`, true);
+      block.removeInput(`VAL${i}`, true);
+      block.removeInput(`ROW${i}`, true);
+      i++;
+    }
+    if (!block.getInput("EMPTY")) {
+      block.appendDummyInput("EMPTY").appendField("empty");
+    }
+  } else {
+    if (block.getInput("EMPTY")) block.removeInput("EMPTY");
+    let i = block.itemCount_;
+    while (
+      block.getInput(`KEY${i}`) || block.getInput(`VAL${i}`) ||
+      block.getInput(`ROW${i}`)
+    ) {
+      block.removeInput(`KEY${i}`, true);
+      block.removeInput(`VAL${i}`, true);
+      block.removeInput(`ROW${i}`, true);
+      i++;
+    }
+    for (let n = 0; n < block.itemCount_; n++) {
+      const [keyName, valName, rowName] = pairInputNames(n);
+      if (!block.getInput(keyName)) {
+        block.appendValueInput(keyName)
+          .setCheck("String")
+          .setAlign(inputAlignRight())
+          .appendField("key");
+      }
+      if (!block.getInput(valName)) {
+        block.appendValueInput(valName).appendField(":");
+      }
+      if (
+        !block.getInput(rowName) &&
+        typeof block.appendEndRowInput === "function"
+      ) {
+        block.appendEndRowInput(rowName);
+      }
+    }
+  }
+
+  const order = ["HEADER", "HEADER_END"];
+  for (let n = 0; n < block.itemCount_; n++) {
+    order.push(...pairInputNames(n));
+  }
+  if (block.getInput("EMPTY")) order.push("EMPTY");
+  for (const name of order) {
+    if (block.getInput(name)) block.moveInputBefore(name, null);
+  }
+}
+
 export function registerMapBlocks(): void {
   if (Blockly.Blocks[MAPS_CREATE_WITH]) return;
 
@@ -63,7 +131,7 @@ export function registerMapBlocks(): void {
       this.setOutput(true, "Map");
       this.setColour(MAP_COLOUR);
       this.setTooltip("Create a Map of key/value pairs");
-      this.setInputsInline(false);
+      this.setInputsInline(true);
       this.updateShape_();
     },
     saveExtraState: function (this: MapCreateBlock) {
@@ -77,24 +145,7 @@ export function registerMapBlocks(): void {
       this.updateShape_();
     },
     updateShape_: function (this: MapCreateBlock) {
-      let i = 0;
-      while (this.getInput(`KEY${i}`) || this.getInput(`VAL${i}`)) {
-        if (i >= this.itemCount_) {
-          this.removeInput(`KEY${i}`, true);
-          this.removeInput(`VAL${i}`, true);
-        }
-        i++;
-      }
-      for (let n = 0; n < this.itemCount_; n++) {
-        if (!this.getInput(`KEY${n}`)) {
-          this.appendValueInput(`KEY${n}`)
-            .setCheck("String")
-            .appendField("key");
-        }
-        if (!this.getInput(`VAL${n}`)) {
-          this.appendValueInput(`VAL${n}`).appendField("value");
-        }
-      }
+      updateMapCreateShape(this);
     },
   };
 
@@ -158,27 +209,19 @@ export function registerMapBlocks(): void {
   Blockly.Blocks[DEFAULTS_BLOCK_TYPE] = {
     init: function (this: Blockly.Block) {
       this.appendDummyInput("HEADER")
-        .appendField("openEHR CTX defaults", "TITLE")
+        .appendField("Defaults Map")
         .appendField(
-          new Blockly.FieldImage(
-            FOLDER_SVG,
-            18,
-            18,
-            "Load or save CTX defaults",
-            () => {
-              defaultsMapPickHandler?.();
-            },
-          ),
-          "MANAGE_ICON",
-        )
-        .appendField("manage", "MANAGE_LABEL");
-      this.appendDummyInput("CONTEXT")
-        .appendField("Better / EHRbase conversion context");
+          new Blockly.FieldImage(FOLDER_SVG, 18, 18, "Load/save", () => {
+            defaultsMapPickHandler?.();
+          }),
+        );
       this.appendValueInput("MAP")
         .setCheck("Map")
-        .appendField("values");
+        .appendField("map");
       this.setColour(DEFAULTS_COLOUR);
-      this.setTooltip(DEFAULTS_TOOLTIP);
+      this.setTooltip(
+        "Binds a Map as the named defaults table. Lookups use maps_get by name, not a wire.",
+      );
       this.setDeletable(false);
       this.setMovable(true);
     },

--- a/src/blockly/defaults_canvas.ts
+++ b/src/blockly/defaults_canvas.ts
@@ -8,6 +8,7 @@ import {
   factoryDefaultsEntries,
   MAPS_CREATE_WITH,
   mapsGetExpression,
+  migrateMapsCreateWithJson,
 } from "../core/defaults/mod.ts";
 import { createMapsGetBlock, registerMapBlocks } from "./blocks/map_blocks.ts";
 import {
@@ -72,7 +73,7 @@ export function createFactoryMapBlock(
   map.itemCount_ = entries.length;
   map.updateShape_();
   for (let i = 0; i < entries.length; i++) {
-    connectText(workspace, map, `KEY${i}`, entries[i]!.key);
+    map.setFieldValue(entries[i]!.key, `KEY${i}`);
     connectText(workspace, map, `VAL${i}`, entries[i]!.value);
   }
   return finalize(map);
@@ -133,6 +134,7 @@ export function restoreDefaultsBlockState(
 ): void {
   if (state && typeof Blockly.serialization?.blocks?.append === "function") {
     try {
+      migrateMapsCreateWithJson(state);
       Blockly.serialization.blocks.append(state, workspace);
       const block = findDefaultsBlock(workspace);
       block?.setDeletable(false);
@@ -300,6 +302,7 @@ export function hydrateDefaultsMapArgument(
     input?.connection?.connect(map.outputConnection!);
     return;
   }
+  migrateMapsCreateWithJson(mapBlockState);
   const appended = Blockly.serialization.blocks.append(
     mapBlockState as Record<string, unknown>,
     workspace,

--- a/src/blockly/toolbox_demo.ts
+++ b/src/blockly/toolbox_demo.ts
@@ -34,6 +34,22 @@ function termPickShadow(setId: string, code?: string) {
   return { shadow: { type: "term_pick", fields } };
 }
 
+function mapsCreateWithToolboxBlock(itemCount: number): Record<string, unknown> {
+  const fields: Record<string, string> = {};
+  const inputs: Record<string, unknown> = {};
+  for (let i = 0; i < itemCount; i++) {
+    fields[`KEY${i}`] = "";
+    inputs[`VAL${i}`] = { shadow: { type: "text", fields: { TEXT: "" } } };
+  }
+  return {
+    kind: "block",
+    type: "maps_create_with",
+    extraState: { itemCount },
+    fields,
+    inputs,
+  };
+}
+
 function compositionToolboxBlock(): Record<string, unknown> {
   return {
     kind: "block",
@@ -382,7 +398,7 @@ export function buildDemoToolbox(locale: string, context: ToolboxContext = {}): 
         cssconfig: { row: "blocklyToolboxCategory blocklyToolboxCategoryMaps" },
         contents: [
           { kind: "block", type: "maps_create_with", extraState: { itemCount: 0 } },
-          { kind: "block", type: "maps_create_with", extraState: { itemCount: 3 } },
+          mapsCreateWithToolboxBlock(3),
           { kind: "block", type: "maps_create_empty" },
           {
             kind: "block",

--- a/src/core/defaults/extract.ts
+++ b/src/core/defaults/extract.ts
@@ -50,6 +50,7 @@ export function mapsGetExpression(mapName: string, key: string): string {
  */
 export function mapBlockFromDefaultsJson(parsed: unknown): unknown | null {
   if (!parsed || typeof parsed !== "object") return null;
+  migrateMapsCreateWithJson(parsed);
   const rec = parsed as BlocklyBlockJson & BlocklyWorkspaceJson;
   if (rec.type === MAPS_CREATE_WITH) return parsed;
   if (rec.type === DEFAULTS_BLOCK_TYPE) {
@@ -64,6 +65,56 @@ export function mapBlockFromDefaultsJson(parsed: unknown): unknown | null {
   return map ?? null;
 }
 
+/**
+ * Rewrite legacy `maps_create_with` JSON that stored keys as `KEY{n}` value
+ * inputs (nested `text` blocks) into `fields.KEY{n}` plus `VAL{n}` sockets.
+ * Safe to call on full workspace JSON, a Defaults block, or a map block.
+ */
+export function migrateMapsCreateWithJson<T>(state: T): T {
+  walkMigrate(state);
+  return state;
+}
+
+function walkMigrate(node: unknown): void {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const item of node) walkMigrate(item);
+    return;
+  }
+  const rec = node as BlocklyBlockJson & BlocklyWorkspaceJson & {
+    block?: unknown;
+    shadow?: unknown;
+  };
+  if (rec.type === MAPS_CREATE_WITH) migrateOneMapCreateWith(rec);
+  if (rec.inputs) walkMigrate(rec.inputs);
+  if (rec.next) walkMigrate(rec.next);
+  if (rec.blocks) walkMigrate(rec.blocks);
+  if (rec.block) walkMigrate(rec.block);
+  if (rec.shadow) walkMigrate(rec.shadow);
+}
+
+function migrateOneMapCreateWith(block: BlocklyBlockJson): void {
+  const inputs = block.inputs;
+  if (!inputs) return;
+  const fields = block.fields ?? (block.fields = {});
+  for (const name of Object.keys(inputs)) {
+    if (/^ROW\d+$/.test(name) || name === "HEADER_END") {
+      delete inputs[name];
+      continue;
+    }
+    const match = /^KEY(\d+)$/.exec(name);
+    if (!match) continue;
+    const fieldName = `KEY${match[1]}`;
+    if (fields[fieldName] == null || fields[fieldName] === "") {
+      const lit = literalFromInput(inputs[name]);
+      if (typeof lit === "string" || typeof lit === "number" || typeof lit === "boolean") {
+        fields[fieldName] = String(lit);
+      }
+    }
+    delete inputs[name];
+  }
+}
+
 function topBlocks(state: unknown): BlocklyBlockJson[] {
   if (!state || typeof state !== "object") return [];
   const blocks = (state as BlocklyWorkspaceJson).blocks?.blocks;
@@ -73,17 +124,32 @@ function topBlocks(state: unknown): BlocklyBlockJson[] {
 function mapFromCreateWith(block: BlocklyBlockJson | undefined): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   if (!block || block.type !== MAPS_CREATE_WITH) return out;
+  const fieldKeys = Object.keys(block.fields ?? {}).filter((name) => /^KEY\d+$/.test(name));
+  const valKeys = Object.keys(block.inputs ?? {}).filter((name) => /^VAL\d+$/.test(name));
   const inputKeys = Object.keys(block.inputs ?? {}).filter((name) => /^KEY\d+$/.test(name));
+  const fromNames = (names: string[]) =>
+    names.length ? Math.max(...names.map((name) => Number(name.slice(3)))) + 1 : 0;
   const count = Math.max(
     Number(block.extraState?.itemCount ?? 0),
-    inputKeys.length ? Math.max(...inputKeys.map((name) => Number(name.slice(3)))) + 1 : 0,
+    fromNames(fieldKeys),
+    fromNames(valKeys),
+    fromNames(inputKeys),
   );
   for (let i = 0; i < count; i++) {
-    const key = literalFromInput(block.inputs?.[`KEY${i}`]);
+    const key = keyFromPair(block, i);
     if (typeof key !== "string" || !key) continue;
     out[key] = literalFromInput(block.inputs?.[`VAL${i}`]) ?? "";
   }
   return out;
+}
+
+function keyFromPair(block: BlocklyBlockJson, index: number): unknown {
+  const fromField = block.fields?.[`KEY${index}`];
+  if (typeof fromField === "string" && fromField) return fromField;
+  if (typeof fromField === "number" || typeof fromField === "boolean") {
+    return String(fromField);
+  }
+  return literalFromInput(block.inputs?.[`KEY${index}`]);
 }
 
 function literalFromInput(

--- a/src/core/defaults/mod.ts
+++ b/src/core/defaults/mod.ts
@@ -17,6 +17,7 @@ export {
   MAPS_GET,
   mapBlockFromDefaultsJson,
   mapsGetExpression,
+  migrateMapsCreateWithJson,
   namedMapsFromBlocklyState,
   type NamedMaps,
 } from "./extract.ts";

--- a/test/defaults_test.ts
+++ b/test/defaults_test.ts
@@ -9,6 +9,7 @@ import {
   factoryDefaultsEntries,
   mapBlockFromDefaultsJson,
   mapsGetExpression,
+  migrateMapsCreateWithJson,
   namedMapsFromBlocklyState,
 } from "@intehrgrator/core/defaults/mod.ts";
 import { evaluate, createSourceContext } from "@intehrgrator/core/source/query_runtime.ts";
@@ -23,6 +24,7 @@ import { loadSkeletonIntoWorkspace } from "@intehrgrator/blockly/skeleton_loader
 import {
   ensureDefaultsBlock,
   findDefaultsBlock,
+  hydrateDefaultsMapArgument,
 } from "@intehrgrator/blockly/defaults_canvas.ts";
 import { workspaceToModelJson } from "@intehrgrator/blockly/mod.ts";
 
@@ -41,7 +43,35 @@ Deno.test("factory Defaults Map seeds UI language once and dummy facility", () =
   assertEquals(factoryDefaultsEntries("de").find((e) => e.key === "language")?.value, "de");
 });
 
-Deno.test("namedMapsFromBlocklyState reads the Defaults block Map argument", () => {
+Deno.test("namedMapsFromBlocklyState reads field keys and value sockets", () => {
+  const state = {
+    blocks: {
+      blocks: [
+        {
+          type: "defaults_block",
+          inputs: {
+            MAP: {
+              block: {
+                type: "maps_create_with",
+                extraState: { itemCount: 2 },
+                fields: { KEY0: "language", KEY1: "territory" },
+                inputs: {
+                  VAL0: { shadow: { type: "text", fields: { TEXT: "sv" } } },
+                  VAL1: { shadow: { type: "text", fields: { TEXT: "SE" } } },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+  const maps = namedMapsFromBlocklyState(state);
+  assertEquals(maps[DEFAULTS_MAP_NAME]?.language, "sv");
+  assertEquals(maps[DEFAULTS_MAP_NAME]?.territory, "SE");
+});
+
+Deno.test("namedMapsFromBlocklyState still reads legacy KEY value-input JSON", () => {
   const state = {
     blocks: {
       blocks: [
@@ -68,6 +98,35 @@ Deno.test("namedMapsFromBlocklyState reads the Defaults block Map argument", () 
   const maps = namedMapsFromBlocklyState(state);
   assertEquals(maps[DEFAULTS_MAP_NAME]?.language, "sv");
   assertEquals(maps[DEFAULTS_MAP_NAME]?.territory, "SE");
+});
+
+Deno.test("migrateMapsCreateWithJson moves KEY inputs into fields", () => {
+  const block = {
+    type: "maps_create_with",
+    extraState: { itemCount: 1 },
+    inputs: {
+      KEY0: { shadow: { type: "text", fields: { TEXT: "language" } } },
+      VAL0: { shadow: { type: "text", fields: { TEXT: "sv" } } },
+    },
+  };
+  migrateMapsCreateWithJson(block);
+  assertEquals(block.fields?.KEY0, "language");
+  assertEquals(block.inputs?.KEY0, undefined);
+  assertEquals(
+    (block.inputs?.VAL0 as { shadow?: { fields?: { TEXT?: string } } })?.shadow
+      ?.fields?.TEXT,
+    "sv",
+  );
+  const extracted = mapBlockFromDefaultsJson({
+    type: "maps_create_with",
+    extraState: { itemCount: 1 },
+    inputs: {
+      KEY0: { shadow: { type: "text", fields: { TEXT: "territory" } } },
+      VAL0: { shadow: { type: "text", fields: { TEXT: "SE" } } },
+    },
+  }) as { fields?: Record<string, string>; inputs?: Record<string, unknown> };
+  assertEquals(extracted.fields?.KEY0, "territory");
+  assertEquals(extracted.inputs?.KEY0, undefined);
 });
 
 Deno.test("mapBlockFromDefaultsJson accepts a maps_create_with block or a workspace", () => {
@@ -105,8 +164,8 @@ Deno.test("Test Run resolves maps_get from Blockly Defaults Map JSON", () => {
                 block: {
                   type: "maps_create_with",
                   extraState: { itemCount: 1 },
+                  fields: { KEY0: "language" },
                   inputs: {
-                    KEY0: { shadow: { type: "text", fields: { TEXT: "language" } } },
                     VAL0: { shadow: { type: "text", fields: { TEXT: "sv" } } },
                   },
                 },
@@ -158,6 +217,9 @@ Deno.test("skeleton scaffolding joins an existing Defaults block and plugs langu
   assertEquals(defaults.id, beforeId);
   const maps = namedMapsFromBlocklyState(Blockly.serialization.workspaces.save(workspace));
   assertEquals(maps[DEFAULTS_MAP_NAME]?.language, "sv");
+  const factoryMap = defaults.getInputTargetBlock("MAP");
+  assertEquals(factoryMap?.getFieldValue("KEY0"), "language");
+  assert(!factoryMap?.getInput("KEY0"));
   const lookups = workspace.getAllBlocks(false).filter((block) => block.type === "maps_get");
   assert(lookups.length > 0, "expected Default point Map lookups on the skeleton");
   assert(
@@ -172,5 +234,25 @@ Deno.test("skeleton scaffolding joins an existing Defaults block and plugs langu
     derived.slots.some((slot) => slot.expression.includes('maps_get("defaults", "language")')),
     "language lookup should appear in the Mapping Model",
   );
+  workspace.dispose();
+});
+
+Deno.test("hydrateDefaultsMapArgument loads legacy KEY-input map JSON", () => {
+  registerMapBlocks();
+  const workspace = new Blockly.Workspace();
+  ensureDefaultsBlock(workspace, "sv");
+  hydrateDefaultsMapArgument(workspace, {
+    type: "maps_create_with",
+    extraState: { itemCount: 1 },
+    inputs: {
+      KEY0: { shadow: { type: "text", fields: { TEXT: "language" } } },
+      VAL0: { shadow: { type: "text", fields: { TEXT: "xx" } } },
+    },
+  }, "sv");
+  const map = findDefaultsBlock(workspace)?.getInputTargetBlock("MAP");
+  assertEquals(map?.getFieldValue("KEY0"), "language");
+  assert(!map?.getInput("KEY0"));
+  const maps = namedMapsFromBlocklyState(Blockly.serialization.workspaces.save(workspace));
+  assertEquals(maps[DEFAULTS_MAP_NAME]?.language, "xx");
   workspace.dispose();
 });

--- a/test/ehrtslib_contract_test.ts
+++ b/test/ehrtslib_contract_test.ts
@@ -5,7 +5,11 @@
  */
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
-import { parseTemplateInput } from "ehrtslib/parser/mod.ts";
+import {
+  collectTemplateJsonExternalRefsFromText,
+  parseTemplateInput,
+  parseTemplateJson,
+} from "ehrtslib/parser/mod.ts";
 import {
   attributesFor,
   hasRmType,
@@ -40,6 +44,17 @@ import {
 const bpOpt = await Deno.readTextFile(
   join(import.meta.dirname!, "fixtures", "blood_pressure.opt"),
 );
+const differentialTemplateJson = await Deno.readTextFile(
+  join(
+    import.meta.dirname!,
+    "..",
+    "vendor",
+    "ehrtslib",
+    "test_data",
+    "tjson",
+    "Care unit v2.t.json",
+  ),
+);
 
 Deno.test("ehrtslib APIs intEHRgrator imports still resolve", () => {
   assertEquals(typeof webTemplateToOpt, "function");
@@ -66,6 +81,18 @@ Deno.test("ehrtslib APIs intEHRgrator imports still resolve", () => {
   assertEquals(typeof resolveLocatableLabel, "function");
   assertEquals(TERM_ARCHETYPE_SCOPE_KEY, "term_archetype_scope");
   assertEquals(termCodeCandidates("at0004")[0], "at0004");
+});
+
+Deno.test("differential .t.json resolves overlay parent archetypes", () => {
+  const parentId = "openEHR-EHR-CLUSTER.organisation.v1";
+  const overlayId = "openEHR-EHR-CLUSTER.ovl-organisation-000.v1";
+  const refs = collectTemplateJsonExternalRefsFromText(differentialTemplateJson);
+  assert(refs.includes(parentId), `expected overlay parent in ${refs}`);
+  assert(!refs.includes(overlayId), `inlined overlay must not be fetched: ${refs}`);
+
+  const { overlays } = parseTemplateJson(differentialTemplateJson);
+  assert(overlays.length > 0, "expected an inlined differential overlay");
+  assertEquals(overlays[0]?.parent_archetype_id?.value, parentId);
 });
 
 Deno.test("OPT XML parse keeps colliding at-codes archetype-local", () => {

--- a/test/map_blocks_test.ts
+++ b/test/map_blocks_test.ts
@@ -29,7 +29,7 @@ Deno.test("map blocks register create/get/keys/length/isEmpty and Defaults", () 
   const map = workspace.newBlock(MAPS_CREATE_WITH) as MapCreateBlock;
   map.itemCount_ = 3;
   map.updateShape_();
-  assert(map.getInput("KEY0"));
+  assert(map.getField("KEY0"));
   assert(map.getInput("VAL2"));
   const lookup = workspace.newBlock(MAPS_GET);
   lookup.setFieldValue("defaults", "NAME");
@@ -37,35 +37,47 @@ Deno.test("map blocks register create/get/keys/length/isEmpty and Defaults", () 
   workspace.dispose();
 });
 
-Deno.test("maps_create_with keeps each key:value pair on one row", () => {
+Deno.test("maps_create_with keeps keys as fields and values on the right edge", () => {
   registerMapBlocks();
   const workspace = new Blockly.Workspace();
   const map = workspace.newBlock(MAPS_CREATE_WITH) as MapCreateBlock;
   map.itemCount_ = 2;
   map.updateShape_();
-  assertEquals(map.getInputsInline(), true);
-  assertEquals(inputNames(map), [
-    "HEADER",
-    "HEADER_END",
-    "KEY0",
-    "VAL0",
-    "ROW0",
-    "KEY1",
-    "VAL1",
-    "ROW1",
-  ]);
+  assertEquals(map.getInputsInline(), false);
+  assertEquals(inputNames(map), ["HEADER", "VAL0", "VAL1"]);
   assertEquals(map.getInput("HEADER")?.type, Blockly.inputs.inputTypes.DUMMY);
-  assertEquals(
-    map.getInput("HEADER_END")?.type,
-    Blockly.inputs.inputTypes.END_ROW,
-  );
-  assertEquals(map.getInput("KEY0")?.type, Blockly.inputs.inputTypes.VALUE);
   assertEquals(map.getInput("VAL0")?.type, Blockly.inputs.inputTypes.VALUE);
-  assertEquals(map.getInput("ROW0")?.type, Blockly.inputs.inputTypes.END_ROW);
-  assertEquals(map.getInput("VAL0")?.fieldRow[0]?.getText?.() ?? ":", ":");
+  assertEquals(map.getInput("VAL0")?.align, Blockly.inputs.Align.RIGHT);
+  assertEquals(map.getFieldValue("KEY0"), "");
+  assertEquals(map.getInput("VAL0")?.fieldRow[1]?.getText?.() ?? ":", ":");
+  assert(!map.getInput("KEY0"));
+
+  map.setFieldValue("language", "KEY0");
+  assertEquals(map.getFieldValue("KEY0"), "language");
 
   map.itemCount_ = 0;
   map.updateShape_();
-  assertEquals(inputNames(map), ["HEADER", "HEADER_END", "EMPTY"]);
+  assertEquals(inputNames(map), ["HEADER", "EMPTY"]);
+  workspace.dispose();
+});
+
+Deno.test("maps_create_with serializes field keys and value sockets", () => {
+  registerMapBlocks();
+  const workspace = new Blockly.Workspace();
+  const map = workspace.newBlock(MAPS_CREATE_WITH) as MapCreateBlock;
+  map.itemCount_ = 1;
+  map.updateShape_();
+  map.setFieldValue("territory", "KEY0");
+  const val = map.getInput("VAL0")?.connection;
+  if (val && typeof val.setShadowState === "function") {
+    val.setShadowState({ type: "text", fields: { TEXT: "SE" } });
+  }
+  const saved = Blockly.serialization.blocks.save(map) as {
+    fields?: Record<string, unknown>;
+    inputs?: Record<string, unknown>;
+  };
+  assertEquals(saved.fields?.KEY0, "territory");
+  assertEquals(saved.inputs?.KEY0, undefined);
+  assert(saved.inputs?.VAL0);
   workspace.dispose();
 });

--- a/test/map_blocks_test.ts
+++ b/test/map_blocks_test.ts
@@ -1,5 +1,6 @@
 import { assert, assertEquals } from "@std/assert";
 import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
+import "blockly/blocks";
 import { registerMapBlocks } from "@intehrgrator/blockly/blocks/map_blocks.ts";
 import {
   MAPS_CREATE_WITH,

--- a/test/map_blocks_test.ts
+++ b/test/map_blocks_test.ts
@@ -1,10 +1,19 @@
-import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
 import { registerMapBlocks } from "@intehrgrator/blockly/blocks/map_blocks.ts";
 import {
   MAPS_CREATE_WITH,
   MAPS_GET,
 } from "@intehrgrator/core/defaults/extract.ts";
+
+type MapCreateBlock = Blockly.Block & {
+  itemCount_: number;
+  updateShape_: () => void;
+};
+
+function inputNames(block: Blockly.Block): string[] {
+  return block.inputList.map((input) => input.name);
+}
 
 Deno.test("map blocks register create/get/keys/length/isEmpty and Defaults", () => {
   registerMapBlocks();
@@ -17,10 +26,7 @@ Deno.test("map blocks register create/get/keys/length/isEmpty and Defaults", () 
   assert(Blockly.Blocks["defaults_block"]);
 
   const workspace = new Blockly.Workspace();
-  const map = workspace.newBlock(MAPS_CREATE_WITH) as Blockly.Block & {
-    itemCount_: number;
-    updateShape_: () => void;
-  };
+  const map = workspace.newBlock(MAPS_CREATE_WITH) as MapCreateBlock;
   map.itemCount_ = 3;
   map.updateShape_();
   assert(map.getInput("KEY0"));
@@ -28,12 +34,38 @@ Deno.test("map blocks register create/get/keys/length/isEmpty and Defaults", () 
   const lookup = workspace.newBlock(MAPS_GET);
   lookup.setFieldValue("defaults", "NAME");
   assertEquals(lookup.getFieldValue("NAME"), "defaults");
-  const defaults = workspace.newBlock("defaults_block");
-  assertEquals(defaults.getFieldValue("TITLE"), "openEHR CTX defaults");
-  assertEquals(defaults.getFieldValue("MANAGE_LABEL"), "manage");
-  assert(defaults.getInput("CONTEXT"));
-  assert(defaults.getInput("MAP"));
-  assertStringIncludes(String(defaults.getTooltip()), "composer_name");
-  assertStringIncludes(String(defaults.getTooltip()), "health_care_facility");
+  workspace.dispose();
+});
+
+Deno.test("maps_create_with keeps each key:value pair on one row", () => {
+  registerMapBlocks();
+  const workspace = new Blockly.Workspace();
+  const map = workspace.newBlock(MAPS_CREATE_WITH) as MapCreateBlock;
+  map.itemCount_ = 2;
+  map.updateShape_();
+  assertEquals(map.getInputsInline(), true);
+  assertEquals(inputNames(map), [
+    "HEADER",
+    "HEADER_END",
+    "KEY0",
+    "VAL0",
+    "ROW0",
+    "KEY1",
+    "VAL1",
+    "ROW1",
+  ]);
+  assertEquals(map.getInput("HEADER")?.type, Blockly.inputs.inputTypes.DUMMY);
+  assertEquals(
+    map.getInput("HEADER_END")?.type,
+    Blockly.inputs.inputTypes.END_ROW,
+  );
+  assertEquals(map.getInput("KEY0")?.type, Blockly.inputs.inputTypes.VALUE);
+  assertEquals(map.getInput("VAL0")?.type, Blockly.inputs.inputTypes.VALUE);
+  assertEquals(map.getInput("ROW0")?.type, Blockly.inputs.inputTypes.END_ROW);
+  assertEquals(map.getInput("VAL0")?.fieldRow[0]?.getText?.() ?? ":", ":");
+
+  map.itemCount_ = 0;
+  map.updateShape_();
+  assertEquals(inputNames(map), ["HEADER", "HEADER_END", "EMPTY"]);
   workspace.dispose();
 });

--- a/test/map_blocks_test.ts
+++ b/test/map_blocks_test.ts
@@ -1,7 +1,10 @@
-import { assertEquals, assert } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
 import { registerMapBlocks } from "@intehrgrator/blockly/blocks/map_blocks.ts";
-import { MAPS_CREATE_WITH, MAPS_GET } from "@intehrgrator/core/defaults/extract.ts";
+import {
+  MAPS_CREATE_WITH,
+  MAPS_GET,
+} from "@intehrgrator/core/defaults/extract.ts";
 
 Deno.test("map blocks register create/get/keys/length/isEmpty and Defaults", () => {
   registerMapBlocks();
@@ -25,5 +28,12 @@ Deno.test("map blocks register create/get/keys/length/isEmpty and Defaults", () 
   const lookup = workspace.newBlock(MAPS_GET);
   lookup.setFieldValue("defaults", "NAME");
   assertEquals(lookup.getFieldValue("NAME"), "defaults");
+  const defaults = workspace.newBlock("defaults_block");
+  assertEquals(defaults.getFieldValue("TITLE"), "openEHR CTX defaults");
+  assertEquals(defaults.getFieldValue("MANAGE_LABEL"), "manage");
+  assert(defaults.getInput("CONTEXT"));
+  assert(defaults.getInput("MAP"));
+  assertStringIncludes(String(defaults.getTooltip()), "composer_name");
+  assertStringIncludes(String(defaults.getTooltip()), "health_care_facility");
   workspace.dispose();
 });

--- a/web/main.ts
+++ b/web/main.ts
@@ -81,7 +81,7 @@ import {
 } from "../src/core/example_sets/mod.ts";
 import { formatSaveTime } from "../src/core/persistence/mod.ts";
 import { collectValueSlots } from "../src/core/skeleton/generate_skeleton.ts";
-import { createIndexedDbDefaultsCatalog, mapBlockFromDefaultsJson } from "../src/core/defaults/mod.ts";
+import { createIndexedDbDefaultsCatalog, mapBlockFromDefaultsJson, migrateMapsCreateWithJson } from "../src/core/defaults/mod.ts";
 import {
   buildHandlebarsPath,
   buildHandlebarsTree,
@@ -292,6 +292,7 @@ async function bootBlockly(): Promise<void> {
 
   const loadOnce = takeLoadOnceBlocks();
   if (loadOnce) {
+    migrateMapsCreateWithJson(loadOnce);
     Blockly.serialization.workspaces.load(loadOnce, workspace);
     lockWorkspaceRootsExpanded(workspace);
   }
@@ -521,6 +522,7 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
       Blockly.Events.disable();
       try {
         workspace.clear();
+        migrateMapsCreateWithJson(s.blocklyState);
         Blockly.serialization.workspaces.load(s.blocklyState, workspace);
         if (!findDefaultsBlock(workspace)) ensureDefaultsBlock(workspace, blocklyLocale);
         applyModelLoops(workspace, s.model);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Contract test for ehrtslib differential `t.json` overlay parent fetch (`deno task vendor`).
- `maps_create_with` now matches the App Inventor / Blockly JSON-object layout: **keys in a column of text fields**, **values on right-edge connectors** that take ordinary blocks (`text`, `math_number`, source queries, nested maps).
- Saved maps that still store keys as nested `KEY{n}` text blocks are migrated on load. The dummy-vitals Defaults Map example is in the new shape.

App Inventor’s `dictionaries_create_with` stacks value sockets (`setInputsInline` false, `Align.RIGHT`) but puts keys on separate `pair` blocks. The closer match for “keys in fields, values on the right edge” is Blockly’s JSON-object member pattern (`FieldTextInput` + `:` + value input), copied onto the existing plus/minus map constructor.

## Test plan

- `deno task test` — 249 passed, 0 failed, 1 ignored
- `deno task build`
- Browser (build `925d63c`): Defaults Map nested constructor shows key fields in a column with value sockets on the right

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c80e4955-7f54-4522-9937-fc724b7858fe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c80e4955-7f54-4522-9937-fc724b7858fe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

