### PR TITLE
Chunk 4: AI copy-paste polish + roadmap chunk reorder

### DIFF
--- a/docs/AI_SUGGESTION_FORMAT.md
+++ b/docs/AI_SUGGESTION_FORMAT.md
@@ -114,7 +114,7 @@ Use when source has repeating nodes (e.g. several vitals in one encounter) and t
 4. Link to this doc
 5. Slot manifest: `{ slotId, valueType, label, targetPath?, multiplicity? }` — `valueType` is format-native (openEHR `DV_*`, JSON Schema `string`/`number`, XSD type, …)
 6. Artifact delivery (below)
-7. Instruction: one version-`2` fence; use `loops` + relative paths when `multiplicity` is repeating (repeatable containers are listed separately for `attachSlotId`). Prefer **`maps_get` / `maps_create_with`** for terminology and code translation (e.g. ICD-10 → SNOMED CT) — more common than defaults. Target scaffold generation often wires Defaults Map lookups (`maps_get` with `"defaults"`) before Copy AI Prompt; **omit those slots** unless the user asked for different defaults — then your suggestion replaces the existing mapping. Party identity value slots (e.g. composer `name`) map via `source_query` / `text` on the manifest leaf, not RM container blocks. Do not map source quantities onto ordinal/score fields unless the source is already that score.
+7. Instruction: one version-`2` fence; use `loops` + relative paths when `multiplicity` is repeating (repeatable containers are listed separately for `attachSlotId`). Prefer **`maps_get` / `maps_create_with`** for terminology and code translation (e.g. ICD-10 → SNOMED CT) — more common than bare defaults. Target scaffold generation often wires Defaults Map lookups (`maps_get` with `"defaults"`) before Copy AI Prompt — **omit those slots only when the source has no value** and the user did not ask otherwise. **When the source has data for a slot that scaffold/defaults would fill, map from the source** (`source_query` / `text`); source wins over defaults. Typical examples: **context start time**, **healthcare facility**, **composer** (name/id). Party identity value slots map via `source_query` / `text` on the manifest leaf, not RM container blocks. Do not map source quantities onto ordinal/score fields unless the source is already that score.
 
 ### Artifact delivery
 
@@ -200,7 +200,33 @@ Assume a named map `icd10_snomed` on the canvas (or describe keys in `note`). Lo
 
 For a **small inline table** without a named map, nest `maps_create_with` inside `logic_ternary` branches (one branch per known code).
 
-**Defaults lookup (language)** — often pre-wired by scaffold; suggest only when user overrides:
+**Source over defaults (composer, time, facility)** — scaffold may already use `maps_get("defaults", …)`; when the source has values, map from source:
+
+```intehrgrator-suggestions
+{
+  "format": "intehrgrator-suggestions",
+  "version": "2",
+  "target": { "format": "openehr-template", "targetId": "vitals_encounter_v1" },
+  "suggestions": [
+    {
+      "slotId": "vitals_encounter_v1/context/start_time/value",
+      "block": {
+        "type": "source_query",
+        "fields": { "EXPRESSION": "$.encounter.startTime" }
+      }
+    },
+    {
+      "slotId": "vitals_encounter_v1/composer/name/value",
+      "block": {
+        "type": "source_query",
+        "fields": { "EXPRESSION": "$.author.displayName" }
+      }
+    }
+  ]
+}
+```
+
+**Defaults lookup (language)** — scaffold fallback only when source has no value and user did not override:
 
 ```intehrgrator-suggestions
 {
@@ -217,7 +243,7 @@ For a **small inline table** without a named map, nest `maps_create_with` inside
           "KEY": { "block": { "type": "text", "fields": { "TEXT": "language" } } }
         }
       },
-      "note": "Only when user asked to change language default"
+      "note": "Only when source has no language and user did not specify otherwise"
     }
   ]
 }

--- a/docs/AI_SUGGESTION_FORMAT.md
+++ b/docs/AI_SUGGESTION_FORMAT.md
@@ -83,13 +83,16 @@ Blockly JSON (`type`, `fields`, `inputs`, `extraState` only). No `id`/`x`/`y`/`s
 | Source | `source_query`, `source_query_number`, `source_query_boolean` | `EXPRESSION` (fontoxpath). Pick by `valueType`: number→`_number`, boolean→`_boolean`, else plain. |
 | Loop | `for_each_source` | `VAR`, `PATH` (absolute multi-node path). Statement block — **only** in `loops[]`, not as a value `suggestions[].block`. Leave `DO` empty. |
 | Var | `variables_get` | `VAR` = loop variable name (whole node as value; rare). |
-| Map lookup | `maps_get` | `NAME` = map name (usually `"defaults"`); input `KEY` = key expression (often nested `text`). |
+| Map lookup | `maps_get` | `NAME` = map name; input `KEY` = key expression (literal `text` or dynamic `source_query`). |
+| Map literal | `maps_create_with`, `maps_create_empty` | Inline key/value table: `KEY0`… + `VAL0`… inputs; `extraState.itemCount`. Emits `map("k1", v1, …)`. |
 | Literal | `text`, `math_number`, `logic_boolean` | `TEXT` / `NUM` / `BOOL` (`TRUE`\|`FALSE`) |
 | Text | `text_trim`, `text_join` | `MODE`; `text_join` may need `extraState.itemCount` + `ADD0`… |
 | Math | `math_arithmetic` | `OP`: `ADD`\|`MINUS`\|`MULTIPLY`\|`DIVIDE`; inputs `A`,`B` |
 | Logic | `logic_ternary` | inputs `IF`,`THEN`,`ELSE` |
 
-No JS wrappers (`xpathNumber("…")`). No RM containers, `DV_*` shells, Optional RM, or Handlebars text in this envelope.
+No JS wrappers (`xpathNumber("…")`). No RM containers, `DV_*` shells, Optional RM, Handlebars text, or list-construction blocks (`lists_*`) in this envelope — list-valued RM slots stay structural on the canvas.
+
+**Maps vs lists:** Use `maps_get` / `maps_create_with` for code translations, terminology tables, and lookups. List blocks are for authoring RM list structure on the canvas, not for AI-filled value expressions.
 
 ### Loops (source ↔ target repetition)
 
