### PR TITLE
Improve cogwheel mutator UX: per-option flyout and header placement

### DIFF
--- a/src/blockly/blocks/rm_blocks.ts
+++ b/src/blockly/blocks/rm_blocks.ts
@@ -35,6 +35,15 @@ import {
   type SlotCardinality,
 } from "../slot_cardinality.ts";
 import { registerTermPickBlock } from "./term_pick.ts";
+import {
+  appendMutatorCogwheel,
+  namesFromMutatorStack,
+  openBlockMutator,
+  registerDynamicFlyoutMutator,
+  type MutatorFlyoutBlock,
+} from "../dynamic_mutator.ts";
+
+export { openBlockMutator };
 
 export const EVENT_KIND_OPTIONS: Array<[string, string]> = [
   ["EVENT", "EVENT"],
@@ -721,6 +730,7 @@ function defineContainerBlock(
         this.setFieldValue(options.rmType, "RM_TYPE");
       }
       header.appendField(new FieldSkeletonTitle(options.rmType), "NAME");
+      if (options.expandable) appendMutatorCogwheel(header);
       if (options.specializationCheck) {
         const kind = this.appendValueInput(RM_SPECIALIZATION_INPUT);
         kind.setCheck(options.specializationCheck);
@@ -767,6 +777,7 @@ function defineValueElementBlock(): void {
       const header = this.appendDummyInput("HEADER");
       appendBlockOutputEmoji(header, "ELEMENT");
       header.appendField(new FieldSkeletonTitle("ELEMENT"), "NAME");
+      appendMutatorCogwheel(header);
       const value = this.appendValueInput("VALUE")
         .setCheck(null)
         .appendField("value");
@@ -810,6 +821,9 @@ function defineDataValueBlock(rmType: string): void {
       const header = this.appendDummyInput("HEADER");
       appendBlockOutputEmoji(header, rmType);
       header.appendField(new FieldSkeletonTitle(rmType, humanizeRmType(rmType)), "NAME");
+      if (optionalAttributes(rmType).some((a) => isMappableField(a))) {
+        appendMutatorCogwheel(header);
+      }
       this.appendDummyInput()
         .appendField(new Blockly.FieldLabelSerializable(""), "SLOT_ID");
       this.getField("SLOT_ID")!.setVisible(false);
@@ -865,26 +879,6 @@ export function setOptionalRmPickHandler(
   // Cogwheel mutator replaced the + picker.
 }
 
-/** Open the native Blockly mutator bubble (cogwheel) when the icon exists. */
-export function openBlockMutator(block: Blockly.Block): void {
-  const icons = Blockly.icons as {
-    MutatorIcon?: { TYPE?: unknown };
-  };
-  const type = icons.MutatorIcon?.TYPE;
-  const svg = block as Blockly.Block & {
-    getIcon?: (iconType: unknown) => { setBubbleVisible?: (visible: boolean) => void } | null;
-    getIcons?: () => Array<{ setBubbleVisible?: (visible: boolean) => void }>;
-  };
-  const named = type != null ? svg.getIcon?.(type) : null;
-  if (named?.setBubbleVisible) {
-    named.setBubbleVisible(true);
-    return;
-  }
-  for (const icon of svg.getIcons?.() ?? []) {
-    icon.setBubbleVisible?.(true);
-  }
-}
-
 /** Apply a mutator stack of optional RM extras (used by tests and the workbench seam). */
 export function composeOptionalRmExtras(block: Blockly.Block, names: string[]): void {
   if (!block.decompose || !block.compose) return;
@@ -901,7 +895,7 @@ export function composeOptionalRmExtras(block: Blockly.Block, names: string[]): 
     for (const name of names) {
       const quark = bubble.newBlock(OPTIONAL_RM_MUTATOR_ITEM);
       initSvgIfPresent(quark);
-      if (name) quark.setFieldValue(name, "ATTR");
+      if (name) applyMutatorItemLabel(quark, name, name);
       if (connection && quark.previousConnection) {
         connection.connect(quark.previousConnection);
         connection = quark.nextConnection;
@@ -1033,37 +1027,90 @@ function optionalRmMutatorChoices(block: Blockly.Block): Array<[string, string]>
   return rows.length ? rows : [["(none)", ""]];
 }
 
+function humanizeAttrName(name: string): string {
+  return name
+    .split("_")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
 function optionalDvFieldChoices(block: Blockly.Block): Array<[string, string]> {
   const rmType = block.getFieldValue("RM_TYPE");
   const rows = optionalAttributes(rmType)
     .filter((a) => isMappableField(a))
-    .map((a) => [a.name, a.name] as [string, string]);
+    .map((a) => [humanizeAttrName(a.name), a.name] as [string, string]);
   return rows.length ? rows : [["(none)", ""]];
 }
 
-function mutatorWorkspacesOf(item: Blockly.Block): Blockly.Workspace[] {
-  const seen: Blockly.Workspace[] = [];
-  let workspace: Blockly.Workspace | null | undefined = item.workspace;
-  while (workspace && !seen.includes(workspace)) {
-    seen.push(workspace);
-    workspace = (workspace as Blockly.WorkspaceSvg).targetWorkspace ?? null;
-  }
-  return seen;
+export function applyMutatorItemLabel(
+  item: Blockly.Block,
+  attr: string,
+  label: string,
+): void {
+  item.setFieldValue(label, "LABEL");
+  item.setFieldValue(attr, "ATTR");
 }
 
-function mutatorWorkspaceChoices(
-  item: Blockly.Block | null,
-  containerType: string,
-): Array<[string, string]> {
-  if (!item) return [["(none)", ""]];
-  for (const workspace of mutatorWorkspacesOf(item)) {
-    for (const top of workspace.getTopBlocks(false)) {
-      if (top.type === containerType && top.mutatorChoices_?.length) {
-        return top.mutatorChoices_;
-      }
-    }
-  }
-  return [["(none)", ""]];
+export function buildOptionalRmFlyoutContents(
+  block: Blockly.Block,
+  stackNames: string[],
+): MutatorFlyoutBlock[] {
+  return optionalRmMutatorChoices(block)
+    .filter(([, name]) => name && name !== "(none)")
+    .filter(([, name]) => !stackNames.includes(name))
+    .map(([label, name]) => ({
+      kind: "block" as const,
+      type: OPTIONAL_RM_MUTATOR_ITEM,
+      extraState: { attr: name, label },
+    }));
+}
+
+function buildOptionalDvFlyoutContents(
+  block: Blockly.Block,
+  stackNames: string[],
+): MutatorFlyoutBlock[] {
+  return optionalDvFieldChoices(block)
+    .filter(([, name]) => name && name !== "(none)")
+    .filter(([, name]) => !stackNames.includes(name))
+    .map(([label, name]) => ({
+      kind: "block" as const,
+      type: DV_FIELDS_MUTATOR_ITEM,
+      extraState: { attr: name, label },
+    }));
+}
+
+function defineMutatorItemBlock(type: string, colour: string): void {
+  if (Blockly.Blocks[type]) return;
+  Blockly.Blocks[type] = {
+    init: function (this: Blockly.Block) {
+      this.appendDummyInput().appendField(
+        new Blockly.FieldLabelSerializable(""),
+        "LABEL",
+      );
+      this.appendDummyInput()
+        .appendField(new Blockly.FieldLabelSerializable(""), "ATTR");
+      this.getField("ATTR")!.setVisible(false);
+      this.setPreviousStatement(true);
+      this.setNextStatement(true);
+      this.setColour(colour);
+      this.contextMenu = false;
+    },
+    loadExtraState: function (
+      this: Blockly.Block,
+      state: { attr?: string; label?: string },
+    ) {
+      const attr = state?.attr ?? "";
+      const label = state?.label ?? attr;
+      this.setFieldValue(label, "LABEL");
+      this.setFieldValue(attr, "ATTR");
+    },
+    saveExtraState: function (this: Blockly.Block) {
+      return {
+        attr: String(this.getFieldValue("ATTR") || ""),
+        label: String(this.getFieldValue("LABEL") || ""),
+      };
+    },
+  };
 }
 
 function initSvgIfPresent(block: Blockly.Block): void {
@@ -1090,20 +1137,7 @@ function defineOptionalMutatorQuarks(): void {
       },
     };
   }
-  if (!Blockly.Blocks[OPTIONAL_RM_MUTATOR_ITEM]) {
-    Blockly.Blocks[OPTIONAL_RM_MUTATOR_ITEM] = {
-      init: function (this: Blockly.Block) {
-        const menu = new Blockly.FieldDropdown(() =>
-          mutatorWorkspaceChoices(this, OPTIONAL_RM_MUTATOR_CONTAINER)
-        );
-        this.appendDummyInput().appendField(menu, "ATTR");
-        this.setPreviousStatement(true);
-        this.setNextStatement(true);
-        this.setColour(CONTAINER_COLOUR);
-        this.contextMenu = false;
-      },
-    };
-  }
+  defineMutatorItemBlock(OPTIONAL_RM_MUTATOR_ITEM, CONTAINER_COLOUR);
   if (!Blockly.Blocks[DV_FIELDS_MUTATOR_CONTAINER]) {
     Blockly.Blocks[DV_FIELDS_MUTATOR_CONTAINER] = {
       init: function (this: Blockly.Block) {
@@ -1114,20 +1148,7 @@ function defineOptionalMutatorQuarks(): void {
       },
     };
   }
-  if (!Blockly.Blocks[DV_FIELDS_MUTATOR_ITEM]) {
-    Blockly.Blocks[DV_FIELDS_MUTATOR_ITEM] = {
-      init: function (this: Blockly.Block) {
-        const menu = new Blockly.FieldDropdown(() =>
-          mutatorWorkspaceChoices(this, DV_FIELDS_MUTATOR_CONTAINER)
-        );
-        this.appendDummyInput().appendField(menu, "ATTR");
-        this.setPreviousStatement(true);
-        this.setNextStatement(true);
-        this.setColour(DV_COLOUR);
-        this.contextMenu = false;
-      },
-    };
-  }
+  defineMutatorItemBlock(DV_FIELDS_MUTATOR_ITEM, DV_COLOUR);
 }
 
 function stackMutatorItems(
@@ -1135,16 +1156,15 @@ function stackMutatorItems(
   containerType: string,
   itemType: string,
   names: string[],
-  choices: Array<[string, string]>,
+  labels: Map<string, string>,
 ): Blockly.Block {
   const container = workspace.newBlock(containerType);
-  container.mutatorChoices_ = choices;
   initSvgIfPresent(container);
   let connection = container.getInput("STACK")?.connection ?? null;
   for (const name of names) {
     const item = workspace.newBlock(itemType);
     initSvgIfPresent(item);
-    if (name) item.setFieldValue(name, "ATTR");
+    if (name) applyMutatorItemLabel(item, name, labels.get(name) ?? name);
     if (connection && item.previousConnection) {
       connection.connect(item.previousConnection);
       connection = item.nextConnection;
@@ -1153,26 +1173,15 @@ function stackMutatorItems(
   return container;
 }
 
-function namesFromMutatorStack(container: Blockly.Block): string[] {
-  const names: string[] = [];
-  let item: Blockly.Block | null = container.getInputTargetBlock("STACK");
-  while (item) {
-    if (!item.isInsertionMarker()) {
-      const name = String(item.getFieldValue("ATTR") || "");
-      if (name && name !== "(none)" && !names.includes(name)) names.push(name);
-    }
-    item = item.getNextBlock();
-  }
-  return names;
-}
-
 let optionalRmMutatorRegistered = false;
 
 function registerOptionalRmMutator(): void {
   if (optionalRmMutatorRegistered) return;
   optionalRmMutatorRegistered = true;
   defineOptionalMutatorQuarks();
-  Blockly.Extensions.registerMutator("optional_rm_mutator", {
+  registerDynamicFlyoutMutator(
+    "optional_rm_mutator",
+    {
     mutationToDom: function (this: Blockly.Block) {
       const xml = Blockly.utils.xml.createElement("mutation");
       const extras = this.extraInputs_ ?? [];
@@ -1201,12 +1210,13 @@ function registerOptionalRmMutator(): void {
       restoreMutatorAttributes(this, parsed.extras, parsed.attrs);
     },
     decompose: function (this: Blockly.Block, workspace: Blockly.Workspace) {
+      const labels = new Map(optionalRmMutatorChoices(this));
       return stackMutatorItems(
         workspace,
         OPTIONAL_RM_MUTATOR_CONTAINER,
         OPTIONAL_RM_MUTATOR_ITEM,
         this.extraInputs_ ?? [],
-        optionalRmMutatorChoices(this),
+        labels,
       );
     },
     compose: function (this: Blockly.Block, container: Blockly.Block) {
@@ -1282,7 +1292,11 @@ function registerOptionalRmMutator(): void {
         appendSlotTypeEmoji(stmt, slotType);
       }
     },
-  } as Blockly.Mutator & Record<string, unknown>, bindMutatorOpener, [OPTIONAL_RM_MUTATOR_ITEM]);
+    },
+    bindMutatorOpener,
+    buildOptionalRmFlyoutContents,
+    (block) => block.extraInputs_ ?? [],
+  );
 }
 
 let dvFieldsMutatorRegistered = false;
@@ -1291,7 +1305,9 @@ function registerDvFieldsMutator(): void {
   if (dvFieldsMutatorRegistered) return;
   dvFieldsMutatorRegistered = true;
   defineOptionalMutatorQuarks();
-  Blockly.Extensions.registerMutator("dv_fields_mutator", {
+  registerDynamicFlyoutMutator(
+    "dv_fields_mutator",
+    {
     mutationToDom: function (this: Blockly.Block) {
       const xml = Blockly.utils.xml.createElement("mutation");
       xml.setAttribute("fields", JSON.stringify(this.extraDvFields_ ?? []));
@@ -1315,12 +1331,13 @@ function registerDvFieldsMutator(): void {
       this.updateDvFields_?.();
     },
     decompose: function (this: Blockly.Block, workspace: Blockly.Workspace) {
+      const labels = new Map(optionalDvFieldChoices(this));
       return stackMutatorItems(
         workspace,
         DV_FIELDS_MUTATOR_CONTAINER,
         DV_FIELDS_MUTATOR_ITEM,
         this.extraDvFields_ ?? [],
-        optionalDvFieldChoices(this),
+        labels,
       );
     },
     compose: function (this: Blockly.Block, container: Blockly.Block) {
@@ -1363,7 +1380,11 @@ function registerDvFieldsMutator(): void {
         if (attr) appendDvFieldInput(this, attr, true);
       }
     },
-  } as Blockly.Mutator & Record<string, unknown>, bindMutatorOpener, [DV_FIELDS_MUTATOR_ITEM]);
+    },
+    bindMutatorOpener,
+    buildOptionalDvFlyoutContents,
+    (block) => block.extraDvFields_ ?? [],
+  );
 }
 
 declare module "blockly/core" {
@@ -1371,7 +1392,6 @@ declare module "blockly/core" {
     extraInputs_?: string[];
     extraDvFields_?: string[];
     slotCardinalities_?: Record<string, SlotCardinality>;
-    mutatorChoices_?: Array<[string, string]>;
     savedConnection_?: Blockly.Connection | null;
     firePlusClick?: () => void;
     addInput_?: (name: string) => void;

--- a/src/blockly/dynamic_mutator.ts
+++ b/src/blockly/dynamic_mutator.ts
@@ -1,0 +1,186 @@
+/**
+ * Blockly mutator with a per-option flyout (no attribute dropdown) and a
+ * header cogwheel field to the right of the skeleton title.
+ */
+import type { BlockSvg } from "blockly/core";
+import { Blockly } from "./blockly_core.ts";
+
+const MutatorIcon = Blockly.icons.MutatorIcon;
+
+/** Minimal flyout block JSON for MutatorIcon mini-workspace toolboxes. */
+export type MutatorFlyoutBlock = {
+  kind: "block";
+  type: string;
+  extraState?: { attr: string; label: string };
+};
+
+/** Blockly mutator cog (16×16), same motif as MutatorIcon. */
+export const COGWHEEL_SVG = "data:image/svg+xml," + encodeURIComponent(
+  `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">` +
+    `<path fill="#5f6368" d="m4.203,7.296 0,1.368 -0.92,0.677 -0.11,0.41 0.9,1.559 0.41,0.11 1.043,-0.457 1.187,0.683 0.127,1.134 0.3,0.3 1.8,0 0.3,-0.299 0.127,-1.138 1.185,-0.682 1.046,0.458 0.409,-0.11 0.9,-1.559 -0.11,-0.41 -0.92,-0.677 0,-1.366 0.92,-0.677 0.11,-0.41 -0.9,-1.559 -0.409,-0.109 -1.046,0.458 -1.185,-0.682 -0.127,-1.138 -0.3,-0.299 -1.8,0 -0.3,0.3 -0.126,1.135 -1.187,0.682 -1.043,-0.457 -0.41,0.11 -0.899,1.559 0.108,0.409z"/>` +
+    `<circle fill="#5f6368" cx="8" cy="8" r="2.7"/>` +
+    `</svg>`,
+);
+
+export function appendMutatorCogwheel(
+  header: { appendField: (field: unknown, name?: string) => unknown },
+): void {
+  header.appendField(
+    new Blockly.FieldImage(
+      COGWHEEL_SVG,
+      16,
+      16,
+      "Optional attributes…",
+      function (this: { getSourceBlock: () => BlockSvg }) {
+        const block = this.getSourceBlock();
+        if (block) openBlockMutator(block);
+      },
+    ),
+    "MUTATOR_COG",
+  );
+}
+
+/** Hide Blockly's default top-left mutator icon; the header cogwheel replaces it. */
+export function hideDefaultMutatorIcon(block: Blockly.Block): void {
+  const svg = block as BlockSvg;
+  const apply = () => {
+    const MutatorIconType = Blockly.icons?.MutatorIcon?.TYPE;
+    if (!MutatorIconType) return;
+    const icon = svg.getIcon?.(MutatorIconType);
+    if (icon?.svgRoot) icon.svgRoot.style.display = "none";
+  };
+  if (svg.rendered) {
+    apply();
+    return;
+  }
+  const workspace = svg.workspace;
+  if (!workspace) return;
+  const listener = (event: { blockId?: string }) => {
+    if (event.blockId !== svg.id || !svg.rendered) return;
+    apply();
+    workspace.removeChangeListener(listener);
+  };
+  workspace.addChangeListener(listener);
+}
+
+export function openBlockMutator(block: Blockly.Block): void {
+  const MutatorIconType = Blockly.icons?.MutatorIcon?.TYPE;
+  const svg = block as BlockSvg;
+  const icon = MutatorIconType ? svg.getIcon?.(MutatorIconType) : null;
+  if (icon?.setBubbleVisible) {
+    void icon.setBubbleVisible(true);
+    return;
+  }
+  for (const candidate of svg.getIcons?.() ?? []) {
+    candidate.setBubbleVisible?.(true);
+  }
+}
+
+type FlyoutProvider = (
+  block: BlockSvg,
+  stackNames: string[],
+) => MutatorFlyoutBlock[];
+
+function readMutatorStackNames(
+  icon: MutatorIcon,
+  fallback: string[],
+): string[] {
+  const root = (icon as unknown as { rootBlock?: Blockly.Block }).rootBlock;
+  if (root) return namesFromMutatorStack(root);
+  return fallback;
+}
+
+export function namesFromMutatorStack(container: Blockly.Block): string[] {
+  const names: string[] = [];
+  let item: Blockly.Block | null = container.getInputTargetBlock("STACK");
+  while (item) {
+    if (!item.isInsertionMarker()) {
+      const name = String(item.getFieldValue("ATTR") || "");
+      if (name && name !== "(none)" && !names.includes(name)) names.push(name);
+    }
+    item = item.getNextBlock();
+  }
+  return names;
+}
+
+function refreshMutatorFlyout(
+  icon: DynamicFlyoutMutatorIcon,
+  contentsFor: FlyoutProvider,
+): void {
+  const mini = icon.getWorkspace?.();
+  const flyout = mini?.getFlyout?.();
+  if (!flyout) return;
+  const block = icon.sourceBlock as BlockSvg;
+  const extras = (block as BlockSvg & { extraInputs_?: string[] }).extraInputs_ ??
+    (block as BlockSvg & { extraDvFields_?: string[] }).extraDvFields_ ??
+    [];
+  const stackNames = readMutatorStackNames(icon, extras);
+  const contents = contentsFor(block, stackNames);
+  flyout.show(contents);
+}
+
+export class DynamicFlyoutMutatorIcon extends MutatorIcon {
+  private flyoutRefreshListener: ((event: unknown) => void) | null = null;
+
+  constructor(
+    sourceBlock: BlockSvg,
+    private readonly contentsFor: FlyoutProvider,
+    private readonly stackFallback: () => string[],
+  ) {
+    super([], sourceBlock);
+  }
+
+  override setBubbleVisible(visible: boolean): Promise<void> {
+    const block = this.sourceBlock as BlockSvg;
+    const self = this as unknown as Record<string, unknown>;
+    self.getMiniWorkspaceConfig = () => {
+      const stackNames = readMutatorStackNames(this, this.stackFallback());
+      const contents = this.contentsFor(block, stackNames);
+      return {
+        disable: false,
+        media: block.workspace.options.pathToMedia,
+        rtl: block.RTL,
+        renderer: block.workspace.options.renderer,
+        rendererOverrides: block.workspace.options.rendererOverrides ?? undefined,
+        ...(contents.length
+          ? { toolbox: { kind: "flyoutToolbox" as const, contents } }
+          : {}),
+      };
+    };
+    return super.setBubbleVisible(visible).then(() => {
+      const mini = this.getWorkspace?.();
+      if (visible && mini) {
+        this.flyoutRefreshListener = () => {
+          refreshMutatorFlyout(this, this.contentsFor);
+        };
+        mini.addChangeListener(this.flyoutRefreshListener);
+        refreshMutatorFlyout(this, this.contentsFor);
+      } else if (this.flyoutRefreshListener && mini) {
+        mini.removeChangeListener(this.flyoutRefreshListener);
+        this.flyoutRefreshListener = null;
+      }
+    });
+  }
+}
+
+export function registerDynamicFlyoutMutator(
+  name: string,
+  mixin: Blockly.Mutator & Record<string, unknown>,
+  helper: (this: Blockly.Block) => void,
+  contentsFor: FlyoutProvider,
+  stackFallback: (block: BlockSvg) => string[],
+): void {
+  Blockly.Extensions.register(name, function (this: Blockly.Block) {
+    this.mixin(mixin);
+    helper.apply(this);
+    const blockSvg = this as BlockSvg;
+    this.setMutator(
+      new DynamicFlyoutMutatorIcon(
+        blockSvg,
+        contentsFor,
+        () => stackFallback(blockSvg),
+      ),
+    );
+    hideDefaultMutatorIcon(this);
+  });
+}

--- a/test/blockly_rm_blocks_test.ts
+++ b/test/blockly_rm_blocks_test.ts
@@ -16,6 +16,8 @@ import {
   RM_SPECIALIZATION_INPUT,
   rmAttributeInputName,
   optionalRmInputName,
+  applyMutatorItemLabel,
+  buildOptionalRmFlyoutContents,
   OPTIONAL_RM_MUTATOR_CONTAINER,
   OPTIONAL_RM_MUTATOR_ITEM,
   DV_FIELDS_MUTATOR_ITEM,
@@ -791,6 +793,33 @@ Deno.test("Blockly JSON extraState restores dynamic ATTR_ sockets including EVEN
   loaded.dispose();
 });
 
+Deno.test("optional RM mutator flyout lists one labeled block per option", () => {
+  ensureBlocks();
+  const workspace = new Blockly.Workspace();
+  const composition = workspace.newBlock("composition");
+  assert(composition.getField("MUTATOR_COG"), "cogwheel belongs after skeleton title");
+  const flyout = buildOptionalRmFlyoutContents(composition, []);
+  assert(flyout.length > 1, `expected multiple flyout options, got ${flyout.length}`);
+  assert(
+    flyout.every((entry) => entry.extraState?.attr && entry.extraState?.label),
+    "each flyout block carries attr + human label",
+  );
+  const withoutFeeder = buildOptionalRmFlyoutContents(composition, ["feeder_audit"]);
+  assertEquals(
+    withoutFeeder.some((entry) => entry.extraState?.attr === "feeder_audit"),
+    false,
+    "already-added options disappear from the flyout",
+  );
+
+  const bubble = new Blockly.Workspace();
+  const item = bubble.newBlock(OPTIONAL_RM_MUTATOR_ITEM);
+  applyMutatorItemLabel(item, "feeder_audit", "Feeder audit (feeder_audit)");
+  assertEquals(item.getFieldValue("ATTR"), "feeder_audit");
+  assertEquals(item.getFieldValue("LABEL"), "Feeder audit (feeder_audit)");
+  workspace.dispose();
+  bubble.dispose();
+});
+
 Deno.test("optional RM mutator cogwheel adds extras and orphans on remove", () => {
   ensureBlocks();
   const workspace = new Blockly.Workspace();
@@ -802,7 +831,7 @@ Deno.test("optional RM mutator cogwheel adds extras and orphans on remove", () =
   const bubble = new Blockly.Workspace();
   const container = composition.decompose!(bubble);
   const item = bubble.newBlock(OPTIONAL_RM_MUTATOR_ITEM);
-  item.setFieldValue("feeder_audit", "ATTR");
+  applyMutatorItemLabel(item, "feeder_audit", "Feeder audit (feeder_audit)");
   container.getInput("STACK")!.connection!.connect(item.previousConnection!);
   composition.compose!(container);
   assert(composition.getInput(optionalRmInputName("feeder_audit")));
@@ -842,7 +871,7 @@ Deno.test("DATA_VALUE mutator adds optional fields and has no plus-fields button
   const container = qty.decompose!(bubble);
   const item = bubble.newBlock(DV_FIELDS_MUTATOR_ITEM);
   const fieldName = item.getFieldValue("ATTR") || "normal_status";
-  item.setFieldValue(fieldName, "ATTR");
+  applyMutatorItemLabel(item, fieldName, fieldName);
   container.getInput("STACK")!.connection!.connect(item.previousConnection!);
   qty.compose!(container);
   assert(

--- a/web/styles.css
+++ b/web/styles.css
@@ -536,6 +536,17 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
   font-weight: 700 !important;
 }
 
+.blockly-mount .blocklyImage.blocklyMutatorCog,
+.blockly-mount img[alt="Optional attributes…"] {
+  margin-left: 4px;
+  opacity: 0.85;
+}
+
+/* Default Blockly mutator icon is replaced by header cogwheel on RM blocks */
+.blockly-mount .blocklyDraggable:has(img[alt="Optional attributes…"]) > .blocklyIconGroup.blockly-icon-mutator {
+  display: none !important;
+}
+
 .blockly-icon-warning .blocklyIconShape {
   fill: #F9A825 !important;
   stroke: #E65100 !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements roadmap item B (line 11): improve the cogwheel optional-attribute configuration UX.

- **Per-option flyout blocks** — the mutator mini-workspace lists one labeled block per optional RM attribute / DV field instead of a single block with a dropdown. Already-added options disappear from the flyout (add-once semantics).
- **Header cogwheel placement** — the cogwheel sits in the block header to the right of the dual-line skeleton title (name + RM class), replacing Blockly's default top-left mutator icon beside the ZipEHR emoji.

## Changes

- New `src/blockly/dynamic_mutator.ts` — dynamic flyout mutator icon + header cogwheel field
- Updated `optional_rm_mutator` / `dv_fields_mutator` item quarks to fixed labels (no dropdown)
- CSS hides the default Blockly mutator icon when the header cog is present
- Tests updated/added in `test/blockly_rm_blocks_test.ts`

## Testing

- `deno test -A --no-check test/blockly_rm_blocks_test.ts` — 39 passed
- `deno task test` — 304 passed
- `deno test -A --no-check test/ui/optional_rm_mutator_test.ts` — passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79b41d92-3024-460a-8b42-1211c5877430?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79b41d92-3024-460a-8b42-1211c5877430&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

