### PR TITLE
Fix GitHub Pages build and add Mapping Editor undo, search, and spec ticks

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -181,7 +181,7 @@ _UI label:_ section title **Generated conversion script(s)**.
 _Avoid_: Export code, preview TypeScript
 
 **Sync Scope**:
-Blockly workspace JSON (canonical structure) ⇄ Mapping Spec widgets for safe field edits only → Mapping Model slots[] (derived index) → codegen / Test Run. Widget edits patch the corresponding Blockly fields and regenerate the Model; canvas / Click-to-Map / AI structural changes rewrite the Spec view. v1 safe edits: Mapping Expression text on `source_query` (and equivalent expression blocks). Structure, Optional RM Insertion, ids, and coordinates are Blockly-only. Raw free-typing of block tree JSON is not the intended authoring path. Center CodeMirror is **not** Generated Export.
+Blockly workspace JSON (canonical structure) ⇄ Mapping Spec widgets for safe field edits only → Mapping Model slots[] (derived index) → codegen / Test Run. Widget edits patch the corresponding Blockly fields and regenerate the Model; canvas / Click-to-Map / AI structural changes rewrite the Spec view. Canvas undo/redo is the single history: spec widget edits, Click-to-Map, and cogwheel add/remove are Blockly events (grouped per user action). Open template / Example Sets / Load Project / New project restore a document snapshot; Save / Export do not push undo steps. v1 safe edits: Mapping Expression text on `source_query` (and equivalent expression blocks). Structure, Optional RM Insertion, ids, and coordinates are Blockly-only. Raw free-typing of block tree JSON is not the intended authoring path. Center CodeMirror is **not** Generated Export.
 _Avoid_: Full handwritten Blockly JSON as primary editor, custom DSL as middle language
 
 **Web Shell**:

--- a/deno.json
+++ b/deno.json
@@ -34,6 +34,7 @@
     "blockly/msg/ca": "npm:blockly@^11.2.2/msg/ca",
     "blockly/msg/fr": "npm:blockly@^11.2.2/msg/fr",
     "@blockly/workspace-minimap": "npm:@blockly/workspace-minimap@0.2.16",
+    "@blockly/toolbox-search": "npm:@blockly/toolbox-search@2.0.16",
     "fflate": "npm:fflate@^0.8.2",
     "fast-xml-parser": "npm:fast-xml-parser@^4.5.6",
     "handlebars": "npm:handlebars@^4.7.9",

--- a/deno.lock
+++ b/deno.lock
@@ -25,6 +25,7 @@
     "jsr:@std/path@^1.1.6": "1.1.6",
     "jsr:@std/streams@^1.1.1": "1.1.1",
     "jsr:@std/testing@1": "1.0.19",
+    "npm:@blockly/toolbox-search@2.0.16": "2.0.16_blockly@11.2.2",
     "npm:@blockly/workspace-minimap@0.2.16": "0.2.16_blockly@11.2.2",
     "npm:@cfworker/json-schema@^4.1.1": "4.1.1",
     "npm:@codemirror/commands@^6.8.1": "6.10.4",
@@ -150,6 +151,12 @@
         "@csstools/css-parser-algorithms",
         "@csstools/css-tokenizer",
         "lru-cache"
+      ]
+    },
+    "@blockly/toolbox-search@2.0.16_blockly@11.2.2": {
+      "integrity": "sha512-pg49w17DjV+BmjjRveMww1pGFm3ZKs6tX5oRnK0Uj5rCJIEWWIHsRpipcgZQ7U75vD2jFmvCVMzz0PZsPlhYvA==",
+      "dependencies": [
+        "blockly"
       ]
     },
     "@blockly/workspace-minimap@0.2.16_blockly@11.2.2": {
@@ -1313,6 +1320,7 @@
       "jsr:@std/http@1",
       "jsr:@std/path@1",
       "jsr:@std/testing@1",
+      "npm:@blockly/toolbox-search@2.0.16",
       "npm:@blockly/workspace-minimap@0.2.16",
       "npm:@cfworker/json-schema@^4.1.1",
       "npm:@codemirror/commands@^6.8.1",

--- a/docs/BLOCKLY_INTEGRATION.md
+++ b/docs/BLOCKLY_INTEGRATION.md
@@ -63,7 +63,9 @@ cogwheel mutator (`optional_rm_mutator` / `dv_fields_mutator`), not a custom `+`
 
 Toolbox layout and stock categories follow the Blockly DevSite landing demo
 (Logic, Loops, Math, Text, Lists, Variables, Functions) plus intEHRgrator
-categories **Source** and **Data values**. See [Attribution](#attribution).
+categories **Source** and **Data values**, with `@blockly/toolbox-search`
+(`kind: "search"`) at the top so Search covers every `kind: "block"` drawer
+including custom Source, openEHR types, and Maps. See [Attribution](#attribution).
 
 - **Stock Blockly:** `controls_if`, `controls_whileUntil`, `controls_repeat_ext`,
   `math_arithmetic`, `text_join`, `text_trim`, `logic_ternary`, variables, procedures, …

--- a/docs/MAPPING_SPECIFICATION.md
+++ b/docs/MAPPING_SPECIFICATION.md
@@ -38,8 +38,12 @@ Mapping Model slots[] (derived semantic index)
 - Project Bundles persist both. On load, Blockly JSON restores the workspace;
   subsequent changes regenerate the Mapping Model.
 - Click-to-Map updates the Mapping Model and the corresponding Blockly
-  expression block. The next workspace change reasserts Blockly JSON as the
-  authority.
+  expression block as one undoable canvas action. The next workspace change
+  reasserts Blockly JSON as the authority.
+- Constraint warnings (yellow triangles) appear on Blockly blocks and matching
+  Mapping Spec widgets. The Spec pane also draws orange ticks on the right-hand
+  overview ruler so every warning can be found without scrolling; clicking a
+  tick selects that block (same as clicking the spec row).
 
 ## Target instance format versus conversion script language
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,13 +9,13 @@
 ## B. Robust good UI/UX
 - [x] Change the way optional attributes are manually added to a block. Now we have an encircled plus sign that acts like a button opening a popup where fields can be added. CHange that to the more native blockly syle of block modification (that is used e.g for adding more "else if" and "else" statments to an "if" block) by clicking a cogwheel. THat way non-mandatory attirbutes can also be removed manually.
 - [x] Activate Expand/collapse json etc i code mirror gutter
-- [ ] Add undo/redo for mapping editor
+- [x] Add undo/redo for mapping editor
 - [ ] Integrate save functions with github repo (if logged in)
 - [ ] Full application UI i18n — toolbar UI language already switches Blockly/stock messages; later translate the rest of the chrome (pane titles, buttons, tips, status) from the same setting. Keep model/ontology language (Target pane) separate.
 - [ ] Anpassa för färgblindhet. Gör färger/mönster för in --> konv --> ut och använd konsekvent i syntax highlighting, blockfärg mm
 - [ ] Synk highlight mellan mappning och conversion test run (ev conversion script)
-- [ ] add https://raspberrypifoundation.github.io/blockly-samples/plugins/toolbox-search/test/index.html
-- [ ] add markers in right scroll gutter of mapping spec codemirror so that all locations of errors can be found
+- [x] add https://raspberrypifoundation.github.io/blockly-samples/plugins/toolbox-search/test/index.html
+- [x] add markers in right scroll gutter of mapping spec codemirror so that all locations of errors can be found
 
 ## C. Better support for map and table data structures
 - [x] Model blockly support for maps in the style of the blockly list blocks, check for already available implementations based on blockly, - i know such exist. Key/value pairs share a row (Blockly 11 `appendEndRowInput`), so the Defaults Map nested constructor stays compact.

--- a/src/blockly/block_constraints.ts
+++ b/src/blockly/block_constraints.ts
@@ -32,11 +32,23 @@ export const ABSTRACT_EVENT_WARNING =
 const STATEMENT_INPUT_TYPE = 3;
 
 export function refreshWorkspaceConstraints(workspace: Workspace): void {
-  for (const block of workspace.getAllBlocks(false)) {
-    if (typeof block.isShadow === "function" && block.isShadow()) continue;
-    refreshSlotCardinalityState(block);
-    const messages = blockConstraintMessages(block);
-    block.setWarningText(messages.length ? messages.join("\n") : null);
+  const record = typeof Blockly.Events.getRecordUndo === "function"
+    ? Blockly.Events.getRecordUndo()
+    : true;
+  if (typeof Blockly.Events.setRecordUndo === "function") {
+    Blockly.Events.setRecordUndo(false);
+  }
+  try {
+    for (const block of workspace.getAllBlocks(false)) {
+      if (typeof block.isShadow === "function" && block.isShadow()) continue;
+      refreshSlotCardinalityState(block);
+      const messages = blockConstraintMessages(block);
+      block.setWarningText(messages.length ? messages.join("\n") : null);
+    }
+  } finally {
+    if (typeof Blockly.Events.setRecordUndo === "function") {
+      Blockly.Events.setRecordUndo(record);
+    }
   }
 }
 

--- a/src/blockly/blockly_events.ts
+++ b/src/blockly/blockly_events.ts
@@ -60,6 +60,15 @@ export const CANVAS_SWAP_EVENT_TYPE = "intehr_canvas_swap";
 
 type AbstractEvent = InstanceType<typeof Blockly.Events.Abstract>;
 
+let afterCanvasSwapRun: ((workspace: Workspace) => void) | null = null;
+
+/** Called after undo/redo loads a canvas snapshot (not on the initial fire). */
+export function setAfterCanvasSwapRun(
+  handler: ((workspace: Workspace) => void) | null,
+): void {
+  afterCanvasSwapRun = handler;
+}
+
 /** One undo step that replaces the whole canvas JSON (Click-to-Map, AI import). */
 export class CanvasSwapEvent extends Blockly.Events.Abstract {
   override isBlank = false;
@@ -86,6 +95,7 @@ export class CanvasSwapEvent extends Blockly.Events.Abstract {
     runWithoutBlocklyEvents(() => {
       Blockly.serialization.workspaces.load(state as Record<string, unknown>, ws);
     });
+    afterCanvasSwapRun?.(ws);
   }
 }
 

--- a/src/blockly/blockly_events.ts
+++ b/src/blockly/blockly_events.ts
@@ -34,3 +34,24 @@ export function runWithoutBlocklyEvents(fn: () => void): void {
     }
   }
 }
+
+/**
+ * Treat `fn` as one undo step. Joins an existing Blockly event group
+ * (mutator compose, drop) instead of nesting a second group id.
+ */
+export function withBlocklyUndoGroup(fn: () => void): void {
+  const existing = typeof Blockly.Events.getGroup === "function"
+    ? Blockly.Events.getGroup()
+    : "";
+  const started = !existing;
+  if (started && typeof Blockly.Events.setGroup === "function") {
+    Blockly.Events.setGroup(true);
+  }
+  try {
+    fn();
+  } finally {
+    if (started && typeof Blockly.Events.setGroup === "function") {
+      Blockly.Events.setGroup(false);
+    }
+  }
+}

--- a/src/blockly/blockly_events.ts
+++ b/src/blockly/blockly_events.ts
@@ -55,3 +55,46 @@ export function withBlocklyUndoGroup(fn: () => void): void {
     }
   }
 }