@@ -111,7 +114,7 @@ Use when source has repeating nodes (e.g. several vitals in one encounter) and t
 4. Link to this doc
 5. Slot manifest: `{ slotId, valueType, label, targetPath?, multiplicity? }` — `valueType` is format-native (openEHR `DV_*`, JSON Schema `string`/`number`, XSD type, …)
 6. Artifact delivery (below)
-7. Instruction: one version-`2` fence; use `loops` + relative paths when `multiplicity` is repeating. Repeatable containers are listed separately for `attachSlotId`. Use `maps_get` for Defaults Map keys (language, territory, encoding). Party identity value slots (e.g. composer `name`) map via `source_query` / `text` on the manifest leaf — not RM container blocks. Do not map source quantities onto ordinal/score fields unless the source is already that score.
+7. Instruction: one version-`2` fence; use `loops` + relative paths when `multiplicity` is repeating (repeatable containers are listed separately for `attachSlotId`). Prefer **`maps_get` / `maps_create_with`** for terminology and code translation (e.g. ICD-10 → SNOMED CT) — more common than defaults. Target scaffold generation often wires Defaults Map lookups (`maps_get` with `"defaults"`) before Copy AI Prompt; **omit those slots** unless the user asked for different defaults — then your suggestion replaces the existing mapping. Party identity value slots (e.g. composer `name`) map via `source_query` / `text` on the manifest leaf, not RM container blocks. Do not map source quantities onto ordinal/score fields unless the source is already that score.
 
 ### Artifact delivery
 
@@ -164,7 +167,40 @@ GitHub `.t.json` closures: `uri` → root URL; `inline` → each fileset file.
 }
 ```
 
-**Defaults lookup (language)**
+**Terminology translation (ICD-10 → SNOMED CT)**
+
+User prompt: *“Map diagnosis ICD-10 codes to SNOMED CT using a lookup table.”*  
+Assume a named map `icd10_snomed` on the canvas (or describe keys in `note`). Lookup with dynamic key from source:
+
+```intehrgrator-suggestions
+{
+  "format": "intehrgrator-suggestions",
+  "version": "2",
+  "target": { "format": "openehr-template", "targetId": "problem_list_v1" },
+  "suggestions": [
+    {
+      "slotId": "problem_list_v1/content/data/items/at0002/value/value/defining_code/code_string/value",
+      "block": {
+        "type": "maps_get",
+        "fields": { "NAME": "icd10_snomed" },
+        "inputs": {
+          "KEY": {
+            "block": {
+              "type": "source_query",
+              "fields": { "EXPRESSION": "$.diagnosis.icd10" }
+            }
+          }
+        }
+      },
+      "note": "Map icd10_snomed: I10→38341003, E11→44054006, … (user may load table on canvas)"
+    }
+  ]
+}
+```
+
+For a **small inline table** without a named map, nest `maps_create_with` inside `logic_ternary` branches (one branch per known code).
+
+**Defaults lookup (language)** — often pre-wired by scaffold; suggest only when user overrides:
 
 ```intehrgrator-suggestions
 {
@@ -180,7 +216,8 @@ GitHub `.t.json` closures: `uri` → root URL; `inline` → each fileset file.
         "inputs": {
           "KEY": { "block": { "type": "text", "fields": { "TEXT": "language" } } }
         }
-      }
+      },
+      "note": "Only when user asked to change language default"
     }
   ]
 }

--- a/docs/AI_SUGGESTION_FORMAT.md
+++ b/docs/AI_SUGGESTION_FORMAT.md
@@ -83,6 +83,7 @@ Blockly JSON (`type`, `fields`, `inputs`, `extraState` only). No `id`/`x`/`y`/`s
 | Source | `source_query`, `source_query_number`, `source_query_boolean` | `EXPRESSION` (fontoxpath). Pick by `valueType`: number→`_number`, boolean→`_boolean`, else plain. |
 | Loop | `for_each_source` | `VAR`, `PATH` (absolute multi-node path). Statement block — **only** in `loops[]`, not as a value `suggestions[].block`. Leave `DO` empty. |
 | Var | `variables_get` | `VAR` = loop variable name (whole node as value; rare). |
+| Map lookup | `maps_get` | `NAME` = map name (usually `"defaults"`); input `KEY` = key expression (often nested `text`). |
 | Literal | `text`, `math_number`, `logic_boolean` | `TEXT` / `NUM` / `BOOL` (`TRUE`\|`FALSE`) |
 | Text | `text_trim`, `text_join` | `MODE`; `text_join` may need `extraState.itemCount` + `ADD0`… |
 | Math | `math_arithmetic` | `OP`: `ADD`\|`MINUS`\|`MULTIPLY`\|`DIVIDE`; inputs `A`,`B` |
@@ -110,7 +111,7 @@ Use when source has repeating nodes (e.g. several vitals in one encounter) and t
 4. Link to this doc
 5. Slot manifest: `{ slotId, valueType, label, targetPath?, multiplicity? }` — `valueType` is format-native (openEHR `DV_*`, JSON Schema `string`/`number`, XSD type, …)
 6. Artifact delivery (below)
-7. Instruction: one version-`2` fence; use `loops` + relative paths when `multiplicity` is repeating. Repeatable containers are listed separately for `attachSlotId`. Do not map source quantities onto ordinal/score fields unless the source is already that score.
+7. Instruction: one version-`2` fence; use `loops` + relative paths when `multiplicity` is repeating. Repeatable containers are listed separately for `attachSlotId`. Use `maps_get` for Defaults Map keys (language, territory, encoding). Party identity value slots (e.g. composer `name`) map via `source_query` / `text` on the manifest leaf — not RM container blocks. Do not map source quantities onto ordinal/score fields unless the source is already that score.
 
 ### Artifact delivery
 
@@ -131,7 +132,7 @@ GitHub `.t.json` closures: `uri` → root URL; `inline` → each fileset file.
 1. Extract fence (or raw JSON). `format` and `target` may be omitted; the loaded target is used.
 2. Require `version` `"2"`; match `target` when present
 3. Nested `attachSlotId` / `for_each_source` groups inside `suggestions[]` are flattened into `loops[]`. Validate `for_each_source`; keep `loopVar` + relative `EXPRESSION` as-is; wrap the repeating container with `for_each_source` on the canvas
-4. Apply each suggestion `block` → value slot; report applied / skipped / errors
+4. Apply each valid suggestion `block` → value slot; skip invalid entries; report applied / skipped / errors
 5. User **Test Run**
 
 ## Examples
@@ -156,6 +157,28 @@ GitHub `.t.json` closures: `uri` → root URL; `inline` → each fileset file.
               "fields": { "EXPRESSION": "$.name.family", "RETURN_TYPE": "string" }
             }
           }
+        }
+      }
+    }
+  ]
+}
+```
+
+**Defaults lookup (language)**
+
+```intehrgrator-suggestions
+{
+  "format": "intehrgrator-suggestions",
+  "version": "2",
+  "target": { "format": "openehr-template", "targetId": "vitals_encounter_v1" },
+  "suggestions": [
+    {
+      "slotId": "vitals_encounter_v1/language/value",
+      "block": {
+        "type": "maps_get",
+        "fields": { "NAME": "defaults" },
+        "inputs": {
+          "KEY": { "block": { "type": "text", "fields": { "TEXT": "language" } } }
         }
       }
     }

--- a/docs/AI_SUGGESTION_FORMAT.schema.json
+++ b/docs/AI_SUGGESTION_FORMAT.schema.json
@@ -137,6 +137,7 @@
             "text_handlebars",
             "maps_create_with",
             "maps_create_empty",
+            "maps_get",
             "math_number",
             "logic_boolean",
             "text_trim",

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -65,9 +65,9 @@
 - [ ] add special support for TakeCare term id (multiple systems, e.g. both test and prod )
 
 ## I. Initial AI Assistance
-- [ ] validate that AI assistance (initial cut & paste variant) works, improve if needed.
-- [ ] Add hints in prompt/instruction-file regarding openehr-assistant (possibly with deepwiki link)
-- [ ] Clairfy button lable inport AI suggestion
+- [x] validate that AI assistance (initial cut & paste variant) works, improve if needed.
+- [x] Add hints in prompt/instruction-file regarding openehr-assistant (possibly with deepwiki link)
+- [x] Clarify button label Import AI suggestions
 
 
 # conversion script generation

--- a/src/core/ai/mod.ts
+++ b/src/core/ai/mod.ts
@@ -195,9 +195,20 @@ export function buildPrompt(options: BuildPromptOptions): string {
     }, null, 2),
     "```",
     "",
