### PR TITLE
Restore abstract ⁇ tip alongside attribute help viewer

### DIFF
--- a/src/blockly/block_checks.ts
+++ b/src/blockly/block_checks.ts
@@ -35,3 +35,19 @@ export function blocklyCheckForDv(rmType: string): string | string[] | null {
   const primitive = blocklyCheckForReturnType(returnTypeForDv(rmType));
   return primitive ? [primitive] : null;
 }
+
+/**
+ * Output type(s) for a DV_* block. Always include `DATA_VALUE` so shells can
+ * reconnect to a generic ELEMENT.value slot during Blockly serialization
+ * (init sets check to DATA_VALUE before per-slot configureElementValueSlot).
+ */
+export function blocklyOutputForDv(rmType: string): string | string[] | null {
+  const check = blocklyCheckForDv(rmType);
+  if (check == null) return null;
+  const types = Array.isArray(check) ? [...check] : [check];
+  if (!types.includes("DATA_VALUE") && types.every((t) => isDataValueType(t) || t === "CODE_PHRASE")) {
+    // CODE_PHRASE is not a DATA_VALUE; only widen true DV_* outputs.
+    if (types.some((t) => isDataValueType(t))) types.push("DATA_VALUE");
+  }
+  return types.length === 1 ? types[0]! : types;
+}

--- a/src/blockly/blocks/rm_blocks.ts
+++ b/src/blockly/blocks/rm_blocks.ts
@@ -19,7 +19,7 @@ import {
   subtypesOf,
   type RmAttributeMeta,
 } from "../../core/rm_meta.ts";