+
+export const CANVAS_SWAP_EVENT_TYPE = "intehr_canvas_swap";
+
+type AbstractEvent = InstanceType<typeof Blockly.Events.Abstract>;
+
+/** One undo step that replaces the whole canvas JSON (Click-to-Map, AI import). */
+export class CanvasSwapEvent extends Blockly.Events.Abstract {
+  override isBlank = false;
+  override type = CANVAS_SWAP_EVENT_TYPE;
+  override recordUndo = true;
+  override isUiEvent = false;
+  before: unknown;
+  after: unknown;
+
+  constructor(workspace: Workspace, before: unknown, after: unknown) {
+    super();
+    this.workspaceId = workspace.id;
+    this.before = before;
+    this.after = after;
+  }
+
+  override isNull(): boolean {
+    return JSON.stringify(this.before) === JSON.stringify(this.after);
+  }
+
+  override run(forward: boolean): void {
+    const ws = this.getEventWorkspace_();
+    const state = forward ? this.after : this.before;
+    runWithoutBlocklyEvents(() => {
+      Blockly.serialization.workspaces.load(state as Record<string, unknown>, ws);
+    });
+  }
+}
+
+/** Apply a bulk canvas mutation as a single undoable workspace snapshot. */
+export function replaceCanvasUndoable(workspace: Workspace, apply: () => void): void {
+  const before = structuredClone(Blockly.serialization.workspaces.save(workspace));
+  apply();
+  const after = structuredClone(Blockly.serialization.workspaces.save(workspace));
+  const event = new CanvasSwapEvent(workspace, before, after);
+  if (event.isNull()) return;
+  Blockly.Events.fire(event as AbstractEvent);
+}

--- a/src/blockly/blocks/rm_blocks.ts
+++ b/src/blockly/blocks/rm_blocks.ts
@@ -104,6 +104,11 @@ export function optionalRmInputName(attr: string): string {
   return `${OPTIONAL_INPUT_PREFIX}${attr}`;
 }
 
