### PR TITLE
Keep maps; join Lists & maps toolbox; desktop 0.5

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,7 +45,7 @@ Blockly loop that binds each node from a multi-valued Source Path to a named var
 _Avoid_: Context boundary, frame as context root (unless discussing kintegrate)
 
 **Map**:
-A key-value collection in the Mapping Editor, parallel to a Blockly List. Entries are retrieved by key, not by index. Used for a **Defaults Map** and other 1D lookups.
+A key-value collection in the Mapping Editor, parallel to a Blockly List. Entries are retrieved by key, not by index. Used for a **Defaults Map** and other 1D lookups. Toolbox: list and map blocks share one **Lists & maps** drawer; **Sheets** is a separate drawer.
 _Avoid_: Dictionary, hashmap, JSON object (the object/member stack is a different Blockly metaphor), **Sheet** (2D grid)
 
 **Sheet** (matrix / spreadsheet):

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ Visual integration workbench for mapping source data (JSON/XML) to openEHR Compo
 ## Webapp for users
 Go to https://regionstockholm.github.io/intehrgrator/ click (i) - encircled i - at various places in the interface to learn about use.
 
-## Desktop app (0.3)
+## Desktop app (0.5)
 
 Download a platform build from [Releases](https://github.com/regionstockholm/intehrgrator/releases) and run it locally — no Deno install, no GitHub Pages. The same workbench opens in a native window (OS webview) and talks only to `127.0.0.1`.
 
-**New in 0.3:** localhost **Agent API** and stdio **MCP** server for IDE/AI agents, plus an installable mapping skill. See [docs/AGENT_WORKFLOW.md](docs/AGENT_WORKFLOW.md) and [.cursor/skills/intehrgrator-mapping/SKILL.md](.cursor/skills/intehrgrator-mapping/SKILL.md).
+**New in 0.5:** **Sheets** in Mapping Editors (jspreadsheet-ce widget, CSV import/export, `sheet_*` Blockly accessors, convert-time `ctx.sheets` bag). Lists and Maps share one toolbox drawer (**Lists & maps**); `maps_*` stay for Defaults Map and nested Blockly values. See [docs/ROADMAP.md](docs/ROADMAP.md) §C and [tasks/DESIGN-sheets-vs-maps.md](tasks/DESIGN-sheets-vs-maps.md).
+
+**From 0.3:** localhost **Agent API** and stdio **MCP** server for IDE/AI agents, plus an installable mapping skill. See [docs/AGENT_WORKFLOW.md](docs/AGENT_WORKFLOW.md) and [.cursor/skills/intehrgrator-mapping/SKILL.md](.cursor/skills/intehrgrator-mapping/SKILL.md).
 
 | Asset | Platform |
 | --- | --- |

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@regionstockholm/intehrgrator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "exports": "./src/mod.ts",
   "nodeModulesDir": "auto",
   "compilerOptions": {

--- a/docs/BLOCKLY_INTEGRATION.md
+++ b/docs/BLOCKLY_INTEGRATION.md
@@ -62,10 +62,10 @@ cogwheel mutator (`optional_rm_mutator` / `dv_fields_mutator`), not a custom `+`
 ### 4. Control Flow & Utility Blocks
 
 Toolbox layout and stock categories follow the Blockly DevSite landing demo
-(Logic, Loops, Math, Text, Lists, Variables, Functions) plus intEHRgrator
-categories **Source** and **Data values**, with `@blockly/toolbox-search`
+(Logic, Loops, Math, Text, Lists & maps, Variables, Functions) plus intEHRgrator
+categories **Source**, **Data values**, and **Sheets**, with `@blockly/toolbox-search`
 (`kind: "search"`) at the top so Search covers every `kind: "block"` drawer
-including custom Source, openEHR types, and Maps. See [Attribution](#attribution).
+including custom Source, openEHR types, Maps (`maps_*` in **Lists & maps**), and Sheets. See [Attribution](#attribution).
 
 - **Stock Blockly:** `controls_if`, `controls_whileUntil`, `controls_repeat_ext`,
   `math_arithmetic`, `text_join`, `text_trim`, `logic_ternary`, variables, procedures, …

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -25,6 +25,7 @@
 - [x] De-uglify the maps implementation to look more like App Inventor / BlockPy: keys in a column of text fields, values as right-edge connectors that take ordinary Blockly blocks (`text`, `math_number`, source queries, nested maps). Layout follows App Inventor `dictionaries_create_with` (stacked, not inline, `Align.RIGHT`) plus Blockly JSON-object members (`FieldTextInput` + `:` + value socket). Legacy `KEY{n}` input JSON is migrated on load.
 - [x] **Chunk 8 — spreadsheet/matrix first:** embed a real sheet widget (Excel/Sheets paste, named column headers, optional row names, typed columns). Persist a project-owned 2D sheet model. Library comparison: [spreadsheet-matrix-libraries.md](future/spreadsheet-matrix-libraries.md). **Then** add Blockly accessor/mutator blocks whose names follow that library’s get/set/insert/delete/header API (cell A1 or x,y; row; column; header; bulk data; lookup-by-content). Maps stay 1D key→value (`maps_get`); sheets are the 2D structure for terminology grids (e.g. later: code + rubric → `DV_CODED_TEXT`).
 - [x] Digest CSV / Excel / Google Sheets **into that sheet** (clipboard paste + file), not into `maps_create_with`.
+- [x] **Keep `maps_*`** for Defaults Map + nested Blockly values (Chunk 8 Q9 step 2, option A). Join Lists + Maps toolbox drawers into **Lists & maps**. Sheets stay a separate drawer. See [`tasks/DESIGN-sheets-vs-maps.md`](../tasks/DESIGN-sheets-vs-maps.md).
 - [ ] FHIR ConceptMap / ValueSet → sheet/map import — **deferred** (after the sheet widget + Blockly accessors exist)
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "intehrgrator",
   "displayName": "intEHRgrator",
   "description": "Visual healthcare integration mapping workbench",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "regionstockholm",
   "license": "Apache-2.0",
   "engines": {

--- a/scripts/desktop.compile.json
+++ b/scripts/desktop.compile.json
@@ -1,6 +1,6 @@
 {
   "name": "intehrgrator",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "exports": "./../src/desktop/main.ts",
   "nodeModulesDir": "none",
   "compilerOptions": {

--- a/src/agent/mcp_stdio.ts
+++ b/src/agent/mcp_stdio.ts
@@ -4,6 +4,7 @@
  */
 
 import { getSharedWorkbenchService } from "./http.ts";
+import { APP_VERSION } from "../core/persistence/mod.ts";
 
 type JsonRpcId = string | number | null;
 
@@ -296,7 +297,7 @@ async function handleRequest(req: JsonRpcRequest, client: AgentClient): Promise<
       reply({
         protocolVersion: "2024-11-05",
         capabilities: { tools: {} },
-        serverInfo: { name: "intehrgrator", version: "0.4.0" },
+        serverInfo: { name: "intehrgrator", version: APP_VERSION },
       });
       return;
     }

--- a/src/blockly/i18n/custom_msg.ts
+++ b/src/blockly/i18n/custom_msg.ts
@@ -30,8 +30,7 @@ export interface IntehrMessages {
   CAT_LOOPS: string;
   CAT_MATH: string;
   CAT_TEXT: string;
-  CAT_LISTS: string;
-  CAT_MAPS: string;
+  CAT_LISTS_AND_MAPS: string;
   CAT_SHEETS: string;
   CAT_VARIABLES: string;
   CAT_PROCEDURES: string;
@@ -70,8 +69,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_LOOPS: "Loops",
     CAT_MATH: "Math",
     CAT_TEXT: "Text",
-    CAT_LISTS: "Lists",
-    CAT_MAPS: "Maps",
+    CAT_LISTS_AND_MAPS: "Lists & maps",
     CAT_SHEETS: "Sheets",
     CAT_VARIABLES: "Variables",
     CAT_PROCEDURES: "Functions",
@@ -112,8 +110,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_LOOPS: "Loopar",
     CAT_MATH: "Matematik",
     CAT_TEXT: "Text",
-    CAT_LISTS: "Listor",
-    CAT_MAPS: "Mappar",
+    CAT_LISTS_AND_MAPS: "Listor & mappar",
     CAT_SHEETS: "Kalkylblad",
     CAT_VARIABLES: "Variabler",
     CAT_PROCEDURES: "Funktioner",
@@ -154,8 +151,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_LOOPS: "Schleifen",
     CAT_MATH: "Mathematik",
     CAT_TEXT: "Text",
-    CAT_LISTS: "Listen",
-    CAT_MAPS: "Maps",
+    CAT_LISTS_AND_MAPS: "Listen & Maps",
     CAT_SHEETS: "Tabellen",
     CAT_VARIABLES: "Variablen",
     CAT_PROCEDURES: "Funktionen",
@@ -196,8 +192,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_LOOPS: "Bucles",
     CAT_MATH: "Matemáticas",
     CAT_TEXT: "Texto",
-    CAT_LISTS: "Listas",
-    CAT_MAPS: "Mapas",
+    CAT_LISTS_AND_MAPS: "Listas y mapas",
     CAT_SHEETS: "Hojas",
     CAT_VARIABLES: "Variables",
     CAT_PROCEDURES: "Funciones",
@@ -238,8 +233,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_LOOPS: "Bucles",
     CAT_MATH: "Matemàtiques",
     CAT_TEXT: "Text",
-    CAT_LISTS: "Llistes",
-    CAT_MAPS: "Mapes",
+    CAT_LISTS_AND_MAPS: "Llistes i mapes",
     CAT_SHEETS: "Fulls",
     CAT_VARIABLES: "Variables",
     CAT_PROCEDURES: "Funcions",
@@ -280,8 +274,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_LOOPS: "Boucles",
     CAT_MATH: "Math",
     CAT_TEXT: "Texte",
-    CAT_LISTS: "Listes",
-    CAT_MAPS: "Maps",
+    CAT_LISTS_AND_MAPS: "Listes et maps",
     CAT_SHEETS: "Feuilles",
     CAT_VARIABLES: "Variables",
     CAT_PROCEDURES: "Fonctions",

--- a/src/blockly/toolbox_demo.ts
+++ b/src/blockly/toolbox_demo.ts
@@ -429,9 +429,9 @@ export function buildDemoToolbox(locale: string, context: ToolboxContext = {}): 
       },
       {
         kind: "category",
-        name: m.CAT_LISTS,
+        name: m.CAT_LISTS_AND_MAPS,
         colour: 172,
-        cssconfig: { row: "blocklyToolboxCategory blocklyToolboxCategoryLists" },
+        cssconfig: { row: "blocklyToolboxCategory blocklyToolboxCategoryListsMaps" },
         contents: [
           { kind: "block", type: "lists_create_with", extraState: { itemCount: 0 } },
           { kind: "block", type: "lists_create_with", extraState: { itemCount: 3 } },
@@ -457,14 +457,6 @@ export function buildDemoToolbox(locale: string, context: ToolboxContext = {}): 
           },
           { kind: "block", type: "lists_sort" },
           { kind: "block", type: "lists_reverse" },
-        ],
-      },
-      {
-        kind: "category",
-        name: m.CAT_MAPS,
-        colour: 260,
-        cssconfig: { row: "blocklyToolboxCategory blocklyToolboxCategoryMaps" },
-        contents: [
           { kind: "block", type: "maps_create_with", extraState: { itemCount: 0 } },
           mapsCreateWithToolboxBlock(3),
           { kind: "block", type: "maps_create_empty" },

--- a/src/core/persistence/mod.ts
+++ b/src/core/persistence/mod.ts
@@ -1,7 +1,7 @@
 import { compressSync, decompressSync, strToU8, strFromU8, zipSync, unzipSync } from "fflate";
 import type { ProjectBundle } from "../../types/mod.ts";
 
-export const APP_VERSION = "0.4.0";
+export const APP_VERSION = "0.5.0";
 export const BUNDLE_VERSION = 1;
 export const AUTOSAVE_STORAGE_KEY = "__autosave__";
 export const MANUAL_SAVE_KEY_PREFIX = "manual:";

--- a/tasks/DESIGN-sheets-vs-maps.md
+++ b/tasks/DESIGN-sheets-vs-maps.md
@@ -1,8 +1,10 @@
 # Design note: Sheets vs Maps (Chunk 8 follow-up)
 
-**Status:** alternatives for a **second implementation step**. Chunk 8 keeps `maps_*` blocks. Do not delete them until this note is judged.
+**Status:** **Adopted 2026-09-04 — option A**, plus a toolbox join.
 
 **Adopted Chunk 8 (Q9 mostly B):** replace maps in **code and example sets** when they are used as 2-column terminology lookups. Leave Defaults Map and nested Blockly map **values** alone.
+
+**Adopted step 2 (this judgement):** **Keep `maps_*`.** Do not delete map blocks. Join the Blockly **Lists** and **Maps** toolbox drawers into one category named **Lists & maps**. **Sheets** stays a separate drawer. Optional later: `sheet_to_map` (two columns → Map) for `maps_get` compatibility.
 
 ## Why maps cannot vanish in one step
 
@@ -15,41 +17,43 @@
 
 - New **Sheet** document + widget + `sheet_*` Blockly accessors (including `sheet_lookup`).
 - AI suggestion examples for **terminology translation** prefer `sheet_lookup` over `maps_get`.
-- Toolbox: Maps category kept; **Sheets** category added.
+- Toolbox: **Lists & maps** is one drawer (`maps_*` kept). **Sheets** is a separate category.
 
-## Alternatives for step 2 (judge before deleting `maps_*`)
+## Alternatives for step 2 (judged)
 
-### A — Keep maps for Defaults + structured values; sheets for 2D grids
+### A — Keep maps for Defaults + structured values; sheets for 2D grids — **adopted**
 
 **Do:** leave `maps_*` and `defaults_block` as they are. Terminology / code+rubric tables live only on Sheets. Optional later: `sheet_to_map` (two columns → Map) for `maps_get` compatibility.
+
+**Plus (this judgement):** one toolbox category **Lists & maps** (not two drawers). Sheets remain separate.
 
 **Pros:** no migration of Defaults or nested values; clear glossary split (CONTEXT already says Map ≠ Sheet).  
 **Cons:** two lookup vocabularies forever; informaticians may still build 2-col maps by habit.
 
 **Recommendation if the goal is “stop using maps as fake spreadsheets” without rewriting Defaults.**
 
-### B — Dual-read period, then drop terminology maps
+### B — Dual-read period, then drop terminology maps — not adopted
 
 **Do:** for a release or two, `maps_get("icd10_snomed", key)` also looks up a **Sheet** of that name (first two columns as key/value) when no Map of that name exists. Then remove toolbox `maps_create_with` except as the Defaults argument, and eventually remove dual-read.
 
 **Pros:** old mappings keep working; one lookup block in slots.  
 **Cons:** silent fallback is hard to explain; name collisions (a Map and a Sheet both called `defaults`).
 
-### C — `sheet_to_map` + migrate 2-col string maps
+### C — `sheet_to_map` + migrate 2-col string maps — deferred
 
 **Do:** scan workspaces for `maps_create_with` whose values are all string/number literals (no nested blocks). Offer “Convert to Sheet”. Keep `maps_create_with` for Defaults and for structured values. Add Blockly `sheet_to_map` (header `code` + header `rubric` → Map) so generated scripts can still call `maps_get` if desired.
 
 **Pros:** explicit migration; nested values untouched.  
 **Cons:** one-shot UI; leftover maps still in toolbox.
 
-### D — Defaults becomes a Sheet named `defaults`
+### D — Defaults becomes a Sheet named `defaults` — rejected
 
 **Do:** rebind `defaults_block` to a Sheet (one row of keys, or two columns key/value). `maps_get("defaults", key)` becomes `sheet_lookup("defaults", "key", key, "value")` or `sheet_get_cell`.
 
 **Pros:** one matrix widget for everything tabular.  
 **Cons:** **loses nested Blockly values** unless we invent per-cell block refs (rejected in Chunk 8 Q6). Factory Defaults (language CODE_PHRASE, encoding, facility PARTY) are not primitives today — they are typed blocks. This option is **unsafe** until Defaults values are flattened to strings (a product change, not a storage change).
 
-### E — Hybrid Defaults: Sheet for scalars, Map for structured leftovers
+### E — Hybrid Defaults: Sheet for scalars, Map for structured leftovers — not adopted
 
 **Do:** scalar ctx keys (`language`, `territory`, `encoding` as strings) move to a `defaults` Sheet. Structured keys (`health_care_facility` as `PARTY_IDENTIFIED`) stay on a Map (or stay scaffolded RM shells, not a table).
 
@@ -60,9 +64,9 @@
 
 Pick one:
 
-1. **A only** (live with both; maybe `sheet_to_map` later) — lowest risk.
+1. **A only** (live with both; maybe `sheet_to_map` later) — lowest risk. **← adopted**, with Lists + Maps joined in the toolbox.
 2. **C** (migrate obvious 2-col maps; keep Defaults Map) — if the canvas already has terminology maps to convert.
 3. **B** (dual-read) — if you want `maps_get` in slots to keep working against sheets without touching blocks.
 4. **Do not pick D** unless Defaults nested blocks are explicitly given up.
 
-After that judgement, a later chunk can delete unused `maps_*` toolbox entries — not before.
+`maps_*` toolbox entries stay. A later chunk can still add `sheet_to_map`; deleting map blocks is out of scope until Defaults/nested values have another home.

--- a/tasks/TASKS-roadmap-chunks.md
+++ b/tasks/TASKS-roadmap-chunks.md
@@ -744,7 +744,9 @@ Include in Chunk 8:
 **B** — Replace terminology `maps_get` with sheets immediately.
 **C** — Auto-project every 2-column sheet into a named Map.
 
-➡️ **Adopted: mostly B.** If maps are used in **code or example sets** as 2-column terminology lookups, **replace with sheets**. **Do not delete `maps_*` in this step.** Defaults Map and map **values** can be entire Blockly structures — that stays. Present alternatives for a **second implementation step** in [`DESIGN-sheets-vs-maps.md`](./DESIGN-sheets-vs-maps.md) and wait for a judgement before removing map blocks.
+➡️ **Adopted: mostly B, then step 2 = A.** If maps are used in **code or example sets** as 2-column terminology lookups, **replace with sheets**. **Do not delete `maps_*`.** Defaults Map and map **values** can be entire Blockly structures — that stays.
+
+**Step 2 (2026-09-04):** keep maps; join Lists + Maps toolbox drawers into **Lists & maps**; Sheets remain a separate category. Recorded in [`DESIGN-sheets-vs-maps.md`](./DESIGN-sheets-vs-maps.md) and `docs/ROADMAP.md` §C.
 
 ---
 
@@ -770,7 +772,7 @@ Include in Chunk 8:
 ### Chunk 8 implementation notes (adopted 2026-09-04)
 
 - **Order:** jspreadsheet-ce (Q1, including native import/export/fullscreen/i18n/Excel paste + host undo) → persist Sheet JSON (Q2) → embed widget in Mapping Editors with scrollbars, adjustable split, modal/fullscreen (Q3, Q7) → Blockly accessors/mutators (Q5) → Test Run/codegen bag (Q8).
-- **Maps:** keep `maps_*`; replace terminology-style usage in code/prompts; Defaults + nested Blockly map values stay. Second step: [`DESIGN-sheets-vs-maps.md`](./DESIGN-sheets-vs-maps.md).
+- **Maps:** keep `maps_*`; replace terminology-style usage in code/prompts; Defaults + nested Blockly map values stay. Step 2 adopted: option A + joint **Lists & maps** toolbox category ([`DESIGN-sheets-vs-maps.md`](./DESIGN-sheets-vs-maps.md)).
 - **Defer:** FHIR; Excel formulas/merge/style; per-cell nested Blockly; `DV_CODED_TEXT` composite helper; deleting `maps_*`.
 - **Do not** paste into `maps_create_with` as the 2D representation.
 
@@ -779,7 +781,7 @@ Include in Chunk 8:
 - `docs/future/spreadsheet-matrix-libraries.md` — library comparison
 - `src/core/sheets/` — Sheet JSON model + lookup (new)
 - `web/` — widget host + paste
-- `src/blockly/blocks/` — `sheet_*` blocks (new); Maps toolbox
+- `src/blockly/blocks/` — `sheet_*` blocks (new); Lists & maps toolbox (`maps_*` kept)
 - `src/core/source/query_runtime.ts`, `src/core/expression/mod.ts` — evaluate accessors
 - `src/core/codegen/` — emit sheet lookups
 - `src/core/test_runner/mod.ts` — `ctx.sheets`
@@ -792,6 +794,7 @@ Include in Chunk 8:
   - [x] 8.5 Test Run + codegen: named sheets bag
   - [x] 8.6 Tests: model, paste, Blockly round-trip, lookup in `runTest`
   - [x] 8.7 Docs: ROADMAP §C, CONTEXT Sheet vs Map
+  - [x] 8.8 Q9 step 2: keep `maps_*`; join Lists + Maps into **Lists & maps**; Sheets stay separate
   - [ ] (later) FHIR ConceptMap → sheet
   - [ ] (later) formulas / `DV_CODED_TEXT` helper / `sheet_to_map`
 

--- a/test/sheets_test.ts
+++ b/test/sheets_test.ts
@@ -168,7 +168,7 @@ Deno.test("project bundle round-trips sheets JSON", () => {
   const bundle: ProjectBundle = {
     version: BUNDLE_VERSION,
     projectId: "p1",
-    appVersion: "0.4.0",
+    appVersion: "0.5.0",
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     template: null,

--- a/test/toolbox_search_test.ts
+++ b/test/toolbox_search_test.ts
@@ -22,3 +22,22 @@ Deno.test("toolbox contains a search category above the minimap covering custom 
     assert(types.includes(type), `toolbox-search index should include ${type}`);
   }
 });
+
+Deno.test("Lists and Maps share one toolbox drawer; Sheets stays separate", () => {
+  const toolbox = buildDemoToolbox("en") as {
+    contents: Array<{ name?: string; contents?: Array<{ type?: string }> }>;
+  };
+  const names = toolbox.contents.map((c) => c.name);
+  assertEquals(names.filter((n) => n === msg("en").CAT_LISTS_AND_MAPS).length, 1);
+  assertEquals(names.includes("Lists"), false);
+  assertEquals(names.includes("Maps"), false);
+  const joint = toolbox.contents.find((c) => c.name === msg("en").CAT_LISTS_AND_MAPS);
+  const types = (joint?.contents ?? []).map((block) => block.type);
+  assert(types.includes("lists_create_with"), "joint drawer includes list blocks");
+  assert(types.includes("maps_get"), "joint drawer includes map blocks");
+  assert(types.includes("maps_create_with"), "joint drawer includes maps_create_with");
+  const sheets = toolbox.contents.find((c) => c.name === msg("en").CAT_SHEETS);
+  assert(sheets, "Sheets remains its own drawer");
+  const sheetTypes = (sheets?.contents ?? []).map((block) => block.type);
+  assert(sheetTypes.includes("sheet"), "Sheets drawer still has sheet blocks");
+});

--- a/web/styles.css
+++ b/web/styles.css
@@ -540,11 +540,8 @@ body.sheets-fullscreen::before {
 .blockly-mount .blocklyToolboxCategoryText {
   border-left: 15px solid #ffca28 !important;
 }
-.blockly-mount .blocklyToolboxCategoryLists {
+.blockly-mount .blocklyToolboxCategoryListsMaps {
   border-left: 15px solid #4db6ac !important;
-}
-.blockly-mount .blocklyToolboxCategoryMaps {
-  border-left: 15px solid #7e57c2 !important;
 }
 .blockly-mount .blocklyToolboxCategorySheets {
   border-left: 15px solid #00897B !important;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Chunk 8 Q9 implementation step 2: keep `maps_*`, join the Lists and Maps toolbox drawers, and cut desktop **0.5**.

## Decision (Q9 step 2)

Adopted **option A** from [`tasks/DESIGN-sheets-vs-maps.md`](../tasks/DESIGN-sheets-vs-maps.md):

- **Keep** `maps_*` for Defaults Map and nested Blockly values.
- **Do not** delete map blocks.
- Join Lists + Maps into one toolbox category **Lists & maps** (localized).
- **Sheets** stays its own drawer.
- Roadmap §C and Chunk 8 tasks record this judgement.

## Version

App version **0.5.0**. GitHub Release **[0.5](https://github.com/regionstockholm/intehrgrator/releases/tag/v0.5)** (`v0.5`) includes Windows zip, Linux AppImage, and both macOS zips.

## Tests

`deno task test` — 381 passed (headless). New unit test asserts one **Lists & maps** drawer containing both `lists_*` and `maps_*`, with Sheets still separate.

Browser: toolbox shows **Lists & maps** (list blocks + `maps_get` / `maps_create_with`); no separate Lists or Maps drawers; Sheets remains its own category.

[lists-and-maps-toolbox.mp4](https://cursor.com/agents/bc-95d08283-9d77-4eea-8f86-58f999f820b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flists-and-maps-toolbox.mp4)
[Toolbox category Lists & maps next to Sheets](https://cursor.com/agents/bc-95d08283-9d77-4eea-8f86-58f999f820b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoolbox_lists_and_maps_category.webp)
[Lists & maps flyout with list and map blocks](https://cursor.com/agents/bc-95d08283-9d77-4eea-8f86-58f999f820b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoolbox_lists_and_maps_flyout.webp)
[Sheets still a separate toolbox drawer](https://cursor.com/agents/bc-95d08283-9d77-4eea-8f86-58f999f820b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftoolbox_sheets_separate.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95d08283-9d77-4eea-8f86-58f999f820b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95d08283-9d77-4eea-8f86-58f999f820b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