-import { blocklyCheckForDv } from "../block_checks.ts";
+import { blocklyCheckForDv, blocklyOutputForDv } from "../block_checks.ts";
 import {
   appendBlockOutputEmoji,
   appendSlotTypeEmoji,
@@ -1101,7 +1101,7 @@ function defineDataValueBlock(rmType: string): void {
         Blockly.Extensions.apply("dv_fields_mutator", this, true);
       }
 
-      this.setOutput(true, blocklyCheckForDv(rmType));
+      this.setOutput(true, blocklyOutputForDv(rmType));
       this.setColour(DV_COLOUR);
       this.setTooltip(rmType);
       enforceOpenEhrBlockLayout(this);

--- a/src/blockly/slot_label.ts
+++ b/src/blockly/slot_label.ts
@@ -23,6 +23,22 @@ import {
 
 export const SLOT_LABEL_FIELD_PREFIX = "SLOT_LABEL_";
 
+/** Which overlay field-level showEditor_ should open when both could apply. */
+export type SlotLabelOverlay = "abstract-tip" | "help" | null;
+
+/**
+ * Abstract ⁇ tip wins over attribute/spec help so concrete-implementation
+ * lists stay reachable on RM slots that also have BMM documentation.
+ */
+export function slotLabelOverlayForEditor(options: {
+  isAbstractSlot: boolean;
+  hasAttrHelp: boolean;
+}): SlotLabelOverlay {
+  if (options.isAbstractSlot) return "abstract-tip";
+  if (options.hasAttrHelp) return "help";
+  return null;
+}
+
 // deno-lint-ignore no-explicit-any
 const FieldLabelBase = Blockly.FieldLabel as any;
 
@@ -106,18 +122,28 @@ export class FieldSlotLabel extends FieldLabelBase {
   }
 
   showEditor_(): void {
-    const help = this.attributeHelp_();
-    if (help) {
-      const anchor = this.attrTspan_ ??
-        this.getClickTarget_?.() ??
-        this.fieldGroup_;
-      if (anchor && "getBoundingClientRect" in anchor) {
-        showSpecHelpPopup(anchor as Element, help);
-      }
+    // Blockly opens the editor from field-group mousedown. Prefer the
+    // abstract ⁇ tip over attribute help so concrete-implementation lists
+    // are not swallowed when both apply (common for RM slots).
+    const action = slotLabelOverlayForEditor({
+      isAbstractSlot: this.isAbstractSlot_(),
+      hasAttrHelp: this.hasAttrHelp_(),
+    });
+    if (action === "abstract-tip") {
+      dismissSpecHelpPopup();
+      pinSlotLabelTip(this);
       return;
     }
-    if (!this.isAbstractSlot_()) return;
-    pinSlotLabelTip(this);
+    if (action !== "help") return;
+    dismissSlotLabelTip();
+    const help = this.attributeHelp_();
+    if (!help) return;
+    const anchor = this.attrTspan_ ??
+      this.getClickTarget_?.() ??
+      this.fieldGroup_;
+    if (anchor && "getBoundingClientRect" in anchor) {
+      showSpecHelpPopup(anchor as Element, help);
+    }
   }
 
   isClickableInFlyout(): boolean {
@@ -234,8 +260,12 @@ export class FieldSlotLabel extends FieldLabelBase {
       tspan.textContent = this.attrLabel;
       if (attrHelp) {
         tspan.style.cursor = "pointer";
+        // Stop Blockly field mousedown→showEditor_ so attr help does not
+        // race the abstract ⁇ tip on the same caption.
+        tspan.addEventListener("mousedown", (event) => event.stopPropagation());
         tspan.addEventListener("click", (event) => {
           event.stopPropagation();
+          dismissSlotLabelTip();
           dismissSpecHelpPopup();
           const help = this.attributeHelp_();
           if (help) showSpecHelpPopup(tspan, help);
@@ -252,8 +282,10 @@ export class FieldSlotLabel extends FieldLabelBase {
         tspan.setAttribute("class", "blockly-slot-abstract-glyph");
         tspan.textContent = glyph;
         tspan.style.cursor = "pointer";
+        tspan.addEventListener("mousedown", (event) => event.stopPropagation());
         tspan.addEventListener("click", (event) => {
           event.stopPropagation();
+          dismissSpecHelpPopup();
           pinSlotLabelTip(this);
         });
         el.appendChild(tspan);
@@ -351,6 +383,16 @@ function measureCaptionWidth(text: string, fontPx: number, abstract: boolean): n
 
 const PIN_ID = "blockly-slot-label-tip";
 
+function dismissSlotLabelTip(): void {
+  if (typeof document === "undefined") return;
+  const tip = document.getElementById(PIN_ID);
+  if (!tip) return;
+  const cleanup = (tip as HTMLElement & { _dismiss?: () => void })._dismiss;
+  cleanup?.();
+  stopAnchoring(tip);
+  tip.remove();
+}
+
 function pinSlotLabelTip(field: FieldSlotLabel): void {
   if (typeof document === "undefined") return;
   Blockly.Tooltip?.hide?.();
@@ -362,14 +404,10 @@ function pinSlotLabelTip(field: FieldSlotLabel): void {
 
   let tip = document.getElementById(PIN_ID);
   if (tip && tip.dataset.anchor === field.pinId) {
-    stopAnchoring(tip);
-    tip.remove();
+    dismissSlotLabelTip();
     return;
   }
-  if (tip) {
-    stopAnchoring(tip);
-    tip.remove();
-  }
+  dismissSlotLabelTip();
   tip = document.createElement("div");
   tip.id = PIN_ID;
   tip.className = "blockly-rm-emoji-tip";
@@ -384,14 +422,15 @@ function pinSlotLabelTip(field: FieldSlotLabel): void {
 
   const dismiss = (event: Event) => {
     if (event.target instanceof Node && tip?.contains(event.target)) return;
-    if (tip) stopAnchoring(tip);
-    tip?.remove();
-    document.removeEventListener("pointerdown", dismiss, true);
-    document.removeEventListener("keydown", onKey, true);
+    dismissSlotLabelTip();
   };
   const onKey = (event: KeyboardEvent) => {
     if (event.key === "Escape") dismiss(event);
   };
   document.addEventListener("pointerdown", dismiss, true);
   document.addEventListener("keydown", onKey, true);
+  (tip as HTMLElement & { _dismiss?: () => void })._dismiss = () => {
+    document.removeEventListener("pointerdown", dismiss, true);
+    document.removeEventListener("keydown", onKey, true);
+  };
 }

--- a/src/core/skeleton/generate_skeleton.ts
+++ b/src/core/skeleton/generate_skeleton.ts
@@ -862,11 +862,19 @@ function extractFixedFields(
 }
 
 function terminologyIdFromAm(cObj: AmObject): string | undefined {
-  const tid = cObj.terminology_id ?? cObj.terminology;
+  return coerceTerminologyId(cObj.terminology_id ?? cObj.terminology);
+}
+
+/** ehrtslib may yield a plain string or a TERMINOLOGY_ID / String wrapper. */
+function coerceTerminologyId(tid: unknown): string | undefined {
   if (typeof tid === "string" && tid) return tid;
-  if (tid && typeof tid === "object") {
-    const value = (tid as { value?: unknown }).value;
-    if (typeof value === "string" && value) return value;
+  if (!tid || typeof tid !== "object") return undefined;
+  const rec = tid as { value?: unknown; _value?: unknown };
+  const nested = rec.value ?? rec._value;
+  if (typeof nested === "string" && nested) return nested;
+  if (nested && typeof nested === "object") {
+    const inner = (nested as { value?: unknown }).value;
+    if (typeof inner === "string" && inner) return inner;
   }
   return undefined;
 }
@@ -1002,9 +1010,11 @@ function extractAllowedOrdinals(cObj: AmObject, terms: TermBag): AllowedOrdinal[
       sym.defining_code?.code_string ??
       amCodeString(sym);
     if (!code) continue;
-    const terminologyId = sym.terminology_id ??
-      sym.defining_code?.terminology_id ??
-      terminologyIdFromAm(sym);
+    const terminologyId = coerceTerminologyId(
+      sym.terminology_id ??
+        sym.defining_code?.terminology_id ??
+        terminologyIdFromAm(sym),
+    );
     const label = lookupTermText(terms, code) ?? code;
     items.push({
       value,

--- a/src/core/target/format_handler.ts
+++ b/src/core/target/format_handler.ts
@@ -334,8 +334,9 @@ function xsdElementToSkeleton(
 ): SkeletonNode {
   const name = stringAttr(element, "@name") || fallbackName;
   const documentation = xsdDocumentationLabel(element, language);
-  // Prefer the element name as the block title; keep annotation prose for help.
-  const label = name;
+  // xml:lang documentation doubles as the localized block title when present;
+  // keep the same prose on `documentation` for the help viewer.
+  const label = documentation || name;
   const complex = asRecord(element.complexType);
   const sequence = asRecord(complex?.sequence) ?? asRecord(complex?.all) ??
     asRecord(complex?.choice);

--- a/test/blockly_rm_blocks_test.ts
+++ b/test/blockly_rm_blocks_test.ts
@@ -4,6 +4,7 @@ import { generateSkeleton } from "@intehrgrator/core/skeleton/generate_skeleton.
 import {
   blocklyCheckForDv,
   blocklyCheckForReturnType,
+  blocklyOutputForDv,
 } from "@intehrgrator/blockly/block_checks.ts";
 import {
   applyFixedFieldsToDataValueShell,
@@ -112,6 +113,12 @@ Deno.test("blocklyCheckForDv maps DV types to typed shell checks", () => {
   assertEquals(blocklyCheckForReturnType("string"), "String");
 });
 
+Deno.test("blocklyOutputForDv widens DV shells with DATA_VALUE for reconnect", () => {
+  assertEquals(blocklyOutputForDv("DV_QUANTITY"), ["DV_QUANTITY", "DATA_VALUE"]);
+  assertEquals(blocklyOutputForDv("DV_BOOLEAN"), ["DV_BOOLEAN", "DATA_VALUE"]);
+  assertEquals(blocklyOutputForDv("DV_TEXT"), ["DV_TEXT", "DV_CODED_TEXT", "DATA_VALUE"]);
+});
+
 Deno.test("orderedRmAttributes puts mandatory RM attrs first", () => {
   assertEquals(
     orderedRmAttributes("OBSERVATION", ["protocol", "data"]),
@@ -152,7 +159,7 @@ Deno.test("DATA_VALUE shell exposes mandatory fields from meta", () => {
   const shell = workspace.newBlock("dv_quantity");
   assert(shell.getInput(dvFieldInputName("magnitude")));
   assert(shell.getInput(dvFieldInputName("units")));
-  assertEquals(shell.outputConnection?.getCheck(), ["DV_QUANTITY"]);
+  assertEquals(shell.outputConnection?.getCheck(), ["DV_QUANTITY", "DATA_VALUE"]);
   workspace.dispose();
 });
 

--- a/test/slot_label_abstract_tip_test.ts
+++ b/test/slot_label_abstract_tip_test.ts
@@ -1,0 +1,45 @@
+/**
+ * Abstract ⁇ tip must win over attribute help when both apply on a slot caption.
+ * (Help viewer previously swallowed ⁇ clicks via showEditor_.)
+ */
+import { assert, assertEquals } from "@std/assert";
+import {
+  ABSTRACT_SLOT_GLYPH,
+  connectionPointGlyph,
+  rmTypeConnectionTooltip,
+} from "@intehrgrator/blockly/rm_type_emoji.ts";
+import { slotLabelOverlayForEditor } from "@intehrgrator/blockly/slot_label.ts";
+import { rmAttributeHelp } from "@intehrgrator/core/spec_help.ts";
+
+Deno.test("COMPOSITION.content has RM attribute help (precondition)", () => {
+  const help = rmAttributeHelp("COMPOSITION", "content");
+  assert(help, "expected ehrtslib spec docs for COMPOSITION.content");
+  assert(help.body.length > 0);
+});
+
+Deno.test("CONTENT_ITEM slot still uses ⁇ and lists concrete subtypes", () => {
+  assertEquals(connectionPointGlyph("CONTENT_ITEM", true), ABSTRACT_SLOT_GLYPH);
+  const tip = rmTypeConnectionTooltip("CONTENT_ITEM");
+  assert(tip.includes("CONTENT_ITEM (abstract)"));
+  assert(tip.includes("Allowed:"));
+  assert(tip.includes("OBSERVATION") || tip.includes("SECTION"));
+});
+
+Deno.test("slotLabelOverlayForEditor prefers abstract ⁇ tip over attribute help", () => {
+  assertEquals(
+    slotLabelOverlayForEditor({ isAbstractSlot: true, hasAttrHelp: true }),
+    "abstract-tip",
+  );
+  assertEquals(
+    slotLabelOverlayForEditor({ isAbstractSlot: true, hasAttrHelp: false }),
+    "abstract-tip",
+  );
+  assertEquals(
+    slotLabelOverlayForEditor({ isAbstractSlot: false, hasAttrHelp: true }),
+    "help",
+  );
+  assertEquals(
+    slotLabelOverlayForEditor({ isAbstractSlot: false, hasAttrHelp: false }),
+    null,
+  );
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clicking the abstract-slot `⁇` glyph stopped showing the concrete-implementations tip after the help-viewer work: field-level `showEditor_` opened attribute/spec help whenever ehrtslib had docs (almost all RM attrs), so the ⁇ tip never ran.

## Fix

- Prefer the abstract tip in `showEditor_` when the slot is abstract
- Stop Blockly `mousedown` on the attr-name and `⁇` tspans so the two click targets do not race
- Attr-name clicks still open the spec help popup; `⁇` still lists allowed concrete subclasses
- Add a regression test for the overlay preference

## CI follow-up

Also fixed five related failures exposed on this branch:

- **codegen / minimap**: `DV_*` outputs now include `DATA_VALUE` so Blockly can reconnect shells to generic `ELEMENT.value` after serialize/load
- **ordinal skeleton**: coerce ehrtslib `TERMINOLOGY_ID` wrappers to plain `"local"` strings
- **XSD labels**: restore `xml:lang` documentation as skeleton labels (help text still kept on `documentation`)

## Test plan

- [x] `deno test -A --no-check test/slot_label_abstract_tip_test.ts test/codegen_test.ts test/minimap_test.ts test/skeleton_test.ts test/target_format_handler_test.ts test/blockly_rm_blocks_test.ts`
- [x] CI green on PR
- [ ] Manually: abstract slot ⁇ tip lists allowed types; attr name opens help popup
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ba025b4-f879-4bd1-8258-36b6267ac6ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ba025b4-f879-4bd1-8258-36b6267ac6ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