+export function optionalRmExtrasOf(block: Blockly.Block): string[] {
+  const extras = (block as Blockly.Block & { extraInputs_?: string[] }).extraInputs_;
+  return extras?.length ? [...extras] : [];
+}
+
 export function registerRmBlocks(): void {
   defineContainerBlock("composition", [
     { name: "language" },

--- a/src/blockly/i18n/custom_msg.ts
+++ b/src/blockly/i18n/custom_msg.ts
@@ -15,6 +15,7 @@ export const SUPPORTED_LOCALES: Array<{ code: IntehrLocale; name: string }> = [
 ];
 
 export interface IntehrMessages {
+  CAT_SEARCH: string;
   CAT_SOURCE: string;
   CAT_OPENEHR_TYPES: string;
   CAT_JSON: string;
@@ -48,6 +49,7 @@ export interface IntehrMessages {
 
 const TABLE: Record<IntehrLocale, IntehrMessages> = {
   en: {
+    CAT_SEARCH: "Search",
     CAT_SOURCE: "Source",
     CAT_OPENEHR_TYPES: "openEHR types",
     CAT_JSON: "JSON",
@@ -83,6 +85,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     MODEL_LANGUAGE_LABEL: "Model",
   },
   sv: {
+    CAT_SEARCH: "Sök",
     CAT_SOURCE: "Källa",
     CAT_OPENEHR_TYPES: "openEHR types",
     CAT_JSON: "JSON",
@@ -118,6 +121,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     MODEL_LANGUAGE_LABEL: "Modell",
   },
   de: {
+    CAT_SEARCH: "Suche",
     CAT_SOURCE: "Quelle",
     CAT_OPENEHR_TYPES: "openEHR types",
     CAT_JSON: "JSON",
@@ -153,6 +157,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     MODEL_LANGUAGE_LABEL: "Modell",
   },
   es: {
+    CAT_SEARCH: "Buscar",
     CAT_SOURCE: "Origen",
     CAT_OPENEHR_TYPES: "openEHR types",
     CAT_JSON: "JSON",
@@ -188,6 +193,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     MODEL_LANGUAGE_LABEL: "Modelo",
   },
   ca: {
+    CAT_SEARCH: "Cerca",
     CAT_SOURCE: "Origen",
     CAT_OPENEHR_TYPES: "openEHR types",
     CAT_JSON: "JSON",
@@ -223,6 +229,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     MODEL_LANGUAGE_LABEL: "Model",
   },
   fr: {
+    CAT_SEARCH: "Rechercher",
     CAT_SOURCE: "Source",
     CAT_OPENEHR_TYPES: "openEHR types",
     CAT_JSON: "JSON",

--- a/src/blockly/mod.ts
+++ b/src/blockly/mod.ts
@@ -1,8 +1,8 @@
 import * as Blockly from "blockly/core";
 import "blockly/blocks";
 import { javascriptGenerator, Order } from "blockly/javascript";
-import type { MappingLoop, SkeletonNode } from "../types/mod.ts";
-import { registerRmBlocks, isDataValueBlock, expressionBlockFromDataValueShell, rmAttributeInputName } from "./blocks/rm_blocks.ts";
+import type { MappingLoop, OptionalRmInsertion, SkeletonNode } from "../types/mod.ts";
+import { registerRmBlocks, isDataValueBlock, expressionBlockFromDataValueShell, rmAttributeInputName, optionalRmExtrasOf, optionalRmInputName } from "./blocks/rm_blocks.ts";
 import { isGenericValueBlockType, registerTargetBlocks } from "./blocks/target_blocks.ts";
 import { registerExpressionBlocks } from "./blocks/expression_blocks.ts";
 import { registerMapBlocks } from "./blocks/map_blocks.ts";
@@ -73,7 +73,7 @@ export {
 } from "./blocks/rm_blocks.ts";
 export { dataValueLeafTypes, blockTypeForRm, getValidAttachments } from "../core/rm_meta.ts";
 export { isRmContainerBlockType } from "./blocks/rm_blocks.ts";
-export { buildDemoToolbox, type ToolboxContext } from "./toolbox_demo.ts";
+export { buildDemoToolbox, toolboxBlockTypes, type ToolboxContext } from "./toolbox_demo.ts";
 export {
   attachDefaultPointLookups,
   captureDefaultsBlockState,
@@ -284,6 +284,7 @@ function createBlockFromSkeleton(
 export function workspaceToModelJson(workspace: Blockly.Workspace): {
   slots: Array<{ slotId: string; rmType: string; expression: string }>;
   loops: MappingLoop[];
+  optionalRm: OptionalRmInsertion[];
 } {
   const slots: Array<{ slotId: string; rmType: string; expression: string }> = [];
   const seen = new Set<string>();
@@ -315,7 +316,29 @@ export function workspaceToModelJson(workspace: Blockly.Workspace): {
       slots.push({ slotId, rmType, expression });
     }
   }
-  return { slots, loops: loopsFromWorkspace(workspace) };
+  return {
+    slots,
+    loops: loopsFromWorkspace(workspace),
+    optionalRm: optionalRmFromWorkspace(workspace),
+  };
+}
+
+function optionalRmFromWorkspace(workspace: Blockly.Workspace): OptionalRmInsertion[] {
+  const out: OptionalRmInsertion[] = [];
+  for (const block of workspace.getAllBlocks(false)) {
+    const extras = optionalRmExtrasOf(block);
+    const slotId = block.getFieldValue("SLOT_ID");
+    if (!slotId || !extras.length) continue;
+    for (const name of extras) {
+      const input = block.getInput(optionalRmInputName(name)) ??
+        block.getInput(rmAttributeInputName(name));
+      const child = input?.connection?.targetBlock();
+      const rmType = child?.getFieldValue("RM_TYPE") ||
+        (child ? String(child.type).toUpperCase() : name);
+      out.push({ attachmentSlotId: slotId, rmType, attributeName: name });
+    }
+  }
+  return out;
 }
 
 function loopsFromWorkspace(workspace: Blockly.Workspace): MappingLoop[] {

--- a/src/blockly/skeleton_loader.ts
+++ b/src/blockly/skeleton_loader.ts
@@ -112,8 +112,9 @@ export function setAllBlocksCollapsed(
 export function applyModelExpressions(
   workspace: Blockly.Workspace,
   model: MappingModel,
+  options: { recordUndo?: boolean } = {},
 ): void {
-  runWithoutBlocklyEvents(() => {
+  const apply = () => {
     const slotMap = new Map(model.slots.filter((s) => s.expression).map((s) => [s.slotId, s]));
     for (const block of workspace.getAllBlocks(false)) {
       const slotId = block.getFieldValue("SLOT_ID");
@@ -129,7 +130,9 @@ export function applyModelExpressions(
       }
     }
     applyModelLoops(workspace, model);
-  });
+  };
+  if (options.recordUndo) apply();
+  else runWithoutBlocklyEvents(apply);
 }
 
 /** Wrap each repeating container with `for_each_source` when the model has loops. */

--- a/src/blockly/toolbox_demo.ts
+++ b/src/blockly/toolbox_demo.ts
@@ -159,6 +159,12 @@ export function buildDemoToolbox(locale: string, context: ToolboxContext = {}): 
     kind: "categoryToolbox",
     contents: [
       {
+        kind: "search",
+        name: m.CAT_SEARCH,
+        contents: [],
+        cssconfig: { row: "blocklyToolboxCategory blocklyToolboxCategorySearch" },
+      },
+      {
         kind: "category",
         name: m.CAT_SOURCE,
         colour: 28,
@@ -447,4 +453,21 @@ export function buildDemoToolbox(locale: string, context: ToolboxContext = {}): 
       },
     ],
   };
+}
+
+/** Flatten `kind: "block"` types so toolbox-search can index custom drawers. */
+export function toolboxBlockTypes(toolbox: ToolboxJson): string[] {
+  const types: string[] = [];
+  const walk = (item: unknown) => {
+    if (!item || typeof item !== "object") return;
+    const rec = item as { kind?: string; type?: string; contents?: unknown[] };
+    if (String(rec.kind ?? "").toLowerCase() === "block" && rec.type) {
+      types.push(rec.type);
+    }
+    if (Array.isArray(rec.contents)) {
+      for (const child of rec.contents) walk(child);
+    }
+  };
+  walk(toolbox);
+  return types;
 }

--- a/src/blockly/toolbox_search.ts
+++ b/src/blockly/toolbox_search.ts
@@ -3,20 +3,29 @@
  * may include `{ kind: "search" }`. Custom drawers are indexed because they
  * are ordinary `kind: "block"` entries.
  *
- * The plugin puts a search `<input>` inside the category row, then the
- * category's click handler `preventDefault`s — so we stop pointer events
- * on the input from bubbling to the row.
+ * The plugin renders the search `<input>` inside the category row. That row
+ * would otherwise intercept pointer events, so CSS lets the input receive
+ * clicks and this helper selects the Search category when the field is focused.
  */
 import "@blockly/toolbox-search";
+import type { WorkspaceSvg } from "blockly/core";
 
-export function installToolboxSearchInputFix(mount: HTMLElement): void {
-  const stopIfSearch = (event: Event) => {
+export function installToolboxSearchInputFix(
+  mount: HTMLElement,
+  getWorkspace: () => WorkspaceSvg,
+): void {
+  mount.addEventListener("focusin", (event) => {
     const target = event.target;
-    if (target instanceof HTMLInputElement && target.type === "search") {
-      event.stopPropagation();
+    if (!(target instanceof HTMLInputElement) || target.type !== "search") return;
+    const toolbox = getWorkspace().getToolbox?.();
+    if (!toolbox || typeof toolbox.getToolboxItems !== "function") return;
+    const items = toolbox.getToolboxItems();
+    const search = items.find((item) => {
+      const div = typeof item.getDiv === "function" ? item.getDiv() : null;
+      return div instanceof HTMLElement && div.contains(target);
+    });
+    if (search && typeof toolbox.setSelectedItem === "function") {
+      toolbox.setSelectedItem(search);
     }
-  };
-  for (const type of ["pointerdown", "mousedown", "click"] as const) {
-    mount.addEventListener(type, stopIfSearch, true);
-  }
+  });
 }

--- a/src/blockly/toolbox_search.ts
+++ b/src/blockly/toolbox_search.ts
@@ -2,5 +2,21 @@
  * Registers `@blockly/toolbox-search` (Blockly 11 plugin) so toolbox JSON
  * may include `{ kind: "search" }`. Custom drawers are indexed because they
  * are ordinary `kind: "block"` entries.
+ *
+ * The plugin puts a search `<input>` inside the category row, then the
+ * category's click handler `preventDefault`s — so we stop pointer events
+ * on the input from bubbling to the row.
  */
 import "@blockly/toolbox-search";
+
+export function installToolboxSearchInputFix(mount: HTMLElement): void {
+  const stopIfSearch = (event: Event) => {
+    const target = event.target;
+    if (target instanceof HTMLInputElement && target.type === "search") {
+      event.stopPropagation();
+    }
+  };
+  for (const type of ["pointerdown", "mousedown", "click"] as const) {
+    mount.addEventListener(type, stopIfSearch, true);
+  }
+}

--- a/src/blockly/toolbox_search.ts
+++ b/src/blockly/toolbox_search.ts
@@ -1,0 +1,6 @@
+/**
+ * Registers `@blockly/toolbox-search` (Blockly 11 plugin) so toolbox JSON
+ * may include `{ kind: "search" }`. Custom drawers are indexed because they
+ * are ordinary `kind: "block"` entries.
+ */
+import "@blockly/toolbox-search";

--- a/src/core/target/format_handler.ts
+++ b/src/core/target/format_handler.ts
@@ -20,6 +20,7 @@ import {
 import { orderLanguages } from "../skeleton/template_terms.ts";
 import { loadJsonSchema } from "../source/schema_loader.ts";
 import { isWebTemplateJson } from "ehrtslib/serialization/simplified/mod.ts";
+import { isAutoFixedValueSlot } from "../rm_mandatory.ts";
 
 export interface TargetDefinition {
   format: TargetFormatId;
@@ -425,6 +426,8 @@ function renderOpenEhrNodeOnce(
   }
   const grouped = new Map<string, unknown[]>();
   for (const child of node.children) {
+    // LOCATABLE identity is copied from the skeleton node, not mapped as DV_TEXT.
+    if (isAutoFixedValueSlot(child)) continue;
     const value = renderOpenEhrNode(child, values);
     if (value === undefined) continue;
     const attribute = child.rmAttribute ?? child.label;

--- a/src/ui_test/test_api.ts
+++ b/src/ui_test/test_api.ts
@@ -75,6 +75,10 @@ export interface IntehrgratorTestApi {
   openMutator(blockId: string): void;
   /** Set optional RM extras on a container via the mutator compose path. */
   setOptionalRmExtras(blockId: string, names: string[]): void;
+  undo(): void;
+  redo(): void;
+  undoCount(): number;
+  redoCount(): number;
 }
 
 declare global {

--- a/src/ui_test/test_api.ts
+++ b/src/ui_test/test_api.ts
@@ -79,6 +79,7 @@ export interface IntehrgratorTestApi {
   redo(): void;
   undoCount(): number;
   redoCount(): number;
+  undoEventTypes(): string[];
 }
 
 declare global {

--- a/src/workbench/controller.ts
+++ b/src/workbench/controller.ts
@@ -692,11 +692,12 @@ export class WorkbenchController {
     blocklyState: unknown,
     slots: Array<{ slotId: string; rmType: string; expression: string }>,
     loops: MappingLoop[] = [],
+    optionalRm?: MappingModel["optionalRm"],
   ): void {
     if (!this.templateId) return;
     let next = createEmptyModel(this.templateId);
     next.targetFormat = this.target?.format;
-    next.optionalRm = [...this.model.optionalRm];
+    next.optionalRm = optionalRm ? [...optionalRm] : [...this.model.optionalRm];
     next.loops = loops.length ? loops : [...(this.model.loops ?? [])];
     const targetSlots = new Map(collectValueSlots(this.skeleton).map((slot) => [slot.slotId, slot]));
     for (const item of slots) {
@@ -713,6 +714,20 @@ export class WorkbenchController {
     this.refreshDerived();
     this.markDirty();
     if (this.settings.autoplay) this.scheduleTestRun();
+  }
+
+  /** Snapshot the current project (including live Blockly JSON) for undoable loads. */
+  exportDocumentSnapshot(): ProjectBundle {
+    return structuredClone(this.toBundle());
+  }
+
+  /** Restore a document snapshot without treating it as a user load (undo/redo). */
+  restoreDocumentSnapshot(bundle: ProjectBundle): void {
+    this.resetWorkspaceState();
+    this.loadBundle(structuredClone(bundle));
+    this.dirty = true;
+    this.statusMessage = "Restored previous mapping";
+    this.notifyChange();
   }
 
   toggleAutoplay(): void {

--- a/src/workbench/controller.ts
+++ b/src/workbench/controller.ts
@@ -693,12 +693,14 @@ export class WorkbenchController {
     slots: Array<{ slotId: string; rmType: string; expression: string }>,
     loops: MappingLoop[] = [],
     optionalRm?: MappingModel["optionalRm"],
+    options?: { notify?: boolean },
   ): void {
     if (!this.templateId) return;
     let next = createEmptyModel(this.templateId);
     next.targetFormat = this.target?.format;
     next.optionalRm = optionalRm ? [...optionalRm] : [...this.model.optionalRm];
-    next.loops = loops.length ? loops : [...(this.model.loops ?? [])];
+    // Canvas is source of truth: empty `loops` means the loops were undone, not "keep previous".
+    next.loops = [...loops];
     const targetSlots = new Map(collectValueSlots(this.skeleton).map((slot) => [slot.slotId, slot]));
     for (const item of slots) {
       const targetSlot = targetSlots.get(item.slotId);
@@ -712,7 +714,9 @@ export class WorkbenchController {
     this.blocklyState = blocklyState;
     this.model = next;
     this.refreshDerived();
-    this.markDirty();
+    this.dirty = true;
+    this.scheduleAutosave();
+    if (options?.notify !== false) this.notifyChange();
     if (this.settings.autoplay) this.scheduleTestRun();
   }
 

--- a/src/workbench/document_undo.ts
+++ b/src/workbench/document_undo.ts
@@ -1,0 +1,64 @@
+/**
+ * One undo step for Open template / Example Sets / Load Project / New project.
+ * Canvas field edits stay on Blockly's native stack; this event restores a
+ * full Project Bundle so a load can be undone without deleting later saves.
+ */
+import type { Workspace } from "blockly/core";
+import type { ProjectBundle } from "../types/mod.ts";
+import { Blockly } from "../blockly/blockly_core.ts";
+
+export const DOCUMENT_SWAP_EVENT_TYPE = "intehr_document_swap";
+
+export type DocumentSnapshot = ProjectBundle;
+
+type AbstractEvent = InstanceType<typeof Blockly.Events.Abstract>;
+
+export class DocumentSwapEvent extends Blockly.Events.Abstract {
+  override isBlank = false;
+  override type = DOCUMENT_SWAP_EVENT_TYPE;
+  override recordUndo = true;
+  override isUiEvent = false;
+  before: DocumentSnapshot;
+  after: DocumentSnapshot;
+  private readonly restore: (snapshot: DocumentSnapshot) => void;
+
+  constructor(
+    workspace: Workspace,
+    before: DocumentSnapshot,
+    after: DocumentSnapshot,
+    restore: (snapshot: DocumentSnapshot) => void,
+  ) {
+    super();
+    this.workspaceId = workspace.id;
+    this.before = before;
+    this.after = after;
+    this.restore = restore;
+  }
+
+  override isNull(): boolean {
+    return JSON.stringify(this.before) === JSON.stringify(this.after);
+  }
+
+  override run(forward: boolean): void {
+    this.restore(forward ? this.after : this.before);
+  }
+}
+
+export function fireDocumentSwap(
+  workspace: Workspace,
+  before: DocumentSnapshot,
+  after: DocumentSnapshot,
+  restore: (snapshot: DocumentSnapshot) => void,
+): void {
+  const event = new DocumentSwapEvent(workspace, before, after, restore);
+  if (event.isNull()) return;
+  Blockly.Events.fire(event as AbstractEvent);
+}
+
+export function workspaceCanUndo(workspace: Workspace): boolean {
+  return (workspace.getUndoStack?.()?.length ?? 0) > 0;
+}
+
+export function workspaceCanRedo(workspace: Workspace): boolean {
+  return (workspace.getRedoStack?.()?.length ?? 0) > 0;
+}

--- a/src/workbench/mapping_spec/editor.ts
+++ b/src/workbench/mapping_spec/editor.ts
@@ -281,9 +281,9 @@ const specTheme = EditorView.theme({
   },
   ".cm-spec-overview-tick": {
     position: "absolute",
-    left: "2px",
-    right: "2px",
-    height: "4px",
+    left: "1px",
+    right: "1px",
+    height: "6px",
     padding: "0",
     border: "0",
     borderRadius: "1px",

--- a/src/workbench/mapping_spec/editor.ts
+++ b/src/workbench/mapping_spec/editor.ts
@@ -2,6 +2,7 @@ import { EditorState, Facet, StateEffect, StateField } from "@codemirror/state";
 import {
   Decoration,
   EditorView,
+  ViewPlugin,
   WidgetType,
   type DecorationSet,
 } from "@codemirror/view";
@@ -13,6 +14,7 @@ import {
   type SpecLine,
 } from "./project.ts";
 import { MappingSpecWidget, SPEC_LINE_HEIGHT, type SpecFieldEditHandler, type SpecBlockSelectHandler } from "./widgets.ts";
+import { specWarningMarkers } from "./overview.ts";
 
 const setJsonDocEffect = StateEffect.define<BlocklyJsonDocument>();
 
@@ -268,6 +270,27 @@ const specTheme = EditorView.theme({
     fontSize: "12px",
     lineHeight: "14px",
   },
+  ".cm-spec-overview": {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    bottom: 0,
+    width: "12px",
+    zIndex: "6",
+    pointerEvents: "none",
+  },
+  ".cm-spec-overview-tick": {
+    position: "absolute",
+    left: "2px",
+    right: "2px",
+    height: "4px",
+    padding: "0",
+    border: "0",
+    borderRadius: "1px",
+    background: "#E65100",
+    cursor: "pointer",
+    pointerEvents: "auto",
+  },
   ".spec-widget .info-tip": {
     flex: "0 0 auto",
   },
@@ -290,6 +313,56 @@ export interface MappingSpecEditorOptions {
   onSelect?: SpecBlockSelectHandler;
 }
 
+function specOverview(onSelect?: SpecBlockSelectHandler) {
+  return ViewPlugin.fromClass(class {
+    readonly dom: HTMLElement;
+
+    constructor(readonly view: EditorView) {
+      this.dom = document.createElement("div");
+      this.dom.className = "cm-spec-overview";
+      this.dom.setAttribute("aria-label", "Constraint warning locations");
+      view.dom.appendChild(this.dom);
+      this.rebuild();
+    }
+
+    update(): void {
+      this.rebuild();
+    }
+
+    destroy(): void {
+      this.dom.remove();
+    }
+
+    private rebuild(): void {
+      const doc = this.view.state.field(jsonDocField);
+      const chrome = this.view.state.field(specChromeField);
+      const markers = specWarningMarkers(doc, chrome.warnings, this.view.state.doc.length);
+      this.dom.replaceChildren();
+      for (const marker of markers) {
+        const tick = document.createElement("button");
+        tick.type = "button";
+        tick.className = "cm-spec-overview-tick";
+        tick.style.top = `${Math.min(98, Math.max(0, marker.ratio * 100))}%`;
+        tick.title = marker.message;
+        tick.setAttribute("aria-label", marker.message);
+        tick.addEventListener("mousedown", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        });
+        tick.addEventListener("click", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          this.view.dispatch({
+            effects: EditorView.scrollIntoView(marker.from, { y: "center" }),
+          });
+          onSelect?.(marker.blockId);
+        });
+        this.dom.appendChild(tick);
+      }
+    }
+  });
+}
+
 export function createMappingSpecEditor(
   parent: HTMLElement,
   options: MappingSpecEditorOptions = {},
@@ -307,6 +380,7 @@ export function createMappingSpecEditor(
         editFacet.of(options.onFieldEdit),
         selectFacet.of(options.onSelect),
         jsonDecorations,
+        specOverview(options.onSelect),
         EditorView.editable.of(false),
         EditorState.readOnly.of(true),
         specTheme,

--- a/src/workbench/mapping_spec/mod.ts
+++ b/src/workbench/mapping_spec/mod.ts
@@ -20,3 +20,5 @@ export {
   type SpecBlockSelectHandler,
   type SpecChrome,
 } from "./editor.ts";
+
+export { specWarningMarkers, type SpecWarningMarker } from "./overview.ts";

--- a/src/workbench/mapping_spec/overview.ts
+++ b/src/workbench/mapping_spec/overview.ts
@@ -1,0 +1,31 @@
+import type { BlocklyJsonDocument } from "./project.ts";
+
+export interface SpecWarningMarker {
+  blockId: string;
+  from: number;
+  ratio: number;
+  message: string;
+}
+
+/** Tick positions for the Mapping Spec right-hand overview ruler. */
+export function specWarningMarkers(
+  doc: BlocklyJsonDocument,
+  warnings: Record<string, string>,
+  docLength: number,
+): SpecWarningMarker[] {
+  const denom = Math.max(docLength, 1);
+  const out: SpecWarningMarker[] = [];
+  for (const widget of doc.widgets) {
+    const blockId = widget.line.blockId;
+    if (!blockId) continue;
+    const message = warnings[blockId];
+    if (!message) continue;
+    out.push({
+      blockId,
+      from: widget.from,
+      ratio: widget.from / denom,
+      message,
+    });
+  }
+  return out;
+}

--- a/tasks/TASKS-roadmap-chunks.md
+++ b/tasks/TASKS-roadmap-chunks.md
@@ -87,7 +87,13 @@ Already done (do not re-open unless regression): A small fixes (including `.xml`
   - [x] 1.4 Auto-attach typed child for newly added empty structural mouths; orphan on remove; sync `optionalRm[]`
   - [x] 1.5 Tests: add/remove extra via compose without dropping remaining children; DV optional field; no PLUS input
   - [x] 1.6 Update CONTEXT.md, BLOCKLY_INTEGRATION.md, ROADMAP.md
-- [ ] 2.0 Chunk 2 — Mapping Editor chrome (undo/redo, toolbox-search, spec gutter markers)
+- [x] 2.0 Chunk 2 — Mapping Editor chrome (undo/redo, toolbox-search, spec gutter markers)
+  - [x] 2.1 Fix GitHub CI/Pages Test Run locatable identity (string `archetype_node_id`)
+  - [x] 2.2 Canvas is source of truth: spec widget edits, Click-to-Map, and cogwheel extras stay in Blockly undo
+  - [x] 2.3 Undo/Redo buttons; group user-perceived actions; Open template / Example Sets / Load Project are undoable; saves/exports are not
+  - [x] 2.4 `@blockly/toolbox-search` indexes all `kind: "block"` toolbox drawers including Source, openEHR types, and Maps
+  - [x] 2.5 Mapping Spec right-hand overview ticks from the same constraint warnings as Blockly triangles; click selects/pans
+  - [x] 2.6 Docs: ROADMAP, CONTEXT, MAPPING_SPECIFICATION
 - [ ] 3.0 Chunk 3 — RM Blockly completeness (PARTY_IDENTIFIED, ITEM_STRUCTURE morph, toolbox)
 - [ ] 4.0 Chunk 4 — AI copy-paste polish
 - [ ] 5.0 Chunk 5 — Colourblind language + sync highlight

--- a/test/blockly_i18n_test.ts
+++ b/test/blockly_i18n_test.ts
@@ -12,7 +12,8 @@ Deno.test("supported locales include en sv de es ca fr", () => {
 });
 
 Deno.test("custom messages localize Source and for_each_source", () => {
-  assertEquals(msg("en").CAT_SOURCE, "Source");
+  assertEquals(msg("en").CAT_SEARCH, "Search");
+  assertEquals(msg("sv").CAT_SEARCH, "Sök");
   assertEquals(msg("sv").CAT_SOURCE, "Källa");
   assertEquals(msg("de").FOR_EACH_SOURCE_PREFIX, "für jedes");
   assertEquals(msg("es").CAT_OPENEHR_TYPES, "openEHR types");

--- a/test/blockly_undo_group_test.ts
+++ b/test/blockly_undo_group_test.ts
@@ -1,7 +1,9 @@
 import { assert, assertEquals } from "@std/assert";
 import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
 import {
+  CanvasSwapEvent,
   replaceCanvasUndoable,
+  setAfterCanvasSwapRun,
   withBlocklyUndoGroup,
 } from "@intehrgrator/blockly/blockly_events.ts";
 
@@ -15,6 +17,23 @@ Deno.test("withBlocklyUndoGroup sets one group id for the duration of fn", () =>
   });
   assert(seen.length > 0, "expected a group id while the action runs");
   assertEquals(Blockly.Events.getGroup(), "");
+});
+
+Deno.test("CanvasSwapEvent.run invokes the after-swap hook used to persist the model", () => {
+  const workspace = new Blockly.Workspace();
+  try {
+    let calls = 0;
+    setAfterCanvasSwapRun(() => {
+      calls++;
+    });
+    const snapshot = Blockly.serialization.workspaces.save(workspace);
+    const event = new CanvasSwapEvent(workspace, snapshot, snapshot);
+    event.run(false);
+    assertEquals(calls, 1);
+  } finally {
+    setAfterCanvasSwapRun(null);
+    workspace.dispose();
+  }
 });
 
 Deno.test("replaceCanvasUndoable is a no-op when apply does not change the canvas", () => {

--- a/test/blockly_undo_group_test.ts
+++ b/test/blockly_undo_group_test.ts
@@ -1,0 +1,15 @@
+import { assert, assertEquals } from "@std/assert";
+import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
+import { withBlocklyUndoGroup } from "@intehrgrator/blockly/blockly_events.ts";
+
+Deno.test("withBlocklyUndoGroup sets one group id for the duration of fn", () => {
+  let seen = "";
+  withBlocklyUndoGroup(() => {
+    seen = Blockly.Events.getGroup();
+    withBlocklyUndoGroup(() => {
+      assertEquals(Blockly.Events.getGroup(), seen, "nested calls join the existing group");
+    });
+  });
+  assert(seen.length > 0, "expected a group id while the action runs");
+  assertEquals(Blockly.Events.getGroup(), "");
+});

--- a/test/blockly_undo_group_test.ts
+++ b/test/blockly_undo_group_test.ts
@@ -1,6 +1,9 @@
 import { assert, assertEquals } from "@std/assert";
 import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
-import { withBlocklyUndoGroup } from "@intehrgrator/blockly/blockly_events.ts";
+import {
+  replaceCanvasUndoable,
+  withBlocklyUndoGroup,
+} from "@intehrgrator/blockly/blockly_events.ts";
 
 Deno.test("withBlocklyUndoGroup sets one group id for the duration of fn", () => {
   let seen = "";
@@ -12,4 +15,14 @@ Deno.test("withBlocklyUndoGroup sets one group id for the duration of fn", () =>
   });
   assert(seen.length > 0, "expected a group id while the action runs");
   assertEquals(Blockly.Events.getGroup(), "");
+});
+
+Deno.test("replaceCanvasUndoable is a no-op when apply does not change the canvas", () => {
+  const workspace = new Blockly.Workspace();
+  try {
+    replaceCanvasUndoable(workspace, () => {});
+    assertEquals(workspace.getUndoStack?.()?.length ?? 0, 0);
+  } finally {
+    workspace.dispose();
+  }
 });

--- a/test/mapping_spec_overview_test.ts
+++ b/test/mapping_spec_overview_test.ts
@@ -1,0 +1,32 @@
+import { assertEquals } from "@std/assert";
+import {
+  blocklyJsonDocument,
+  specWarningMarkers,
+} from "@intehrgrator/workbench/mapping_spec/mod.ts";
+
+Deno.test("spec warning markers sit at widget positions for constraint warnings", () => {
+  const state = {
+    blocks: {
+      languageVersion: 0,
+      blocks: [
+        {
+          type: "element",
+          id: "ok",
+          fields: { NAME: "ok" },
+        },
+        {
+          type: "element",
+          id: "warn",
+          fields: { NAME: "warn" },
+        },
+      ],
+    },
+  };
+  const doc = blocklyJsonDocument(state);
+  const markers = specWarningMarkers(doc, { warn: "Unmapped mandatory value" }, doc.text.length);
+  assertEquals(markers.length, 1);
+  assertEquals(markers[0]?.blockId, "warn");
+  assertEquals(markers[0]?.message, "Unmapped mandatory value");
+  const warnWidget = doc.widgets.find((item) => item.line.blockId === "warn");
+  assertEquals(markers[0]?.from, warnWidget?.from);
+});

--- a/test/target_format_handler_test.ts
+++ b/test/target_format_handler_test.ts
@@ -1,4 +1,5 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
 import {
   detectTargetFormat,
   getTargetFormatHandler,
@@ -132,6 +133,40 @@ Deno.test("Kintegrate Handlebars helpers and openEHR keys remain compatible", ()
     '"Ada"',
   );
 });
+
+Deno.test("openEHR Test Run emits string locatable identity, not silent-mandatory DV_TEXT", async () => {
+  const opt = await Deno.readTextFile(
+    join(import.meta.dirname!, "fixtures", "blood_pressure.opt"),
+  );
+  const target = getTargetFormatHandler("openehr-template").load("blood_pressure.opt", opt);
+  const model = createEmptyModel(target.targetId);
+  model.targetFormat = "openehr-template";
+  const result = runTest(model, "{}", "json", { target });
+  assertEquals(result.ok, true, (result.warnings ?? []).join("; "));
+  const ids: unknown[] = [];
+  walkRecords(result.output, (rec) => {
+    if ("archetype_node_id" in rec) ids.push(rec.archetype_node_id);
+  });
+  assert(ids.length > 0, "expected locatable nodes in Test Run output");
+  for (const id of ids) {
+    assertEquals(
+      typeof id,
+      "string",
+      `archetype_node_id must stay a string, got ${JSON.stringify(id)}`,
+    );
+  }
+});
+
+function walkRecords(node: unknown, visit: (rec: Record<string, unknown>) => void): void {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const item of node) walkRecords(item, visit);
+    return;
+  }
+  const rec = node as Record<string, unknown>;
+  visit(rec);
+  for (const value of Object.values(rec)) walkRecords(value, visit);
+}
 
 Deno.test("Handlebars Test Run can walk source without a structured target", () => {
   const model = createEmptyModel("narrative");

--- a/test/toolbox_search_test.ts
+++ b/test/toolbox_search_test.ts
@@ -1,0 +1,22 @@
+import { assert, assertEquals } from "@std/assert";
+import { buildDemoToolbox, toolboxBlockTypes } from "@intehrgrator/blockly/toolbox_demo.ts";
+import { msg } from "@intehrgrator/blockly/i18n/custom_msg.ts";
+
+Deno.test("toolbox starts with a search category covering custom drawers", () => {
+  const toolbox = buildDemoToolbox("en") as {
+    contents: Array<{ kind?: string; name?: string }>;
+  };
+  assertEquals(toolbox.contents[0]?.kind, "search");
+  assertEquals(toolbox.contents[0]?.name, msg("en").CAT_SEARCH);
+  const types = toolboxBlockTypes(toolbox);
+  for (const type of [
+    "source_query",
+    "source_query_number",
+    "observation",
+    "maps_create_with",
+    "for_each_source",
+    "text_handlebars",
+  ]) {
+    assert(types.includes(type), `toolbox-search index should include ${type}`);
+  }
+});

--- a/test/ui/mapping_undo_test.ts
+++ b/test/ui/mapping_undo_test.ts
@@ -1,0 +1,62 @@
+/**
+ * Browser UI test: Mapping Editor Undo reverses a Click-to-Map action.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { chromium } from "npm:playwright@1.51.0";
+import {
+  baseUrl,
+  findSystolicSlotId,
+  getSnapshot,
+  loadBpFixtures,
+  waitForMappedSlot,
+  waitForTestApi,
+  clickBlocklyBlock,
+  findElementBlockId,
+} from "./helpers.ts";
+
+Deno.test({
+  name: "UI: undo reverses Click-to-Map and redo restores it",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const page = await browser.newPage();
+      await page.goto(`${baseUrl}/?testMode=1`, { waitUntil: "networkidle" });
+      await waitForTestApi(page);
+      await loadBpFixtures(page);
+
+      const slotId = await findSystolicSlotId(page);
+      const blockId = await findElementBlockId(page, slotId);
+      await clickBlocklyBlock(page, blockId);
+      await page.click('#example-tree .tree-row[data-path="$.systolic"] .tree-label');
+      await waitForMappedSlot(page, slotId);
+
+      const undoEnabled = await page.evaluate(() => {
+        const btn = document.getElementById("btn-undo") as HTMLButtonElement | null;
+        return Boolean(btn && !btn.disabled);
+      });
+      assert(undoEnabled, "Undo should enable after Click-to-Map");
+
+      await page.click("#btn-undo");
+      await page.waitForFunction((id) => {
+        const api = (globalThis as unknown as {
+          intehrgratorTestApi: { getSnapshot(): { model: { slots: Array<{ slotId: string; expression?: string }> } } };
+        }).intehrgratorTestApi;
+        const slot = api.getSnapshot().model.slots.find((s) => s.slotId === id);
+        return !slot?.expression?.includes("systolic");
+      }, slotId, { timeout: 10_000 });
+
+      await page.click("#btn-redo");
+      await waitForMappedSlot(page, slotId);
+      const afterRedo = await getSnapshot(page);
+      assertEquals(
+        Boolean(afterRedo.model.slots.find((s) => s.slotId === slotId)?.expression.includes("systolic")),
+        true,
+      );
+    } finally {
+      await browser.close();
+    }
+  },
+});

--- a/test/ui/mapping_undo_test.ts
+++ b/test/ui/mapping_undo_test.ts
@@ -32,22 +32,52 @@ Deno.test({
       await clickBlocklyBlock(page, blockId);
       await page.click('#example-tree .tree-row[data-path="$.systolic"] .tree-label');
       await waitForMappedSlot(page, slotId);
-
-      const undoEnabled = await page.evaluate(() => {
-        const btn = document.getElementById("btn-undo") as HTMLButtonElement | null;
-        return Boolean(btn && !btn.disabled);
+      const beforeUndo = await page.evaluate(() => {
+        const api = (globalThis as unknown as {
+          intehrgratorTestApi: {
+            undoCount(): number;
+            redoCount(): number;
+            undoEventTypes(): string[];
+          };
+        }).intehrgratorTestApi;
+        const undoBtn = document.getElementById("btn-undo") as HTMLButtonElement | null;
+        return {
+          undo: api.undoCount(),
+          redo: api.redoCount(),
+          types: api.undoEventTypes(),
+          undoDisabled: Boolean(undoBtn?.disabled),
+        };
       });
-      assert(undoEnabled, "Undo should enable after Click-to-Map");
+      if (beforeUndo.undoDisabled || beforeUndo.undo === 0) {
+        throw new Error(`Undo not recorded after Click-to-Map: ${JSON.stringify(beforeUndo)}`);
+      }
+      const canvasSwaps = beforeUndo.types.filter((t) => t === "intehr_canvas_swap");
+      assertEquals(
+        canvasSwaps.length,
+        1,
+        `Click-to-Map should be one undo step, got ${JSON.stringify(beforeUndo)}`,
+      );
 
-      await page.click("#btn-undo");
+      await page.evaluate(() => {
+        (globalThis as unknown as { intehrgratorTestApi: { undo(): void } })
+          .intehrgratorTestApi.undo();
+      });
       await page.waitForFunction((id) => {
         const api = (globalThis as unknown as {
-          intehrgratorTestApi: { getSnapshot(): { model: { slots: Array<{ slotId: string; expression?: string }> } } };
+          intehrgratorTestApi: {
+            getSnapshot(): { model: { slots: Array<{ slotId: string; expression?: string }> } };
+          };
         }).intehrgratorTestApi;
         const slot = api.getSnapshot().model.slots.find((s) => s.slotId === id);
         return !slot?.expression?.includes("systolic");
-      }, slotId, { timeout: 10_000 });
+      }, slotId, { timeout: 10_000 }).catch(() => {
+        throw new Error(`Undo did not clear mapping; before ${JSON.stringify(beforeUndo)}`);
+      });
 
+      await page.waitForFunction(() => {
+        const btn = document.getElementById("btn-redo");
+        return btn instanceof HTMLButtonElement && !btn.disabled;
+      }, { timeout: 5_000 });
       await page.click("#btn-redo");
       await waitForMappedSlot(page, slotId);
       const afterRedo = await getSnapshot(page);

--- a/test/ui/toolbox_search_test.ts
+++ b/test/ui/toolbox_search_test.ts
@@ -3,7 +3,6 @@
  * and the search input is clickable (not covered by the category row).
  */
 
-import { assert, assertEquals } from "@std/assert";
 import { chromium } from "npm:playwright@1.51.0";
 import { baseUrl, loadBpFixtures, waitForTestApi } from "./helpers.ts";
 
@@ -22,29 +21,18 @@ Deno.test({
       const search = page.locator('.blocklyToolboxDiv input[type="search"]');
       await search.waitFor({ timeout: 10_000 });
       await search.click();
-      await search.fill("source_query");
+      await search.pressSequentially("source", { delay: 40 });
       await page.waitForFunction(() => {
         const flyout = document.querySelector(".blocklyFlyout");
         return Boolean(flyout && /source/i.test(flyout.textContent ?? ""));
-      }, { timeout: 5_000 });
-      const sourceFlyout = await page.locator(".blocklyFlyout").innerText();
-      assert(/source/i.test(sourceFlyout), sourceFlyout);
+      }, { timeout: 8_000 });
 
-      await search.fill("maps");
+      await search.fill("");
+      await search.pressSequentially("maps", { delay: 40 });
       await page.waitForFunction(() => {
         const flyout = document.querySelector(".blocklyFlyout");
         return Boolean(flyout && /map/i.test(flyout.textContent ?? ""));
-      }, { timeout: 5_000 });
-      const mapsFlyout = await page.locator(".blocklyFlyout").innerText();
-      assert(/map/i.test(mapsFlyout), mapsFlyout);
-
-      const types = await page.evaluate(() => {
-        const api = (globalThis as unknown as {
-          intehrgratorTestApi: { getSnapshot(): { templateId: string } };
-        }).intehrgratorTestApi;
-        return api.getSnapshot().templateId;
-      });
-      assertEquals(Boolean(types), true);
+      }, { timeout: 8_000 });
     } finally {
       await browser.close();
     }

--- a/test/ui/toolbox_search_test.ts
+++ b/test/ui/toolbox_search_test.ts
@@ -1,0 +1,52 @@
+/**
+ * Browser UI test: toolbox Search indexes custom Source / Maps blocks
+ * and the search input is clickable (not covered by the category row).
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { chromium } from "npm:playwright@1.51.0";
+import { baseUrl, loadBpFixtures, waitForTestApi } from "./helpers.ts";
+
+Deno.test({
+  name: "UI: toolbox Search finds custom Source and Maps blocks",
+  sanitizeResources: false,
+  sanitizeOps: false,
+  async fn() {
+    const browser = await chromium.launch({ headless: true });
+    try {
+      const page = await browser.newPage({ viewport: { width: 1400, height: 900 } });
+      await page.goto(`${baseUrl}/?testMode=1`, { waitUntil: "networkidle" });
+      await waitForTestApi(page);
+      await loadBpFixtures(page);
+
+      const search = page.locator('.blocklyToolboxDiv input[type="search"]');
+      await search.waitFor({ timeout: 10_000 });
+      await search.click();
+      await search.fill("source_query");
+      await page.waitForFunction(() => {
+        const flyout = document.querySelector(".blocklyFlyout");
+        return Boolean(flyout && /source/i.test(flyout.textContent ?? ""));
+      }, { timeout: 5_000 });
+      const sourceFlyout = await page.locator(".blocklyFlyout").innerText();
+      assert(/source/i.test(sourceFlyout), sourceFlyout);
+
+      await search.fill("maps");
+      await page.waitForFunction(() => {
+        const flyout = document.querySelector(".blocklyFlyout");
+        return Boolean(flyout && /map/i.test(flyout.textContent ?? ""));
+      }, { timeout: 5_000 });
+      const mapsFlyout = await page.locator(".blocklyFlyout").innerText();
+      assert(/map/i.test(mapsFlyout), mapsFlyout);
+
+      const types = await page.evaluate(() => {
+        const api = (globalThis as unknown as {
+          intehrgratorTestApi: { getSnapshot(): { templateId: string } };
+        }).intehrgratorTestApi;
+        return api.getSnapshot().templateId;
+      });
+      assertEquals(Boolean(types), true);
+    } finally {
+      await browser.close();
+    }
+  },
+});

--- a/test/workbench_load_test.ts
+++ b/test/workbench_load_test.ts
@@ -318,6 +318,27 @@ Deno.test("mapNodeToSlot promotes indexed JSON paths onto repeating EVENT slots"
   assertEquals(controller.getState().model.loops?.[0]?.path, "$.measurements");
 });
 
+Deno.test("syncFromBlockly empty loops clears previous loops (canvas undo)", async () => {
+  const wt = await Deno.readTextFile(
+    join(
+      import.meta.dirname!,
+      "../vendor/openEHR-model-examples/local/theme-packs/sport-event-details/templates/Accident report including vital signs.wt.json",
+    ),
+  );
+  const controller = new WorkbenchController(stubHost());
+  controller.loadTemplateContent("Accident report including vital signs.wt.json", wt);
+  const rate = collectValueSlots(controller.getState().skeleton).find((s) =>
+    s.slotId.includes("OBSERVATION.pulse.v2") &&
+    s.slotId.includes("items/at0004/") &&
+    s.rmType === "DV_QUANTITY"
+  );
+  assert(rate);
+  controller.mapNodeToSlot(rate.slotId, "$.measurements[1].pulse", "json");
+  assertEquals(controller.getState().model.loops?.[0]?.path, "$.measurements");
+  controller.syncFromBlockly({}, [], [], undefined, { notify: false });
+  assertEquals(controller.getState().model.loops ?? [], []);
+});
+
 Deno.test("controller switches multilingual target ontology language without dropping mappings", async () => {
   const wt = await Deno.readTextFile(
     join(

--- a/web/index.html
+++ b/web/index.html
@@ -139,6 +139,8 @@
       <div class="pane-header">
         <h2>Mapping Editors</h2>
         <div class="pane-header-actions">
+          <button id="btn-undo" class="pane-btn pane-btn-on-dark" type="button" title="Undo last mapping editor action" disabled>Undo</button>
+          <button id="btn-redo" class="pane-btn pane-btn-on-dark" type="button" title="Redo last mapping editor action" disabled>Redo</button>
           <button id="btn-expand-all" class="pane-btn pane-btn-on-dark" type="button" title="Expand all nested blocks">Expand all</button>
           <button id="btn-collapse-all" class="pane-btn pane-btn-on-dark" type="button" title="Collapse all nested blocks">Collapse all</button>
           <button

--- a/web/main.ts
+++ b/web/main.ts
@@ -64,7 +64,7 @@ import { attachWorkspaceMinimap } from "../src/blockly/minimap.ts";
 import { installBlocklyFloatingOverlays } from "../src/blockly/floating_overlays.ts";
 import "../src/blockly/toolbox_search.ts";
 import { installAnchoredMenu } from "../src/ui/anchored_menu.ts";
-import { runWithoutBlocklyEvents, withBlocklyUndoGroup, replaceCanvasUndoable, CANVAS_SWAP_EVENT_TYPE } from "../src/blockly/blockly_events.ts";
+import { runWithoutBlocklyEvents, withBlocklyUndoGroup, replaceCanvasUndoable, CANVAS_SWAP_EVENT_TYPE, setAfterCanvasSwapRun } from "../src/blockly/blockly_events.ts";
 import { refreshWorkspaceConstraints } from "../src/blockly/block_constraints.ts";
 import {
   DOCUMENT_SWAP_EVENT_TYPE,
@@ -347,6 +347,10 @@ async function bootBlockly(): Promise<void> {
 
   attachWorkspaceMinimap(workspace, blocklyMount);
 
+  setAfterCanvasSwapRun(() => {
+    persistBlocklyCanvas();
+  });
+
   setOptionalRmMutatorChangeHandler((change) => {
     withBlocklyUndoGroup(() => {
       const slotId = change.parent.getFieldValue("SLOT_ID") || "";
@@ -397,8 +401,6 @@ async function bootBlockly(): Promise<void> {
     refreshUndoButtons();
     if (event.type === DOCUMENT_SWAP_EVENT_TYPE) return;
     if (event.type === CANVAS_SWAP_EVENT_TYPE) {
-      // Initial fire already applied the canvas; only sync the model on undo/redo.
-      if (!event.recordUndo) persistBlocklyCanvas();
       refreshUndoButtons();
       return;
     }
@@ -506,13 +508,14 @@ function persistBlocklyCanvas(options?: { notify?: boolean }): void {
     derived.slots,
     derived.loops,
     derived.optionalRm,
-    { notify: options?.notify },
+    { notify: false },
   );
   // Track the post-sync model, not the raw canvas extract — applyExpressionEdit
   // can normalize strings, and the next render compares against model.slots.
   const s = controller.getState();
   blocklySlotSignature = slotSignatureFrom(s.model.slots, s.model.loops ?? []);
   refreshUndoButtons();
+  if (options?.notify !== false) controller.notifyChange();
 }
 
 function slotSignatureFrom(
@@ -787,12 +790,9 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
       replaceCanvasUndoable(workspace, () => {
         applyModelExpressions(workspace, s.model);
       });
-      // Align model ← canvas without a nested render (that would fire a second swap).
-      persistBlocklyCanvas({ notify: false });
-    } else {
-      blocklySlotSignature = slotSignature;
-      controller.syncCanvasSnapshot(Blockly.serialization.workspaces.save(workspace));
     }
+    blocklySlotSignature = slotSignature;
+    controller.syncCanvasSnapshot(Blockly.serialization.workspaces.save(workspace));
     refreshUndoButtons();
   }
 

--- a/web/main.ts
+++ b/web/main.ts
@@ -62,7 +62,7 @@ import {
 } from "../src/blockly/mod.ts";
 import { attachWorkspaceMinimap } from "../src/blockly/minimap.ts";
 import { installBlocklyFloatingOverlays } from "../src/blockly/floating_overlays.ts";
-import "../src/blockly/toolbox_search.ts";
+import { installToolboxSearchInputFix } from "../src/blockly/toolbox_search.ts";
 import { installAnchoredMenu } from "../src/ui/anchored_menu.ts";
 import { runWithoutBlocklyEvents, withBlocklyUndoGroup, replaceCanvasUndoable, CANVAS_SWAP_EVENT_TYPE, setAfterCanvasSwapRun } from "../src/blockly/blockly_events.ts";
 import { refreshWorkspaceConstraints } from "../src/blockly/block_constraints.ts";
@@ -346,6 +346,7 @@ async function bootBlockly(): Promise<void> {
   });
 
   attachWorkspaceMinimap(workspace, blocklyMount);
+  installToolboxSearchInputFix(blocklyMount);
 
   setAfterCanvasSwapRun(() => {
     persistBlocklyCanvas();

--- a/web/main.ts
+++ b/web/main.ts
@@ -62,9 +62,17 @@ import {
 } from "../src/blockly/mod.ts";
 import { attachWorkspaceMinimap } from "../src/blockly/minimap.ts";
 import { installBlocklyFloatingOverlays } from "../src/blockly/floating_overlays.ts";
+import "../src/blockly/toolbox_search.ts";
 import { installAnchoredMenu } from "../src/ui/anchored_menu.ts";
-import { runWithoutBlocklyEvents } from "../src/blockly/blockly_events.ts";
+import { runWithoutBlocklyEvents, withBlocklyUndoGroup } from "../src/blockly/blockly_events.ts";
 import { refreshWorkspaceConstraints } from "../src/blockly/block_constraints.ts";
+import {
+  DOCUMENT_SWAP_EVENT_TYPE,
+  fireDocumentSwap,
+  workspaceCanRedo,
+  workspaceCanUndo,
+  type DocumentSnapshot,
+} from "../src/workbench/document_undo.ts";
 import {
   optionalRmInputName,
   presentAttributeNames,
@@ -194,6 +202,9 @@ let blocklySlotSignature = "";
 let toolboxKey = "";
 let ephemeralTreeHighlight: TreeHighlightState | null = null;
 let lastActiveExampleId: string | null = null;
+let suppressBlocklyModelSync = false;
+let applyingDocumentUndo = false;
+let documentReplaceDepth = 0;
 
 function showTextView(view: "mapping-json" | "handlebars"): void {
   activeTextView = view;
@@ -210,7 +221,9 @@ function showTextView(view: "mapping-json" | "handlebars"): void {
 mappingJsonTab.addEventListener("click", () => showTextView("mapping-json"));
 handlebarsTab.addEventListener("click", () => showTextView("handlebars"));
 downloadSpecBtn.addEventListener("click", () => controller.exportBlocklyDefinition());
-uploadSpecBtn?.addEventListener("click", () => void controller.importBlocklyDefinition());
+uploadSpecBtn?.addEventListener("click", () =>
+  void withUndoableDocumentReplace(() => controller.importBlocklyDefinition())
+);
 exportTargetSelect.addEventListener("change", () => {
   const target = exportTargetSelect.value as
     | "preview"
@@ -335,27 +348,29 @@ async function bootBlockly(): Promise<void> {
   attachWorkspaceMinimap(workspace, blocklyMount);
 
   setOptionalRmMutatorChangeHandler((change) => {
-    const slotId = change.parent.getFieldValue("SLOT_ID") || "";
-    const rmType = rmTypeOfBlock(change.parent);
-    for (const name of change.removed) {
-      if (slotId) controller.removeOptionalRm(slotId, name);
-    }
-    for (const name of change.added) {
-      const present = presentAttributeNames(change.parent).filter((attr) => attr !== name);
-      const options = controller.getOptionalAttachmentsFor(rmType, slotId, present);
-      const picked = options.find((option) => option.attributeName === name) ?? {
-        attributeName: name,
-        rmType: slotRmTypeForAttr(rmType, name) || name,
-        label: name,
-        cardinality: { min: 0, max: 1 },
-      };
-      if (slotId) controller.addOptionalRm(slotId, picked.rmType, name);
-      const input = change.parent.getInput(optionalRmInputName(name)) ??
-        change.parent.getInput(rmAttributeInputName(name));
-      if (!input?.connection?.targetBlock()) {
-        attachOptionalRmChild(workspace, change.parent, picked);
+    withBlocklyUndoGroup(() => {
+      const slotId = change.parent.getFieldValue("SLOT_ID") || "";
+      const rmType = rmTypeOfBlock(change.parent);
+      for (const name of change.removed) {
+        if (slotId) controller.removeOptionalRm(slotId, name);
       }
-    }
+      for (const name of change.added) {
+        const present = presentAttributeNames(change.parent).filter((attr) => attr !== name);
+        const options = controller.getOptionalAttachmentsFor(rmType, slotId, present);
+        const picked = options.find((option) => option.attributeName === name) ?? {
+          attributeName: name,
+          rmType: slotRmTypeForAttr(rmType, name) || name,
+          label: name,
+          cardinality: { min: 0, max: 1 },
+        };
+        if (slotId) controller.addOptionalRm(slotId, picked.rmType, name);
+        const input = change.parent.getInput(optionalRmInputName(name)) ??
+          change.parent.getInput(rmAttributeInputName(name));
+        if (!input?.connection?.targetBlock()) {
+          attachOptionalRmChild(workspace, change.parent, picked);
+        }
+      }
+    });
   });
 
   workspace.configureContextMenu = (options) => {
@@ -379,6 +394,8 @@ async function bootBlockly(): Promise<void> {
   initBlocklySourceDrop();
 
   workspace.addChangeListener((event) => {
+    refreshUndoButtons();
+    if (event.type === DOCUMENT_SWAP_EVENT_TYPE) return;
     if (event.type === Blockly.Events.CLICK) {
       const blockId = "blockId" in event && typeof event.blockId === "string"
         ? event.blockId
@@ -396,19 +413,15 @@ async function bootBlockly(): Promise<void> {
       const block = workspace.getBlockById(event.blockId);
       const next = String((event as { newValue?: unknown }).newValue ?? "");
       if (block && (isEventFamilyType(next) || next === "EVENT")) {
-        applyEventRmType(block, next);
+        withBlocklyUndoGroup(() => applyEventRmType(block, next));
       }
     }
     if (event.type !== Blockly.Events.FINISHED_LOADING && !event.isUiEvent) {
       refreshWorkspaceConstraints(workspace);
     }
     if (event.type === Blockly.Events.FINISHED_LOADING || event.isUiEvent) return;
-    const derived = workspaceToModelJson(workspace);
-    controller.syncFromBlockly(
-      Blockly.serialization.workspaces.save(workspace),
-      derived.slots,
-      derived.loops,
-    );
+    if (suppressBlocklyModelSync || applyingDocumentUndo) return;
+    persistBlocklyCanvas();
   });
 }
 
@@ -486,7 +499,88 @@ function persistBlocklyCanvas(): void {
     Blockly.serialization.workspaces.save(workspace),
     derived.slots,
     derived.loops,
+    derived.optionalRm,
   );
+  blocklySlotSignature = slotSignatureFrom(derived.slots, derived.loops);
+  refreshUndoButtons();
+}
+
+function slotSignatureFrom(
+  slots: Array<{ slotId: string; expression: string }>,
+  loops: Array<{ attachSlotId: string; varName: string; path: string }>,
+): string {
+  return [
+    ...slots.map((slot) => `${slot.slotId}=${slot.expression}`),
+    ...loops.map((loop) => `loop:${loop.attachSlotId}=${loop.varName}@${loop.path}`),
+  ].join("|");
+}
+
+function refreshUndoButtons(): void {
+  const undoBtn = document.getElementById("btn-undo") as HTMLButtonElement | null;
+  const redoBtn = document.getElementById("btn-redo") as HTMLButtonElement | null;
+  if (!workspace || !undoBtn || !redoBtn) return;
+  undoBtn.disabled = !workspaceCanUndo(workspace);
+  redoBtn.disabled = !workspaceCanRedo(workspace);
+}
+
+function restoreDocumentFromUndo(snapshot: DocumentSnapshot): void {
+  applyingDocumentUndo = true;
+  try {
+    controller.restoreDocumentSnapshot(snapshot);
+  } finally {
+    applyingDocumentUndo = false;
+    refreshUndoButtons();
+  }
+}
+
+function withUndoableDocumentReplace<T>(fn: () => T | Promise<T>): Promise<T> {
+  const run = (): T | Promise<T> => fn();
+  if (applyingDocumentUndo || !workspace) {
+    try {
+      return Promise.resolve(run() as T);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  }
+  const nested = documentReplaceDepth > 0;
+  documentReplaceDepth++;
+  const before = nested ? null : controller.exportDocumentSnapshot();
+  const finish = () => {
+    documentReplaceDepth--;
+    if (!nested && before) {
+      fireDocumentSwap(
+        workspace,
+        before,
+        controller.exportDocumentSnapshot(),
+        restoreDocumentFromUndo,
+      );
+      refreshUndoButtons();
+    }
+  };
+  try {
+    const result = run();
+    if (isThenable(result)) {
+      return Promise.resolve(result).then(
+        (value) => {
+          finish();
+          return value as T;
+        },
+        (err) => {
+          finish();
+          throw err;
+        },
+      );
+    }
+    finish();
+    return Promise.resolve(result);
+  } catch (err) {
+    finish();
+    return Promise.reject(err);
+  }
+}
+
+function isThenable(value: unknown): value is Promise<unknown> {
+  return Boolean(value) && typeof (value as { then?: unknown }).then === "function";
 }
 
 function collectConstraintWarnings(): Record<string, string> {
@@ -627,12 +721,7 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
   }
 
   const skeletonKey = `${s.projectId}|${s.templateId}|${s.skeleton.length}|${s.blocklyReloadToken}`;
-  const slotSignature = [
-    ...s.model.slots.map((slot) => `${slot.slotId}=${slot.expression}`),
-    ...(s.model.loops ?? []).map((loop) =>
-      `loop:${loop.attachSlotId}=${loop.varName}@${loop.path}`
-    ),
-  ].join("|");
+  const slotSignature = slotSignatureFrom(s.model.slots, s.model.loops ?? []);
   const labelLanguage = s.modelLanguage ?? "";
 
   if (skeletonKey !== blocklySkeletonKey) {
@@ -657,6 +746,7 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
           Blockly.serialization.workspaces.save(workspace),
           derived.slots,
           derived.loops,
+          derived.optionalRm,
         );
       }
       applyPendingDefaultsMap();
@@ -681,13 +771,20 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
   }
 
   if (slotSignature !== blocklySlotSignature) {
-    applyModelExpressions(workspace, s.model);
+    suppressBlocklyModelSync = true;
+    try {
+      withBlocklyUndoGroup(() => {
+        applyModelExpressions(workspace, s.model, { recordUndo: true });
+      });
+    } finally {
+      suppressBlocklyModelSync = false;
+    }
     blocklySlotSignature = slotSignature;
-    // applyModelExpressions suppresses Blockly events, so the usual
-    // change-listener → syncFromBlockly → refreshDerived path never runs.
-    // Snapshot the updated canvas so Generated conversion script(s) picks
-    // up Import Suggestions / Spec edits that only changed the Mapping Model.
+    // applyModelExpressions with recordUndo does not run the change-listener
+    // sync path; snapshot the canvas so Generated conversion script(s) picks
+    // up Import Suggestions / model-first Click-to-Map.
     controller.syncCanvasSnapshot(Blockly.serialization.workspaces.save(workspace));
+    refreshUndoButtons();
   }
 
   highlightListeningSlot(workspace, s.listeningSlotId, s.listeningSourceBlockId);
@@ -759,8 +856,8 @@ installUrlLoadUi({
       main: requireEl<HTMLButtonElement>("btn-open-template"),
       chevron: requireEl<HTMLButtonElement>("btn-open-template-menu"),
       menu: requireEl("menu-open-template"),
-      fromFile: () => controller.openTemplate(),
-      fromUrl: (url) => controller.openTemplateFromUrl(url),
+      fromFile: () => withUndoableDocumentReplace(() => controller.openTemplate()),
+      fromUrl: (url) => withUndoableDocumentReplace(() => controller.openTemplateFromUrl(url)),
       title: "Open target from URL",
       hint: "OPT, Web Template, JSON Schema, or a GitHub .t.json. GitHub file pages are converted to raw content.",
       placeholder: "https://github.com/Ehrlibs/openEHR-model-examples/blob/main/local/…",
@@ -775,6 +872,14 @@ installUrlLoadUi({
   },
 });
 
+bind("btn-undo", () => {
+  workspace.undo(false);
+  refreshUndoButtons();
+});
+bind("btn-redo", () => {
+  workspace.undo(true);
+  refreshUndoButtons();
+});
 bind("btn-expand-all", () => {
   setAllBlocksCollapsed(workspace, false);
   Blockly.svgResize(workspace);
@@ -828,7 +933,7 @@ bind("btn-new-project", () => void handleNewProject());
 bind("btn-load-project", () => void openLoadProjectDialog());
 bind("btn-save-project", () => openSaveAsDialog());
 bind("btn-export-project", () => controller.exportProject());
-bind("btn-import-project", () => controller.importProject());
+bind("btn-import-project", () => void withUndoableDocumentReplace(() => controller.importProject()));
 bind("btn-copy-ai", () => controller.copyAiPrompt(lastAiDelivery()));
 installImportAiDialog({
   dialog: requireEl<HTMLDialogElement>("dialog-import-ai"),
@@ -923,7 +1028,7 @@ function installExampleSetsMenu(): void {
     if (!confirmReplace()) return;
     void (async () => {
       try {
-        await controller.loadExampleSet(set);
+        await withUndoableDocumentReplace(() => controller.loadExampleSet(set));
       } catch {
         // Status bar already has the error.
       }
@@ -1320,10 +1425,12 @@ function handleNewProject(): void {
     ? "Start a new project? The current workspace will be cleared. Unsaved changes may be lost."
     : "Start a new empty project?";
   if (!confirm(message)) return;
-  controller.newProject();
-  resetBlocklyView();
-  ephemeralTreeHighlight = null;
-  lastActiveExampleId = null;
+  void withUndoableDocumentReplace(() => {
+    controller.newProject();
+    resetBlocklyView();
+    ephemeralTreeHighlight = null;
+    lastActiveExampleId = null;
+  });
 }
 
 function openSaveAsDialog(): void {
@@ -1364,7 +1471,7 @@ async function openLoadProjectDialog(): Promise<void> {
           ) {
             return;
           }
-          await controller.loadStoredProject(entry.storageKey);
+          await withUndoableDocumentReplace(() => controller.loadStoredProject(entry.storageKey));
           resetBlocklyView();
           ephemeralTreeHighlight = null;
         })();
@@ -1497,6 +1604,7 @@ function render(): void {
   const autoplayBtn = document.getElementById("btn-autoplay") as HTMLButtonElement;
   autoplayBtn.disabled = !s.examples.length;
   autoplayBtn.textContent = s.settings.autoplay ? "⏸ Pause" : "▶ Autoplay";
+  refreshUndoButtons();
 }
 
 function formatTestOutput(output: unknown): string {
@@ -1610,7 +1718,7 @@ function installWorkbenchTestApi(): void {
   const api: IntehrgratorTestApi = {
     ready: () => workbenchReady,
     loadTemplate(filename, content) {
-      controller.loadTemplateContent(filename, content);
+      void withUndoableDocumentReplace(() => controller.loadTemplateContent(filename, content));
     },
     loadSchema(filename, content) {
       controller.loadSchemaContent(filename, content);
@@ -1684,7 +1792,7 @@ function installWorkbenchTestApi(): void {
       return mappingSpecDocumentText(specEditor);
     },
     loadBlocklyJson(filename, content) {
-      controller.loadBlocklyDefinition(filename, content);
+      void withUndoableDocumentReplace(() => controller.loadBlocklyDefinition(filename, content));
     },
     getBlockClientRect(blockId) {
       const block = workspace.getBlockById(blockId) as BlockSvg | null;
@@ -1711,6 +1819,20 @@ function installWorkbenchTestApi(): void {
     setOptionalRmExtras(blockId, names) {
       const block = workspace.getBlockById(blockId);
       if (block) composeOptionalRmExtras(block, names);
+    },
+    undo() {
+      workspace.undo(false);
+      refreshUndoButtons();
+    },
+    redo() {
+      workspace.undo(true);
+      refreshUndoButtons();
+    },
+    undoCount() {
+      return workspace.getUndoStack?.()?.length ?? 0;
+    },
+    redoCount() {
+      return workspace.getRedoStack?.()?.length ?? 0;
     },
   };
   // Some test helpers look for `globalThis.intehrgratorTestApi` rather than

--- a/web/main.ts
+++ b/web/main.ts
@@ -64,7 +64,7 @@ import { attachWorkspaceMinimap } from "../src/blockly/minimap.ts";
 import { installBlocklyFloatingOverlays } from "../src/blockly/floating_overlays.ts";
 import "../src/blockly/toolbox_search.ts";
 import { installAnchoredMenu } from "../src/ui/anchored_menu.ts";
-import { runWithoutBlocklyEvents, withBlocklyUndoGroup } from "../src/blockly/blockly_events.ts";
+import { runWithoutBlocklyEvents, withBlocklyUndoGroup, replaceCanvasUndoable, CANVAS_SWAP_EVENT_TYPE } from "../src/blockly/blockly_events.ts";
 import { refreshWorkspaceConstraints } from "../src/blockly/block_constraints.ts";
 import {
   DOCUMENT_SWAP_EVENT_TYPE,
@@ -396,6 +396,12 @@ async function bootBlockly(): Promise<void> {
   workspace.addChangeListener((event) => {
     refreshUndoButtons();
     if (event.type === DOCUMENT_SWAP_EVENT_TYPE) return;
+    if (event.type === CANVAS_SWAP_EVENT_TYPE) {
+      // Initial fire already applied the canvas; only sync the model on undo/redo.
+      if (!event.recordUndo) persistBlocklyCanvas();
+      refreshUndoButtons();
+      return;
+    }
     if (event.type === Blockly.Events.CLICK) {
       const blockId = "blockId" in event && typeof event.blockId === "string"
         ? event.blockId
@@ -493,15 +499,19 @@ function handleSourceSelection(
   controller.bindFromNode(path, format);
 }
 
-function persistBlocklyCanvas(): void {
+function persistBlocklyCanvas(options?: { notify?: boolean }): void {
   const derived = workspaceToModelJson(workspace);
   controller.syncFromBlockly(
     Blockly.serialization.workspaces.save(workspace),
     derived.slots,
     derived.loops,
     derived.optionalRm,
+    { notify: options?.notify },
   );
-  blocklySlotSignature = slotSignatureFrom(derived.slots, derived.loops);
+  // Track the post-sync model, not the raw canvas extract — applyExpressionEdit
+  // can normalize strings, and the next render compares against model.slots.
+  const s = controller.getState();
+  blocklySlotSignature = slotSignatureFrom(s.model.slots, s.model.loops ?? []);
   refreshUndoButtons();
 }
 
@@ -771,19 +781,18 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
   }
 
   if (slotSignature !== blocklySlotSignature) {
-    suppressBlocklyModelSync = true;
-    try {
-      withBlocklyUndoGroup(() => {
-        applyModelExpressions(workspace, s.model, { recordUndo: true });
+    const derived = workspaceToModelJson(workspace);
+    const canvasSig = slotSignatureFrom(derived.slots, derived.loops);
+    if (canvasSig !== slotSignature) {
+      replaceCanvasUndoable(workspace, () => {
+        applyModelExpressions(workspace, s.model);
       });
-    } finally {
-      suppressBlocklyModelSync = false;
+      // Align model ← canvas without a nested render (that would fire a second swap).
+      persistBlocklyCanvas({ notify: false });
+    } else {
+      blocklySlotSignature = slotSignature;
+      controller.syncCanvasSnapshot(Blockly.serialization.workspaces.save(workspace));
     }
-    blocklySlotSignature = slotSignature;
-    // applyModelExpressions with recordUndo does not run the change-listener
-    // sync path; snapshot the canvas so Generated conversion script(s) picks
-    // up Import Suggestions / model-first Click-to-Map.
-    controller.syncCanvasSnapshot(Blockly.serialization.workspaces.save(workspace));
     refreshUndoButtons();
   }
 
@@ -1560,11 +1569,18 @@ function render(): void {
       ? "Select an example tab."
       : 'Add example instance(s) to enable "Conversion Test Run(s)" in Target & Previews';
   }
-  syncBlocklyWorkspace(s);
+  // Constraint warning-text events must not persist/re-render during this
+  // pass — that used to stack a second canvas-swap on Click-to-Map.
+  suppressBlocklyModelSync = true;
+  try {
+    syncBlocklyWorkspace(s);
+    refreshWorkspaceConstraints(workspace);
+    highlightListeningSlot(workspace, controller.getState().listeningSlotId, controller.getState().listeningSourceBlockId);
+  } finally {
+    suppressBlocklyModelSync = false;
+  }
   // Blockly apply may have refreshed generatedCode without a re-render.
   const afterCanvas = controller.getState();
-  refreshWorkspaceConstraints(workspace);
-  highlightListeningSlot(workspace, afterCanvas.listeningSlotId, afterCanvas.listeningSourceBlockId);
 
   setMappingSpecFromBlockly(
     specEditor,
@@ -1718,7 +1734,7 @@ function installWorkbenchTestApi(): void {
   const api: IntehrgratorTestApi = {
     ready: () => workbenchReady,
     loadTemplate(filename, content) {
-      void withUndoableDocumentReplace(() => controller.loadTemplateContent(filename, content));
+      controller.loadTemplateContent(filename, content);
     },
     loadSchema(filename, content) {
       controller.loadSchemaContent(filename, content);
@@ -1792,7 +1808,7 @@ function installWorkbenchTestApi(): void {
       return mappingSpecDocumentText(specEditor);
     },
     loadBlocklyJson(filename, content) {
-      void withUndoableDocumentReplace(() => controller.loadBlocklyDefinition(filename, content));
+      controller.loadBlocklyDefinition(filename, content);
     },
     getBlockClientRect(blockId) {
       const block = workspace.getBlockById(blockId) as BlockSvg | null;
@@ -1833,6 +1849,9 @@ function installWorkbenchTestApi(): void {
     },
     redoCount() {
       return workspace.getRedoStack?.()?.length ?? 0;
+    },
+    undoEventTypes() {
+      return (workspace.getUndoStack?.() ?? []).map((event) => String(event.type ?? ""));
     },
   };
   // Some test helpers look for `globalThis.intehrgratorTestApi` rather than

--- a/web/main.ts
+++ b/web/main.ts
@@ -346,7 +346,7 @@ async function bootBlockly(): Promise<void> {
   });
 
   attachWorkspaceMinimap(workspace, blocklyMount);
-  installToolboxSearchInputFix(blocklyMount);
+  installToolboxSearchInputFix(blocklyMount, () => workspace);
 
   setAfterCanvasSwapRun(() => {
     persistBlocklyCanvas();

--- a/web/styles.css
+++ b/web/styles.css
@@ -437,8 +437,12 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
   min-height: 36px !important;
   line-height: 36px !important;
   border-left: 15px solid #5f6368 !important;
+  pointer-events: none;
 }
 .blockly-mount .blocklyToolboxDiv input[type="search"] {
+  pointer-events: auto;
+  position: relative;
+  z-index: 2;
   width: calc(100% - 12px);
   height: 24px;
   margin: 6px;

--- a/web/styles.css
+++ b/web/styles.css
@@ -428,6 +428,21 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
 .blockly-mount .blocklyToolboxCategoryLabel {
   font-family: "Google Sans", "Segoe UI", sans-serif !important;
 }
+.blockly-mount .blocklyToolboxCategorySearch {
+  height: auto;
+  min-height: 28px;
+  line-height: 28px;
+  border-left: 15px solid #5f6368 !important;
+}
+.blockly-mount .blocklyToolboxDiv input[type="search"] {
+  width: calc(100% - 12px);
+  margin: 4px 6px;
+  box-sizing: border-box;
+  font: 12px/1.3 "Google Sans", "Segoe UI", sans-serif;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
 .blockly-mount .blocklyToolboxCategorySource {
   border-left: 15px solid #e87722 !important;
 }
@@ -587,6 +602,9 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
 }
 
 /* Mapping Spec: inline widgets must not inflate CodeMirror's line box. */
+#spec-editor .cm-editor {
+  position: relative;
+}
 #spec-editor .cm-content,
 #spec-editor .cm-line,
 #spec-editor .cm-gutters,

--- a/web/styles.css
+++ b/web/styles.css
@@ -101,13 +101,16 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
 .pane-header {
   display: flex; align-items: center; justify-content: space-between; gap: 8px;
   padding: 8px 12px; background: var(--primary); color: #fff; flex-shrink: 0;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 .pane-header h2 {
   margin: 0; padding: 0; background: none; font-size: 14px; min-width: 0;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.pane-header-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.pane-header-actions {
+  display: flex; align-items: center; gap: 6px; flex-shrink: 0; flex-wrap: wrap;
+  max-width: 100%;
+}
 .pane-select-label {
   display: inline-flex; align-items: center; gap: 5px; font-size: 11px;
   color: rgba(255, 255, 255, 0.9); white-space: nowrap;
@@ -428,15 +431,17 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
 .blockly-mount .blocklyToolboxCategoryLabel {
   font-family: "Google Sans", "Segoe UI", sans-serif !important;
 }
-.blockly-mount .blocklyToolboxCategorySearch {
-  height: auto;
-  min-height: 28px;
-  line-height: 28px;
+.blockly-mount .blocklyToolboxCategorySearch,
+.blockly-mount .blocklyToolboxCategory:has(input[type="search"]) {
+  height: auto !important;
+  min-height: 36px !important;
+  line-height: 36px !important;
   border-left: 15px solid #5f6368 !important;
 }
 .blockly-mount .blocklyToolboxDiv input[type="search"] {
   width: calc(100% - 12px);
-  margin: 4px 6px;
+  height: 24px;
+  margin: 6px;
   box-sizing: border-box;
   font: 12px/1.3 "Google Sans", "Segoe UI", sans-serif;
   padding: 2px 6px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

GitHub Pages never deployed Chunk 1 because `deno task test` failed in CI. Silent-mandatory LOCATABLE children (`archetype_node_id` / `name`) overwrote identity with `DV_TEXT` objects, so Test Run pulse EVENT expansion found 0 events.

Chunk 2 then lands the remaining Mapping Editor chrome from the roadmap, using the user’s grill answers: canvas undo is the single history, toolbox search covers custom drawers, and the Mapping Spec right-hand ticks are the same constraint warnings as Blockly triangles.

## What changed

- **CI / Pages:** Test Run renderer skips auto-fixed LOCATABLE slots so `archetype_node_id` stays a string.
- **Undo/Redo:** Mapping Editors header buttons. Spec widget edits, Click-to-Map, and cogwheel add/remove are Blockly events grouped as one user action. Open template / Example Sets / Load Project / New project / Import are one document-swap undo step. Save / Export do not push undo.
- **Click-to-Map undo:** one `intehr_canvas_swap` per map. Undo persists the restored canvas into the Mapping Model; Redo remaps. Canvas loops are source of truth, so undoing a repeating map also clears `loops[]`.
- **Toolbox search:** `@blockly/toolbox-search@2.0.16` with `{ kind: "search" }` at the top. Custom Source / openEHR types / Maps blocks are ordinary toolbox `kind: "block"` entries, so the plugin indexes them. The Search input is clickable (category row no longer swallows pointer events).
- **Mapping Spec overview:** orange ticks on the right scroller from the same constraint warnings as Blockly triangles; click selects/pans like a spec row.

## How to test

1. After CI is green, the demo at https://regionstockholm.github.io/intehrgrator/ should update (once this is on `main`).
2. Open a template, Click-to-Map a slot, then **Undo** / **Redo**. One Undo should unmap; Redo remaps.
3. Open toolbox **Search** and type `source` or `maps`.
4. Trigger a constraint warning and confirm orange ticks on the Mapping Spec right edge; click a tick to select the block.

[Undo and Redo in the Mapping Editors header](https://cursor.com/agents/bc-79b41d92-3024-460a-8b42-1211c5877430/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmapping_editors_header.png)
[Toolbox Search listing custom Source blocks](https://cursor.com/agents/bc-79b41d92-3024-460a-8b42-1211c5877430/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoolbox_search_source.png)
[Mapping Spec overview ticks for constraint warnings](https://cursor.com/agents/bc-79b41d92-3024-460a-8b42-1211c5877430/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspec_ticks_unmapped.png)
[mapping_editor_undo_search_spec_ticks.mp4](https://cursor.com/agents/bc-79b41d92-3024-460a-8b42-1211c5877430/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmapping_editor_undo_search_spec_ticks.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79b41d92-3024-460a-8b42-1211c5877430?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79b41d92-3024-460a-8b42-1211c5877430&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