-    "**Defaults** — target scaffold often pre-wires `maps_get(\"defaults\", …)` for language/territory; omit unless the user asked to override.",
+    "**Defaults vs source** — scaffold often pre-wires `maps_get(\"defaults\", …)` for language/territory/facility/time/composer. **Source wins:** when the source has data for such a slot, map with `source_query` (e.g. context start time, healthcare facility, composer name). Omit defaults-only slots only when the source has no value.",
     "",
-    "**Party identity `name` slot** (DV_TEXT value leaf):",
+    "**Source over defaults (time / composer)** — map from source when present:",
+    "```json",
+    JSON.stringify({
+      slotId: "{targetId}/context/start_time/value",
+      block: {
+        type: "source_query",
+        fields: { EXPRESSION: "$.encounter.startTime" },
+      },
+    }, null, 2),
+    "```",
+    "",
+    "**Party identity `name` slot** (DV_TEXT value leaf; source over defaults):",
     "```json",
     JSON.stringify({
       slotId: "{targetId}{path/to/composer/name/value}",
@@ -211,7 +222,7 @@ export function buildPrompt(options: BuildPromptOptions): string {
     "**Repeating container** — put `for_each_source` in top-level `loops[]`; child slots use `loopVar` + relative `EXPRESSION` (see Repeatable containers list).",
     "",
     "## Instruction",
-    "Return exactly one `intehrgrator-suggestions` fenced JSON block. Copy each `slotId` from the slot manifest. Prefer `source_query*` blocks with fontoxpath in `EXPRESSION`. Use `maps_get` / `maps_create_with` for terminology and code translation. Scaffold generation often wires Defaults Map slots already — skip them unless the user requested different defaults. For repeating `multiplicity` (`0..*` / `1..*`), emit `loops` with `for_each_source` and child suggestions with matching `loopVar` + relative `EXPRESSION` (do not join onto PATH). Do not map source quantities onto ordinal/score fields unless the source is already that score. Leave unmatched slots out rather than inventing a mapping.",
+    "Return exactly one `intehrgrator-suggestions` fenced JSON block. Copy each `slotId` from the slot manifest. Prefer `source_query*` blocks with fontoxpath in `EXPRESSION`. Use `maps_get` / `maps_create_with` for terminology and code translation. Scaffold often wires Defaults Map slots — omit those only when the source has no value; when source data exists for time, healthcare facility, composer, or similar, map from source (source takes precedence over defaults). For repeating `multiplicity` (`0..*` / `1..*`), emit `loops` with `for_each_source` and child suggestions with matching `loopVar` + relative `EXPRESSION` (do not join onto PATH). Do not map source quantities onto ordinal/score fields unless the source is already that score. Leave unmatched slots out rather than inventing a mapping.",
   );
 
   if (options.delivery === "inline") {

--- a/src/core/ai/mod.ts
+++ b/src/core/ai/mod.ts
@@ -59,6 +59,7 @@ const VALUE_BLOCK_TYPES = new Set([
   "text_handlebars",
   "maps_create_with",
   "maps_create_empty",
+  "maps_get",
   "math_number",
   "logic_boolean",
   "text_trim",
@@ -137,6 +138,13 @@ export function buildPrompt(options: BuildPromptOptions): string {
     "Use version `\"2\"` with Blockly `block` fragments (not JS-shaped xpath wrappers).",
     `The JSON must validate against: ${schemaUrlFromFormatDoc(options.formatDocUrl)}`,
     "",
+  );
+
+  if (options.targetFormat === "openehr-template") {
+    sections.push(...openEhrReferenceSections(options.formatDocUrl));
+  }
+
+  sections.push(
     "## Slot manifest",
     "```json",
     JSON.stringify(manifest, null, 2),
@@ -163,6 +171,36 @@ export function buildPrompt(options: BuildPromptOptions): string {
 
   sections.push(...deliverySections(options.delivery, options.artifacts));
   sections.push(
+    "",
+    "## Block examples",
+    "Value slots only — no RM containers or DV shells in suggestions. Examples:",
+    "",
+    "**Defaults lookup** (`maps_get` against the Defaults Map):",
+    "```json",
+    JSON.stringify({
+      slotId: "{targetId}{path/to/language/value}",
+      block: {
+        type: "maps_get",
+        fields: { NAME: "defaults" },
+        inputs: {
+          KEY: { block: { type: "text", fields: { TEXT: "language" } } },
+        },
+      },
+    }, null, 2),
+    "```",
+    "",
+    "**Party identity `name` slot** (map source string onto a DV_TEXT value leaf):",
+    "```json",
+    JSON.stringify({
+      slotId: "{targetId}{path/to/composer/name/value}",
+      block: {
+        type: "source_query",
+        fields: { EXPRESSION: "$.patient.name" },
+      },
+    }, null, 2),
+    "```",
+    "",
+    "**Repeating container** — put `for_each_source` in top-level `loops[]`; child slots use `loopVar` + relative `EXPRESSION` (see Repeatable containers list).",
     "",
     "## Instruction",
     "Return exactly one `intehrgrator-suggestions` fenced JSON block. Copy each `slotId` from the slot manifest. Prefer `source_query*` blocks with fontoxpath in `EXPRESSION`. For repeating `multiplicity` (`0..*` / `1..*`), emit `loops` with `for_each_source` and child suggestions with matching `loopVar` + relative `EXPRESSION` (do not join onto PATH). The app wraps the repeating container with `for_each_source` and evaluates each source node. Do not map source quantities onto ordinal/score fields unless the source is already that score. Leave unmatched slots out rather than inventing a mapping.",
@@ -191,6 +229,26 @@ function formatTargetTask(format: string): string {
     default:
       return `instances of target format \`${format}\``;
   }
+}
+
+function docUrlFromFormatDoc(formatDocUrl: string, filename: string): string {
+  const base = formatDocUrl.replace(/\/[^/]*$/, "/");
+  return `${base}${filename}`;
+}
+
+function openEhrReferenceSections(formatDocUrl: string): string[] {
+  const primerUrl = docUrlFromFormatDoc(formatDocUrl, "OPENEHR_PRIMER.md");
+  return [
+    "## openEHR references",
+    "When the target is an openEHR template, use authoritative sources — do not invent RM paths, archetype ids, or terminology codes.",
+    "",
+    "- **openehr-assistant MCP** (if available): use for archetype/template lookup, terminology resolution, spec digests, and ADL/AQL guidance before guessing.",
+    `- **Primer**: ${primerUrl}`,
+    "- **ehrtslib (DeepWiki)**: https://deepwiki.com/ErikSundvall/ehrtslib",
+    "- **ehrtslib (GitHub)**: https://github.com/ErikSundvall/ehrtslib",
+    "- **openEHR specifications**: https://specifications.openehr.org/",
+    "",
+  ];
 }
 
 function deliverySections(
@@ -446,7 +504,7 @@ export function explainSuggestionSchemaIssue(
   }
   if (keyword === "enum" || /does not match any of/i.test(raw)) {
     if (/\.type$/.test(path)) {
-      return `${path}: invalid block type. Use source_query, source_query_number, source_query_boolean, source_query_node, text, text_code, or text_handlebars (not source_query_string). Loops use for_each_source only in loops[].`;
+      return `${path}: invalid block type. Use source_query, source_query_number, source_query_boolean, source_query_node, text, text_code, text_handlebars, maps_get, or maps_create_* (not source_query_string). Loops use for_each_source only in loops[].`;
     }
   }
   if (keyword === "const") {
@@ -863,6 +921,13 @@ function blockJsonToExpression(
         parts.push(val ? blockJsonToExpression(val, rewriteSourcePath) ?? "null" : "null");
       }
       return `map(${parts.join(", ")})`;
+    }
+    case "maps_get": {
+      const name = String(fields.NAME ?? "defaults");
+      const key = child("KEY")
+        ? blockJsonToExpression(child("KEY")!, rewriteSourcePath)
+        : '""';
+      return `maps_get(${JSON.stringify(name)}, ${key ?? '""'})`;
     }
     case "math_number":
       return String(fields.NUM ?? 0);

--- a/src/core/ai/mod.ts
+++ b/src/core/ai/mod.ts
@@ -173,23 +173,31 @@ export function buildPrompt(options: BuildPromptOptions): string {
   sections.push(
     "",
     "## Block examples",
-    "Value slots only — no RM containers or DV shells in suggestions. Examples:",
+    "Value slots only — no RM containers or DV shells in suggestions. Prefer maps for code/terminology translation.",
     "",
-    "**Defaults lookup** (`maps_get` against the Defaults Map):",
+    "**Terminology translation (ICD-10 → SNOMED CT)** — `maps_get` with dynamic key from source (named map on canvas, e.g. `icd10_snomed`):",
     "```json",
     JSON.stringify({
-      slotId: "{targetId}{path/to/language/value}",
+      slotId: "{targetId}{path/to/code_string/value}",
       block: {
         type: "maps_get",
-        fields: { NAME: "defaults" },
+        fields: { NAME: "icd10_snomed" },
         inputs: {
-          KEY: { block: { type: "text", fields: { TEXT: "language" } } },
+          KEY: {
+            block: {
+              type: "source_query",
+              fields: { EXPRESSION: "$.diagnosis.icd10" },
+            },
+          },
         },
       },
+      note: "I10→38341003, E11→44054006, …",
     }, null, 2),
     "```",
     "",
-    "**Party identity `name` slot** (map source string onto a DV_TEXT value leaf):",
+    "**Defaults** — target scaffold often pre-wires `maps_get(\"defaults\", …)` for language/territory; omit unless the user asked to override.",
+    "",
+    "**Party identity `name` slot** (DV_TEXT value leaf):",
     "```json",
     JSON.stringify({
       slotId: "{targetId}{path/to/composer/name/value}",
@@ -203,7 +211,7 @@ export function buildPrompt(options: BuildPromptOptions): string {
     "**Repeating container** — put `for_each_source` in top-level `loops[]`; child slots use `loopVar` + relative `EXPRESSION` (see Repeatable containers list).",
     "",
     "## Instruction",
-    "Return exactly one `intehrgrator-suggestions` fenced JSON block. Copy each `slotId` from the slot manifest. Prefer `source_query*` blocks with fontoxpath in `EXPRESSION`. For repeating `multiplicity` (`0..*` / `1..*`), emit `loops` with `for_each_source` and child suggestions with matching `loopVar` + relative `EXPRESSION` (do not join onto PATH). The app wraps the repeating container with `for_each_source` and evaluates each source node. Do not map source quantities onto ordinal/score fields unless the source is already that score. Leave unmatched slots out rather than inventing a mapping.",
+    "Return exactly one `intehrgrator-suggestions` fenced JSON block. Copy each `slotId` from the slot manifest. Prefer `source_query*` blocks with fontoxpath in `EXPRESSION`. Use `maps_get` / `maps_create_with` for terminology and code translation. Scaffold generation often wires Defaults Map slots already — skip them unless the user requested different defaults. For repeating `multiplicity` (`0..*` / `1..*`), emit `loops` with `for_each_source` and child suggestions with matching `loopVar` + relative `EXPRESSION` (do not join onto PATH). Do not map source quantities onto ordinal/score fields unless the source is already that score. Leave unmatched slots out rather than inventing a mapping.",
   );
 
   if (options.delivery === "inline") {
@@ -231,22 +239,16 @@ function formatTargetTask(format: string): string {
   }
 }
 
-function docUrlFromFormatDoc(formatDocUrl: string, filename: string): string {
-  const base = formatDocUrl.replace(/\/[^/]*$/, "/");
-  return `${base}${filename}`;
-}
-
-function openEhrReferenceSections(formatDocUrl: string): string[] {
-  const primerUrl = docUrlFromFormatDoc(formatDocUrl, "OPENEHR_PRIMER.md");
+function openEhrReferenceSections(_formatDocUrl: string): string[] {
   return [
     "## openEHR references",
     "When the target is an openEHR template, use authoritative sources — do not invent RM paths, archetype ids, or terminology codes.",
     "",
-    "- **openehr-assistant MCP** (if available): use for archetype/template lookup, terminology resolution, spec digests, and ADL/AQL guidance before guessing.",
-    `- **Primer**: ${primerUrl}`,
+    "- **openehr-assistant MCP** (recommended): archetype/template lookup, terminology resolution, spec digests, and ADL/AQL guidance. Install the [openEHR Assistant Plugin](https://github.com/cadasto/openehr-assistant-plugin) in your AI environment when possible.",
     "- **ehrtslib (DeepWiki)**: https://deepwiki.com/ErikSundvall/ehrtslib",
     "- **ehrtslib (GitHub)**: https://github.com/ErikSundvall/ehrtslib",
     "- **openEHR specifications**: https://specifications.openehr.org/",
+    "- **openEHR specs (AI index)**: https://specifications.openehr.org/llms.txt",
     "",
   ];
 }

--- a/src/ui/import_ai.ts
+++ b/src/ui/import_ai.ts
@@ -30,8 +30,11 @@ export function formatImportReport(report: ImportSuggestionsReport): {
   kind: "ok" | "partial" | "error";
 } {
   const schemaCount = report.schemaIssues?.length ?? 0;
+  const validNote = schemaCount > 0 && report.applied + report.loopsAccepted > 0
+    ? " · valid entries only"
+    : "";
   const summary =
-    `${report.applied} applied · ${report.loopsAccepted} loops · ${report.skipped} skipped · ${report.errors.length} errors · ${schemaCount} schema`;
+    `${report.applied} applied · ${report.loopsAccepted} loops · ${report.skipped} skipped · ${report.errors.length} errors · ${schemaCount} schema${validNote}`;
   const hasProblems = report.errors.length > 0 || schemaCount > 0;
   if (!hasProblems && report.applied + report.loopsAccepted > 0) {
     return { summary, kind: "ok" };

--- a/tasks/TASKS-roadmap-chunks.md
+++ b/tasks/TASKS-roadmap-chunks.md
@@ -46,6 +46,38 @@ Asked after this plan was written, before coding Chunk 1. Recommended answers **
 
 ➡️ **Adopted: Chunk 2 = remaining B UX that shares Blockly editor surface (undo/redo, toolbox-search, Mapping Spec gutter markers); Chunk 3 = F RM completeness.** Handlebars and tables stay later (higher risk, less blocking).
 
+## Grill round 3 (Chunk 4 frontier)
+
+Asked before coding Chunk 4 (AI copy-paste polish). Recommended answers **adopted**.
+
+❓ **Q1** - **openEHR references in prompt**: Should Copy AI Prompt mention the openehr-assistant MCP, link to docs, or both?
+
+➡️ **Adopted: both.** Add an **openEHR references** section when the target is an openEHR template: hint to use the openehr-assistant MCP for spec/archetype lookup, plus links to `docs/OPENEHR_PRIMER.md`, `docs/AI_SUGGESTION_FORMAT.md`, and DeepWiki/ehrtslib.
+
+---
+
+❓ **Q2** - **Import button label**: Toolbar still says “Import Suggestions”; rename to “Import AI suggestions”?
+
+➡️ **Adopted: already fixed on `main`.** No further work.
+
+---
+
+❓ **Q3** - **CI validation depth**: Should recurring CI call a live LLM, or only fixture/round-trip tests?
+
+➡️ **Adopted: fixture/round-trip only; no live LLM in recurring CI.**
+
+---
+
+❓ **Q4** - **Suggestion envelope breadth**: Expand allowed value `block.type` list and prompt examples (e.g. `maps_get`, loops, party `name` slots)?
+
+➡️ **Adopted: yes.** Add `maps_get` to schema + import codegen; document examples for defaults lookup, repeating containers, and party identity value slots (`name` via `source_query` / `text`).
+
+---
+
+❓ **Q5** - **Partial import**: On schema/apply errors, import valid entries only and report counts?
+
+➡️ **Adopted: yes.** Keep apply-valid-only behaviour; surface applied / loops / skipped / errors / schema counts in the import dialog summary.
+
 ## Relevant Files
 
 - `src/blockly/blocks/rm_blocks.ts` — `optional_rm_mutator` / `dv_fields_mutator`, + image fields, compose/decompose
@@ -67,16 +99,16 @@ Asked after this plan was written, before coding Chunk 1. Recommended answers **
 | 1    | Native cogwheel for optional attributes | B: replace + popup with cogwheel; non-mandatory can be removed                                                                                           | First unfinished item; Blockly-native mutator; unblocks honest optional RM/DV editing      |
 | 2    | Mapping Editor chrome                   | B: undo/redo; toolbox-search plugin; Mapping Spec gutter error markers                                                                                   | Shared editor surface; independent of RM class work                                        |
 | 3    | RM Blockly completeness                 | F: missing classes; toolbox sort/groups/colour; PARTY_IDENTIFIED `name`/`identifiers`; ITEM_STRUCTURE morph like EVENT                                   | Uses cogwheel once it exists; `openehr://spec/type/RM/PARTY_IDENTIFIED` + `ITEM_STRUCTURE` |
-| 4    | AI copy-paste polish                    | I: validate assist; openehr-assistant prompt hint; clarify Import Suggestions label                                                                      | Small, isolated toolbar/prompt work                                                        |
-| 5    | Cross-pane a11y                         | B: colourblind in→conv→out; sync highlight mapping ↔ Conversion Test Run                                                                                 | Visual language; after editor mechanics settle                                             |
-| 6    | Handlebars correctness                  | G: harden Mapping preview Test Run; execute generated Handlebars script; Blockly ↔ Handlebars Template round-trip; arm Click-to-Map on source-node block | Documented as shaky; ADR 0001 / 0003                                                       |
-| 7    | Maps/tables                             | C: CSV/Excel paste tables; FHIR terminology maps                                                                                                         | Needs solid map blocks (already done) + lookup blocks                                      |
-| 8    | Conversion scripts                      | J golden TS/Java/XQuery/Handlebars; K full COMPOSITION XML emit + Saxon/BaseX CI                                                                         | After mapping/RM is trustworthy                                                            |
-| 9    | Persistence, i18n, versioning           | B: GitHub save if logged in; full UI i18n; L: source/target version hashes                                                                               | Platform, not mapping semantics                                                            |
-| 10   | Dynamic schema toolboxes                | H: JSON/XSD target drawers from schema; TakeCare test + term ids                                                                                         | Productized schema-specific Blockly                                                        |
+| 4    | AI copy-paste polish                    | I: validate assist; openehr-assistant prompt hint; clarify Import AI suggestions label                                                                   | Small, isolated toolbar/prompt work                                                        |
+| 5    | Local/offline AI skill                  | D: parallel IDE + local app; installable AI skill for suggestion format                                                                                  | Docs + skill packaging                                                                     |
+| 6    | Dynamic schema toolboxes                | H: JSON/XSD target drawers from schema; TakeCare test + term ids                                                                                         | Productized schema-specific Blockly                                                        |
+| 7    | Handlebars correctness                  | G: harden Mapping preview Test Run; execute generated Handlebars script; Blockly ↔ Handlebars Template round-trip; arm Click-to-Map on source-node block | Documented as shaky; ADR 0001 / 0003                                                       |
+| 8    | Maps/tables                             | C: CSV/Excel paste tables; FHIR terminology maps                                                                                                         | Needs solid map blocks (already done) + lookup blocks                                      |
+| 9    | Conversion scripts                      | J golden TS/Java/XQuery/Handlebars; K full COMPOSITION XML emit + Saxon/BaseX CI                                                                         | After mapping/RM is trustworthy                                                            |
+| 10   | Persistence, i18n, versioning           | B: GitHub save if logged in; full UI i18n; L: source/target version hashes                                                                               | Platform, not mapping semantics                                                            |
 | 11   | Better Form parity                      | G: ScriptApi / formTestApi / Cypress port                                                                                                                | Licensed optional path                                                                     |
 | 12   | Later hosts                             | v1 follow-ups: Java Export UI; VS Code host; Autoplay E2E                                                                                                | Explicitly post-v1                                                                         |
-| 13   | Local/offline AI skill                  | D: parallel IDE + local app; installable AI skill for suggestion format                                                                                  | Docs + skill packaging                                                                     |
+| 13   | Cross-pane a11y                         | B: colourblind in→conv→out; sync highlight mapping ↔ Conversion Test Run                                                                                 | Visual language; after editor mechanics settle                                             |
 
 
 Already done (do not re-open unless regression): A small fixes (including `.xml` pickers), maps de-uglify, target visualisation pane removal, CLUSTER/SECTION colour/cleanup, Handlebars language + template tab, XQuery Model B emit.
@@ -106,13 +138,18 @@ Already done (do not re-open unless regression): A small fixes (including `.xml`
   - [x] 3.4 Nested openEHR toolbox drawers; missing RM blocks in flyout
   - [x] 3.5 TypeScript codegen for `PARTY_REF`, list-valued `identifiers`
   - [x] 3.6 Tests + README note (full Demographics compositions still future)
-- [ ] 4.0 Chunk 4 — AI copy-paste polish (roadmap I) — **grill round 3 pending user answers**
-- [ ] 5.0 Chunk 5 — Colourblind language + sync highlight
-- [ ] 6.0 Chunk 6 — Handlebars Test Run + round-trip
-- [ ] 7.0 Chunk 7 — CSV / FHIR tables
-- [ ] 8.0 Chunk 8 — Conversion script goldens + XQuery Model A/C
-- [ ] 9.0 Chunk 9 — GitHub save, UI i18n, dependency hashes
-- [ ] 10.0 Chunk 10 — Schema-driven dynamic toolboxes
-- [ ] 11.0 Chunk 11 — Better Form parity
+- [ ] 4.0 Chunk 4 — AI copy-paste polish (roadmap I)
+  - [ ] 4.1 `buildPrompt`: openEHR references section (openehr-assistant MCP hint + doc links) when target is openEHR
+  - [ ] 4.2 Expand suggestion envelope: `maps_get` in schema, docs, import codegen; prompt examples for loops / defaults / party `name`
+  - [ ] 4.3 Import dialog: apply-valid-only with clear applied / skipped / schema counts (Q5)
+  - [ ] 4.4 Fixture + round-trip tests only (no live LLM in CI)
+  - [ ] 4.5 ROADMAP I items ticked; Q2 label already on `main`
+- [ ] 5.0 Chunk 5 — Local app + installable AI skill (roadmap D)
+- [ ] 6.0 Chunk 6 — Schema-driven dynamic toolboxes (roadmap H)
+- [ ] 7.0 Chunk 7 — Handlebars Test Run + round-trip (roadmap G)
+- [ ] 8.0 Chunk 8 — CSV / FHIR tables (roadmap C)
+- [ ] 9.0 Chunk 9 — Conversion script goldens + XQuery Model A/C (roadmap J/K)
+- [ ] 10.0 Chunk 10 — GitHub save, UI i18n, dependency hashes (roadmap B/L)
+- [ ] 11.0 Chunk 11 — Better Form parity (roadmap G)
 - [ ] 12.0 Chunk 12 — Java Export UI / VS Code host / Autoplay E2E
-- [ ] 13.0 Chunk 13 — Local app + installable AI skill
+- [ ] 13.0 Chunk 13 — Colourblind language + sync highlight (roadmap B)

--- a/tasks/TASKS-roadmap-chunks.md
+++ b/tasks/TASKS-roadmap-chunks.md
@@ -138,12 +138,12 @@ Already done (do not re-open unless regression): A small fixes (including `.xml`
   - [x] 3.4 Nested openEHR toolbox drawers; missing RM blocks in flyout
   - [x] 3.5 TypeScript codegen for `PARTY_REF`, list-valued `identifiers`
   - [x] 3.6 Tests + README note (full Demographics compositions still future)
-- [ ] 4.0 Chunk 4 — AI copy-paste polish (roadmap I)
-  - [ ] 4.1 `buildPrompt`: openEHR references section (openehr-assistant MCP hint + doc links) when target is openEHR
-  - [ ] 4.2 Expand suggestion envelope: `maps_get` in schema, docs, import codegen; prompt examples for loops / defaults / party `name`
-  - [ ] 4.3 Import dialog: apply-valid-only with clear applied / skipped / schema counts (Q5)
-  - [ ] 4.4 Fixture + round-trip tests only (no live LLM in CI)
-  - [ ] 4.5 ROADMAP I items ticked; Q2 label already on `main`
+- [x] 4.0 Chunk 4 — AI copy-paste polish (roadmap I)
+  - [x] 4.1 `buildPrompt`: openEHR references section (openehr-assistant MCP hint + doc links) when target is openEHR
+  - [x] 4.2 Expand suggestion envelope: `maps_get` in schema, docs, import codegen; prompt examples for loops / defaults / party `name`
+  - [x] 4.3 Import dialog: apply-valid-only with clear applied / skipped / schema counts (Q5)
+  - [x] 4.4 Fixture + round-trip tests only (no live LLM in CI)
+  - [x] 4.5 ROADMAP I items ticked; Q2 label already on `main`
 - [ ] 5.0 Chunk 5 — Local app + installable AI skill (roadmap D)
 - [ ] 6.0 Chunk 6 — Schema-driven dynamic toolboxes (roadmap H)
 - [ ] 7.0 Chunk 7 — Handlebars Test Run + round-trip (roadmap G)

--- a/test/import_ai_dialog_test.ts
+++ b/test/import_ai_dialog_test.ts
@@ -35,6 +35,7 @@ Deno.test("formatImportReport is partial when mappings applied with schema issue
   });
   assertEquals(kind, "partial");
   assertEquals(summary.includes("1 schema"), true);
+  assertEquals(summary.includes("valid entries only"), true);
 });
 
 Deno.test("locateIssueInText highlights an invalid block type", () => {

--- a/test/persistence_ai_test.ts
+++ b/test/persistence_ai_test.ts
@@ -248,6 +248,7 @@ Deno.test("buildPrompt openEHR target includes references and block examples", (
   assertEquals(prompt.includes("deepwiki.com/ErikSundvall/ehrtslib"), true);
   assertEquals(prompt.includes("## Block examples"), true);
   assertEquals(prompt.includes("icd10_snomed"), true);
+  assertEquals(prompt.includes("source takes precedence"), true);
   assertEquals(prompt.includes("maps_get"), true);
   assertEquals(prompt.includes("OPENEHR_PRIMER.md"), false);
 });

--- a/test/persistence_ai_test.ts
+++ b/test/persistence_ai_test.ts
@@ -243,10 +243,13 @@ Deno.test("buildPrompt openEHR target includes references and block examples", (
   });
   assertEquals(prompt.includes("## openEHR references"), true);
   assertEquals(prompt.includes("openehr-assistant MCP"), true);
-  assertEquals(prompt.includes("OPENEHR_PRIMER.md"), true);
+  assertEquals(prompt.includes("cadasto/openehr-assistant-plugin"), true);
+  assertEquals(prompt.includes("llms.txt"), true);
   assertEquals(prompt.includes("deepwiki.com/ErikSundvall/ehrtslib"), true);
   assertEquals(prompt.includes("## Block examples"), true);
+  assertEquals(prompt.includes("icd10_snomed"), true);
   assertEquals(prompt.includes("maps_get"), true);
+  assertEquals(prompt.includes("OPENEHR_PRIMER.md"), false);
 });
 
 Deno.test("buildPrompt uri lists browseable URLs", () => {

--- a/test/persistence_ai_test.ts
+++ b/test/persistence_ai_test.ts
@@ -99,6 +99,67 @@ Deno.test("AI import keeps loopVar relative paths", () => {
   assertEquals(next.loops, [{ attachSlotId: "t1/events", varName: "vital", path: "$.vitals" }]);
 });
 
+Deno.test("AI import applies maps_get suggestion", () => {
+  const model = createEmptyModel("t1");
+  model.targetFormat = "openehr-template";
+  const { model: next, report } = importSuggestions(model, {
+    format: "intehrgrator-suggestions",
+    version: "2",
+    target: { format: "openehr-template", targetId: "t1" },
+    suggestions: [{
+      slotId: "t1/language/value",
+      block: {
+        type: "maps_get",
+        fields: { NAME: "defaults" },
+        inputs: {
+          KEY: { block: { type: "text", fields: { TEXT: "language" } } },
+        },
+      },
+    }],
+  }, new Set(["t1/language/value"]));
+  assertEquals(report.applied, 1);
+  assertEquals(next.slots[0].expression, 'maps_get("defaults", "language")');
+});
+
+Deno.test("AI import applies valid entries when envelope has schema issues", () => {
+  const model = createEmptyModel("t1");
+  model.targetFormat = "json-schema";
+  const payload = parseSuggestionsPayload(`{
+    "format": "intehrgrator-suggestions",
+    "version": "2",
+    "target": { "format": "json-schema", "targetId": "t1" },
+    "suggestions": [
+      {
+        "slotId": "t1:$.good",
+        "block": { "type": "source_query", "fields": { "EXPRESSION": "$.name" } }
+      },
+      {
+        "slotId": "t1:$.bad",
+        "block": { "type": "not_a_real_block", "fields": {} }
+      }
+    ]
+  }`);
+  const schemaIssues = validateSuggestionEnvelope(JSON.parse(`{
+    "format": "intehrgrator-suggestions",
+    "version": "2",
+    "target": { "format": "json-schema", "targetId": "t1" },
+    "suggestions": [
+      { "slotId": "t1:$.good", "block": { "type": "source_query", "fields": { "EXPRESSION": "$.name" } } },
+      { "slotId": "t1:$.bad", "block": { "type": "not_a_real_block", "fields": {} } }
+    ]
+  }`));
+  const { model: next, report } = importSuggestions(
+    model,
+    payload,
+    new Set(["t1:$.good", "t1:$.bad"]),
+  );
+  report.schemaIssues = schemaIssues;
+  assertEquals(report.applied, 1);
+  assertEquals(report.skipped, 1);
+  assertEquals(schemaIssues.length > 0, true);
+  assertEquals(next.slots[0].expression, 'xpathString("$.name")');
+});
+
 Deno.test("joinLoopPath", () => {
   assertEquals(joinLoopPath("$.vitals", "systolic"), "$.vitals[*].systolic");
   assertEquals(joinLoopPath("$.vitals[*]", "systolic"), "$.vitals[*].systolic");
@@ -164,6 +225,28 @@ Deno.test("buildPrompt inline embeds multipart body", () => {
   assertEquals(prompt.includes('X-Intehrgrator-Role: source-schema'), true);
   assertEquals(prompt.includes('{"type":"object"}'), true);
   assertEquals(prompt.includes("AI_SUGGESTION_FORMAT.schema.json"), true);
+});
+
+Deno.test("buildPrompt openEHR target includes references and block examples", () => {
+  const model = createEmptyModel("t1");
+  model.targetFormat = "openehr-template";
+  const prompt = buildPrompt({
+    scope: "full",
+    targetId: "t1",
+    targetFormat: "openehr-template",
+    targetFilename: "bp.opt",
+    skeleton: [],
+    model,
+    formatDocUrl: "https://example.test/docs/AI_SUGGESTION_FORMAT.md",
+    delivery: "attach",
+    artifacts: [],
+  });
+  assertEquals(prompt.includes("## openEHR references"), true);
+  assertEquals(prompt.includes("openehr-assistant MCP"), true);
+  assertEquals(prompt.includes("OPENEHR_PRIMER.md"), true);
+  assertEquals(prompt.includes("deepwiki.com/ErikSundvall/ehrtslib"), true);
+  assertEquals(prompt.includes("## Block examples"), true);
+  assertEquals(prompt.includes("maps_get"), true);
 });
 
 Deno.test("buildPrompt uri lists browseable URLs", () => {
@@ -352,6 +435,25 @@ Deno.test("suggestion JSON Schema accepts the documented repeating-vitals exampl
       block: {
         type: "source_query_number",
         fields: { EXPRESSION: "systolic" },
+      },
+    }],
+  });
+  assertEquals(issues, []);
+});
+
+Deno.test("suggestion JSON Schema accepts maps_get", () => {
+  const issues = validateSuggestionEnvelope({
+    format: "intehrgrator-suggestions",
+    version: "2",
+    target: { format: "openehr-template", targetId: "t1" },
+    suggestions: [{
+      slotId: "t1/language/value",
+      block: {
+        type: "maps_get",
+        fields: { NAME: "defaults" },
+        inputs: {
+          KEY: { block: { type: "text", fields: { TEXT: "language" } } },
+        },
       },
     }],
   });

--- a/test/ui/import_ai_codegen_test.ts
+++ b/test/ui/import_ai_codegen_test.ts
@@ -56,6 +56,8 @@ Deno.test({
       assertStringIncludes(prompt, "intehrgrator-suggestions");
       assertStringIncludes(prompt, "## openEHR references");
       assertStringIncludes(prompt, "openehr-assistant MCP");
+      assertStringIncludes(prompt, "cadasto/openehr-assistant-plugin");
+      assertStringIncludes(prompt, "icd10_snomed");
 
       const { slotId, targetId, envelope } = suggestionsFromPrompt(prompt);
       assert(slotId.endsWith(systolicSuffix), slotId);

--- a/test/ui/import_ai_codegen_test.ts
+++ b/test/ui/import_ai_codegen_test.ts
@@ -54,6 +54,8 @@ Deno.test({
       );
       assertStringIncludes(prompt, "## Slot manifest");
       assertStringIncludes(prompt, "intehrgrator-suggestions");
+      assertStringIncludes(prompt, "## openEHR references");
+      assertStringIncludes(prompt, "openehr-assistant MCP");
 
       const { slotId, targetId, envelope } = suggestionsFromPrompt(prompt);
       assert(slotId.endsWith(systolicSuffix), slotId);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Chunk 4** (roadmap I — AI copy-paste polish) per adopted grill round 3 answers, and reorders later roadmap chunks in `tasks/TASKS-roadmap-chunks.md`.

### Latest refinements

- **Source over defaults**: when source has data for slots scaffold/defaults would fill (time, healthcare facility, composer, …), map from **source** — source takes precedence; omit defaults-only slots only when source has no value
- **Maps / terminology**: ICD-10 → SNOMED CT `maps_get` example is primary
- **openEHR references**: openEHR Assistant Plugin link + `llms.txt` index

### Testing

- `deno task test` — **318 passed**
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79b41d92-3024-460a-8b42-1211c5877430?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79b41d92-3024-460a-8b42-1211c5877430&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

