### PR TITLE
Compact Mapping Spec projection + textual mapping languages note

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -168,12 +168,12 @@ Optional RM types attachable via Optional RM Insertion (cogwheel mutator / conte
 _Avoid_: Primer-only RM list, toolbox free-build of LOCATABLE extras, library-level attachment picker API
 
 **Mapping Specification**:
-Canonical interchange is native Blockly workspace JSON (`ProjectBundle.mapping.blocklyState`), shown in the Mapping Editor Blockly JSON tab with **line numbers**. Blockly is used **declaratively**: the canvas is a slot tree plus constructors (including a **Defaults Map**) and lookups — not an imperative program with statement order. Dense recurring constructs are rendered via CodeMirror widgets; structure stays Blockly-owned. See `docs/MAPPING_SPECIFICATION.md` and ADR 0001.
+Canonical interchange is native Blockly workspace JSON (`ProjectBundle.mapping.blocklyState`). The Mapping Spec tab shows a compact projection of that JSON, not the JSON document itself. Blockly is used **declaratively**: the canvas is a slot tree plus constructors (including a **Defaults Map**) and lookups — not an imperative program with statement order. See `docs/MAPPING_SPECIFICATION.md`, ADR 0001, and ADR 0006.
 _Avoid_: Private `@template` DSL, Mapping script as a third language, treating the canvas as a sequential script
 
 **Mapping Spec Widget**:
-A CodeMirror decoration that collapses a common Blockly JSON construct into a compact, mostly read-only chrome row. v1 covers skeleton containers, value slots, `source_query`, and `DV_*` shells (stock logic/loop widgets later). When the block fills a named RM/DV attribute slot, the attribute name (`language`, `magnitude`, `value`, …) is shown at the start of the row. Only **safe fields** on the widget are editable (e.g. dropdown choices, variable/expression text inputs); rearranging block structure, ids, and coordinates is not done by typing raw JSON. Layout chrome such as `x`/`y` is omitted from the Spec projection by default; an **info** control (encircled *i*) reveals those details in a tooltip-like balloon. Full Blockly JSON including coordinates remains in the Project Bundle for exact restore. A widget whose Blockly block has a **Constraint warning** shows the same yellow warning triangle.
-_Avoid_: Free-form JSON editing of the whole workspace, custom DSL, treating the Spec view as the persistence format byte-for-byte
+One projected row in the Mapping Spec tab: a compact, indented view of one semantic mapping (source path, map lookup, sheet lookup, literal, text generation, flattened condition, or container). Safe Blockly fields are editable in the row (paths, map keys, literals, compare operands, loop VAR/PATH, `text_code` LANG/TEXT). Wrappers that do not change mapping meaning (`xml_text`, `DV_*` shells, unnamed maps) are omitted; their Blockly ids stay on the visible row. Download/Upload still round-trip the **full Blockly JSON document**.
+_Avoid_: JSON fragment, custom DSL, treating the Spec view as the persistence format
 
 **Mapping Model**:
 Derived semantic index (`templateId`, `targetFormat`, `slotId`, `rmType`, `expression`, optional RM insertions). Rebuilt from Blockly JSON on workspace change; used by validation, AI suggestion import, codegen, and Test Run. Does **not** include Conversion script language.
@@ -185,7 +185,7 @@ _UI label:_ section title **Generated conversion script(s)**.
 _Avoid_: Export code, preview TypeScript
 
 **Sync Scope**:
-Blockly workspace JSON (canonical structure) ⇄ Mapping Spec widgets for safe field edits only → Mapping Model slots[] (derived index) → codegen / Test Run. Widget edits patch the corresponding Blockly fields and regenerate the Model; canvas / Click-to-Map / AI structural changes rewrite the Spec view. Canvas undo/redo is the single history: spec widget edits, Click-to-Map, and cogwheel add/remove are Blockly events (grouped per user action). Open template / Example Sets / Load Project / New project restore a document snapshot; Save / Export do not push undo steps. v1 safe edits: Mapping Expression text on `source_query` (and equivalent expression blocks). Structure, Optional RM Insertion, ids, and coordinates are Blockly-only. Raw free-typing of block tree JSON is not the intended authoring path. Center CodeMirror is **not** Generated Export.
+Blockly workspace JSON (canonical structure) ⇄ Mapping Spec widgets for **safe field edits** (source paths, map name/key, literals, compare operands, loop VAR/PATH, `text_code` LANG/TEXT) → Mapping Model slots[] (derived index) → codegen / Test Run. The compact projection is not persisted; Download/Upload keep **full Blockly JSON**. Structure, Optional RM Insertion, ids, and coordinates stay Blockly-only. Canvas undo/redo is the single history. Center CodeMirror is **not** Generated Export.
 _Avoid_: Full handwritten Blockly JSON as primary editor, custom DSL as middle language
 
 **Web Shell**:

--- a/docs/MAPPING_SPECIFICATION.md
+++ b/docs/MAPPING_SPECIFICATION.md
@@ -4,15 +4,27 @@ The canonical Mapping Specification is Blockly workspace JSON from
 `Blockly.serialization.workspaces.save`. It is persisted in
 `ProjectBundle.mapping.blocklyState`.
 
-The Mapping Editor **Mapping Spec** tab stores the **full Blockly workspace
-JSON** as the CodeMirror document (`JSON.stringify(blocklyState, null, 2)`).
-Visual widgets overlay each block `"type"` line and hide layout chrome such as
-`x`/`y`; an ⓘ control still reveals those details. When a block fills a named
-attribute slot (`ATTR_language`, `FLD_magnitude`, ELEMENT `value`, …), the
-widget shows that attribute name at the start of the row. Download/Upload
-round-trip that same JSON so a mapping can be reproduced exactly. Only safe
-fields are editable in the Spec widgets (v1: `source_query` expression and
-return type); structure changes stay in Blockly.
+The Mapping Editor **Mapping Spec** tab shows a **compact projection** of
+the Blockly workspace: one row per semantic mapping (containers, source
+paths, map lookups, literals, text-generation, flattened conditions).
+Layout chrome such as `x`/`y` is omitted; an ⓘ control on the row still
+reveals those details. When a block fills a named attribute slot
+(`language`, `magnitude`, ELEMENT `value`, …), the widget shows that
+attribute name at the start of the row. Nested same-operator `AND`/`OR`
+trees fold into one “all of” / “any of” row. Indent folding in the fold
+gutter collapses containers without dropping mapping rows from the
+document.
+
+Passthrough wrappers (`xml_text`, `DV_*` shells, `code_phrase`, unnamed
+`maps_create_with`) and nested same-operator `AND`/`OR` trees are elided
+so the mapping meaning stays visible without Blockly JSON scaffolding.
+**Safe fields** are editable in the widgets (source paths, map keys,
+literals, `text_code` snippets, compare operands, loop variable/path).
+Structure changes stay in Blockly.
+
+Download/Upload still round-trip the **full Blockly workspace JSON** so a
+mapping can be reproduced exactly. The Spec document itself is not that
+JSON.
 
 The former private `@template ...` DSL has been removed. It duplicated Blockly
 structure and was not an interchange format used by other tools.

--- a/docs/UI_ARCHITECTURE.md
+++ b/docs/UI_ARCHITECTURE.md
@@ -74,7 +74,7 @@ The left pane has two stacked sections: **schema** (upper) and **example instanc
 - **Purpose:** The main workspace where the mapping logic is defined
 - **Default layout:** Vertical split (not tabs):
   - **Top — Blockly canvas:** Nested puzzle-piece blocks representing the openEHR RM structure from the loaded OPT
-  - **Bottom — Mapping Specification:** Block-aligned declarative DSL (not TypeScript). Structure read-only; expressions editable. Synced with Blockly via Mapping Model. See [MAPPING_SPECIFICATION.md](MAPPING_SPECIFICATION.md).
+  - **Bottom — Mapping Specification:** Compact **projection** of the Blockly workspace (not pretty-printed JSON, not a custom DSL). One Mapping Spec Widget per semantic row; wrappers with no mapping meaning are omitted. Safe fields (paths, map keys, literals, `text_code`) are editable in the widgets. **Download** / **Upload** still round-trip full Blockly JSON. Synced with Blockly via Mapping Model. See [MAPPING_SPECIFICATION.md](MAPPING_SPECIFICATION.md) and [ADR 0006](adr/0006-compact-mapping-spec-projection.md).
 - **Blockly toolbox categories:** Source (orange), Literals (green), Logic (brown), Variables (magenta) — colour-coded in the flyout and category rail
 - **Minimap:** Shown when the Blockly workspace content exceeds the visible canvas at the current zoom level, allowing quick navigation in deep templates
 - **Sync pattern reference:** The Blockly ↔ text sync follows patterns demonstrated by [BlockMirror](https://blockpy-edu.github.io/BlockMirror/docs/); the text editor implementation uses [CodeMirror 6](https://codemirror.net/) directly

--- a/docs/adr/0006-compact-mapping-spec-projection.md
+++ b/docs/adr/0006-compact-mapping-spec-projection.md
@@ -1,0 +1,5 @@
+# Mapping Spec view is a compact projection
+
+The Mapping Spec tab is a dense, editable **projection** of Blockly workspace JSON, not the JSON document itself. Download/Upload still round-trip native Blockly JSON. The alternative — keeping pretty-printed Blockly JSON in CodeMirror and hiding chrome with replace decorations — forced JSON line numbers, wasted scroll for `xml_text` / `DV_*` / nested `AND` wrappers, and made text-generation (`text_code`) uneditable.
+
+Safe widget edits write Blockly fields in place (source paths, map keys, literals, compare operands, loops, `text_code`). This does not change ADR 0001: Blockly JSON remains the canonical Mapping Specification in the Project Bundle.

--- a/docs/future/formal-verification-export.md
+++ b/docs/future/formal-verification-export.md
@@ -139,6 +139,7 @@ Mapping Model (slots[], loops, expressions)
 
 ## Related
 
+- [textual-mapping-languages.md](textual-mapping-languages.md) — authoring languages (distinct from this verification export)
 - [xquery-export-investigation.md](xquery-export-investigation.md) — declarative export precedent
 - [MAPPING_SPECIFICATION.md](../MAPPING_SPECIFICATION.md) — Mapping Model pipeline
 - [ADR 0001](../adr/0001-mapping-and-target-seams.md) — mapping and target seams

--- a/docs/future/text-first-mapping-editor.md
+++ b/docs/future/text-first-mapping-editor.md
@@ -42,5 +42,6 @@ Blockly may never be fully removed — it remains valuable for control-flow bloc
 
 ## Related
 
+- [textual-mapping-languages.md](textual-mapping-languages.md) — which language (YAML slot projection, XQuery, JSONata, …) if the text surface becomes more than decorated Blockly JSON
 - [UI_ARCHITECTURE.md](../UI_ARCHITECTURE.md) — CodeMirror Sync Scope
 - [CONTEXT.md](../../CONTEXT.md) — Mapping Expression, Sync Scope

--- a/docs/future/textual-mapping-languages.md
+++ b/docs/future/textual-mapping-languages.md
@@ -1,0 +1,203 @@
+# Textual languages for mapping authoring
+
+**Status:** Investigation — captured 2026-09-07. No language or editor change yet.
+
+Companion to [text-first-mapping-editor.md](text-first-mapping-editor.md) (CodeMirror widgets / Blockly-optional UI). This note asks: **if** the Mapping Editor grows a real text surface, which language is compact and readable for informaticians who prefer typing over Blockly?
+
+## Product constraints (do not ignore)
+
+From [ADR 0001](../adr/0001-mapping-and-target-seams.md), [MAPPING_SPECIFICATION.md](../MAPPING_SPECIFICATION.md), and `CONTEXT.md`:
+
+| Constraint | Implication for a text language |
+|------------|----------------------------------|
+| Native **Blockly workspace JSON** is the canonical Mapping Specification | A text language is a **projection** (or a later replacement of Blockly), not a third source of truth. The old private `@template` DSL was removed because it duplicated Blockly. |
+| Blockly is used **declaratively**: slot tree + constructors + lookups, not statement-order programs | Prefer declarative / expression / path-pair languages over Python/JS “BlockMirror” scripts. |
+| **Mapping Model** (`slots[]`, `loops[]`, expressions) is the derived semantic index | The cheapest text surface is a readable rendering of that index, not a new IR. |
+| Source Paths are already **XPath/XQuery** via fontoxpath | Reusing that dialect beats introducing FHIRPath / JSONata / jq as a *second* query language unless JSON-only mappings dominate. |
+| Mapping Expression AST is a small sandboxed subset: `xpath*`, `trim`, `concat`, `if`, `switch`, `maps_get`, sheet accessors, `for_each_source` | Leaf values already have a compact textual form. The missing piece is **structure + iteration + lookups**, not a new calculator. |
+| Conversion script languages already exist: TypeScript, Java, Handlebars, XQuery, Go template | Those are **exports / runtimes**, not the authoring language — except Handlebars, which already has an Authored Template tab ([ADR 0004](../adr/0004-go-template-codegen-only.md) keeps Go template codegen-only). |
+| AI already speaks a **slot-keyed Blockly subset** (`intehrgrator-suggestions` v2) | Any text language should round-trip through the same `slotId` / `attachSlotId` / `loopVar` vocabulary. |
+
+_Contradicts ADR 0001 if a new language becomes canonical persistence._ Worth reopening only after a projection has been used in anger.
+
+## What the example sets actually need
+
+The catalog in `examples/example-sets.json` is two different jobs:
+
+| Example set | Shape of the mapping | Compact text analog |
+|-------------|----------------------|---------------------|
+| `dummy-json-vitals-mapped`, `Simple-vitals` | Fill named target slots from source paths + Defaults Map | YAML/JSON **slot table** |
+| `chemo-symptoms-flat-to-tc-xml`, `lung-mdt-form-to-tc-xml` | Build a TakeCare `ProfdocHISMessage` tree: schema blocks, `controls_if`, Defaults Map header, `text_code` notes | **Template** (Handlebars / Go template) or **XQuery element constructors** |
+
+No single off-the-shelf language is both (a) a 10-line slot table for dummy vitals and (b) a readable rewrite of the production chemo/MDT scripts. Pick by **mapping style**, or accept two projections sharing the Mapping Model.
+
+Illustrative slot-fill for dummy vitals (source `systolic`/`diastolic`/`unit` → JSON Schema target):
+
+```yaml
+target: DummyVitalsTarget
+defaults: defaults
+slots:
+  systolic:  xpathNumber("$.systolic")
+  diastolic: xpathNumber("$.diastolic")
+  unit:      xpathString("$.unit")
+```
+
+The Blockly JSON for the same stub is an empty workspace today; a filled one is still dozens of `type`/`fields`/`inputs` objects. That compactness gap is the whole point of a text surface.
+
+## Recommendation (ranked)
+
+### 1. Best fit: YAML **slot projection** of the Mapping Model (FHIRconnect-shaped)
+
+**Use as the Mapping Spec tab language** for `openehr-template` / `json-schema` / `xml-schema` targets.
+
+- Compact: one line per mapped slot; loops as a short header; Defaults Map / Sheet names as bindings, not inlined tables.
+- Readable: path-to-path YAML is how informaticians already document mappings (FHIRconnect, OMOCL).
+- Round-trip: generate from Mapping Model + skeleton labels; parse edits back with `applyExpressionEdit` / `upsertLoop`. Structure (Template Skeleton, Optional RM Insertion) stays Blockly-owned — same Sync Scope as v1.
+- Does **not** revive the deleted `@template` DSL: the YAML does not restate RM containers.
+
+Inspiration (not a drop-in grammar):
+
+- FHIRconnect YAML: [spec](https://github.com/SevKohler/FHIRconnect-spec), [Better mapping spec](https://github.com/better-care/fhir-connect-mapping-spec), [paper](https://arxiv.org/abs/2511.14618)
+- Shared header dialect with OMOCL (openEHR → OMOP)
+
+FHIRconnect itself is **FHIR ↔ openEHR** and assumes template-time inference of `DV_*` shells. intEHRgrator also maps generic JSON/XML and TakeCare XSD, so borrow the *look* (YAML path pairs, named types, conditions) rather than the engine.
+
+### 2. Best “real language” for mixed JSON/XML: **XQuery 3.1**
+
+**Use when the user is constructing a target tree** (TakeCare XML, free-form), or wants one language for query *and* transform.
+
+- Source Paths are already XPath/XQuery; [fontoxpath](https://github.com/FontoXML/fontoxpath) evaluates XQuery 3.1 in the browser (element constructors + JSON maps/arrays; not every F&O function).
+- Direct element constructors are the compact text of `xml_element` / `xml_attribute` / `xml_text` + `controls_if`:
+
+```xquery
+element ProfdocHISMessage {
+  attribute MsgType { "Request" },
+  element PatId { maps_get("defaults", "PatientId") },
+  if ($fatigue ne "Nej") then
+    element TextKeyWord {
+      element TermId { 2811 },
+      element Note { $fatigue-note }
+    }
+  else ()
+}
+```
+
+- Already a Conversion script language ([xquery-export-investigation.md](xquery-export-investigation.md)); promoting it to an *authoring* tab is a product decision, not a green-field parser.
+- Spec: [XQuery 3.1](https://www.w3.org/TR/xquery-31/), [XPath 3.1](https://www.w3.org/TR/xpath-31/)
+- Cost: bidirectional Blockly sync of full XQuery is hard; treat XQuery as a **projection of the tree**, same as Go template codegen, not as a BlockMirror pair.
+
+### 3. Best compact JSON→JSON transform: **JSONata**
+
+If JSON Schema targets become the common case and informaticians want to *write the output object*:
+
+```jsonata
+{
+  "systolic":  systolic,
+  "diastolic": diastolic,
+  "unit":      unit ? unit : "mm[Hg]"
+}
+```
+
+- XPath-inspired, declarative, tiny, JS-native, playground at [try.jsonata.org](https://try.jsonata.org/).
+- Docs: [docs.jsonata.org](https://docs.jsonata.org/), [github.com/jsonata-js/jsonata](https://github.com/jsonata-js/jsonata)
+- Cost: **second query dialect** beside fontoxpath; weak on XML and openEHR `DV_*` shells.
+
+### 4. Already in the product — keep as text for tree-construction, not as the Spec language
+
+| Surface | Role today | Text-first role |
+|---------|------------|-----------------|
+| **Handlebars** | Authored Template tab; Kintegrate; lung-MDT production scripts | Best *existing* text for TakeCare-style XML if users already own those scripts |
+| **Go `text/template`** | Codegen-only ([ADR 0004](../adr/0004-go-template-codegen-only.md)); chemo reference scripts | Do not add an authoring tab; the Blockly XML/schema tree is the edit surface |
+| **Mapping Expression** | `xpathNumber("$.systolic")` in slots | Keep as the **leaf language** inside YAML / widgets |
+| **`intehrgrator-suggestions` JSON** | AI import | Machine-oriented sibling of the YAML slot projection — do not ask humans to type it |
+
+## Other languages (why not first)
+
+### Healthcare mapping languages
+
+| Language | Compact / readable? | Why not first |
+|----------|---------------------|---------------|
+| **FHIR Mapping Language** (StructureMap) | Medium. `src.systolic -> tgt.systolic` is nice; groups/ConceptMaps add weight. | FHIRPath-based, Trial Use / Maturity 0, FHIR-centric engine. Spec: [hl7.org/fhir/mapping-language.html](https://hl7.org/fhir/mapping-language.html), [StructureMap](https://hl7.org/fhir/structuremap.html), [FML IG](https://build.fhir.org/ig/HL7/mapping-language-ig/fml.html). Steal the *rule* look, not the runtime. |
+| **FHIRPath** | Compact for navigation | Extraction + invariants, not instance construction. [hl7.org/fhirpath](https://hl7.org/fhirpath/). Overlaps Source Paths without replacing `DV_*` / XML trees. |
+| **CQL** | Readable for clinicians | Clinical quality / CDS, not ETL mapping. [cql.hl7.org](https://cql.hl7.org/01-introduction.html). |
+| **openEHR AQL** | Familiar to CDR users | Query of stored EHRs, not source→target conversion. |
+
+### Config / constraint languages
+
+| Language | Compact / readable? | Why not first |
+|----------|---------------------|---------------|
+| **CUE** | Very, for data+schema unification | Excellent *instance* language; poor *mapping-rule* language. Go-centric toolchain. [cuelang.org](https://cuelang.org/docs/introduction/). Better as a verification/export cousin ([formal-verification-export.md](formal-verification-export.md)) than as Blockly’s twin. |
+| **Nickel / Jsonnet / Dhall** | Jsonnet is JSON-plus-functions (readable); Nickel/Dhall heavier | Generate target documents, not slot mappings. [nickel-lang.org](https://nickel-lang.org/user-manual/introduction/), [jsonnet.org](https://jsonnet.org/), [dhall-lang.org](https://dhall-lang.org/). |
+| **CEL** | Compact C-like expressions | Predicates, not tree transforms. [cel.dev](https://cel.dev/overview/cel-overview), [cel-spec](https://github.com/cel-expr/cel-spec). Could replace the Mapping Expression AST later; not the Spec document. |
+
+### JSON/XML processors
+
+| Language | Compact / readable? | Why not first |
+|----------|---------------------|---------------|
+| **jq** | Compact, often cryptic | JSON-only; WASM possible but a new dialect. [jqlang.org](https://jqlang.org/). |
+| **XSLT 3.0** | Verbose | Loses to XQuery for authoring; same XPath foundation. |
+| **RML / R2RML** | RDF-shaped | Wrong data model unless a knowledge-graph target appears. |
+
+### Blockly ↔ text “same language” (BlockMirror pattern)
+
+[BlockMirror](https://github.com/blockpy-edu/BlockMirror) / [BlockPy](https://github.com/blockpy-edu/blockpy) sync Blockly with **Python**. Blockly’s official generators (JS, Python, Lua, PHP, Dart) are **one-way**. Official Blockly does not parse text back into blocks ([DeepWiki google/blockly](https://deepwiki.com/google/blockly)).
+
+Python/JS as the mapping authoring language would:
+
+- fight the declarative canvas (loops as statements, RM trees as object literals),
+- explode the sandbox (the expression parser already forbids `import` / `eval` / `fetch`),
+- duplicate Conversion script TypeScript.
+
+Use BlockMirror as a **UI sync pattern** only — already noted in [UI_ARCHITECTURE.md](../UI_ARCHITECTURE.md).
+
+## How this should sit in the editor
+
+Align with the existing text-first plan; do not add a third persistence format.
+
+```text
+Blockly workspace JSON          ← canonical (ADR 0001)
+        │
+        ▼
+Mapping Model (slots, loops, expressions)
+        │
+        ├── Mapping Spec YAML / widgets   ← human text for slot-fill
+        ├── Handlebars / XQuery tab       ← human text for tree-construction
+        └── Conversion scripts            ← generated (TS, Java, Go template, …)
+```
+
+Practical sequence:
+
+1. **Improve Mapping Spec widgets** so the current Blockly JSON view *looks* like the YAML slot table (collapse skeleton, show `slot ← expression`, edit safe fields). This is the [text-first-mapping-editor.md](text-first-mapping-editor.md) path and does not pick a new language.
+2. **Optional YAML download/upload** of Mapping Model slots+loops (human-editable sibling of `intehrgrator-suggestions`). Same Sync Scope.
+3. **Only if tree-construction users still want text:** an XQuery (or Handlebars) projection of the schema/XML block tree — codegen first, parse-back later.
+
+## Anti-patterns
+
+- A new private `@template` DSL that reprints the Template Skeleton.
+- Making TypeScript / Python / Go template the *authoring* Mapping Specification.
+- Bidirectional Blockly ↔ full XQuery/JSONata on day one (BlockMirror-scale engineering).
+- Replacing fontoxpath Source Paths with FHIRPath or JSONata paths in the same workspace.
+
+## Related (in-repo)
+
+- [text-first-mapping-editor.md](text-first-mapping-editor.md) — CodeMirror decorations
+- [xquery-export-investigation.md](xquery-export-investigation.md) — XQuery as conversion script
+- [formal-verification-export.md](formal-verification-export.md) — contracts, not authoring
+- [AI_SUGGESTION_FORMAT.md](../AI_SUGGESTION_FORMAT.md) — slot-keyed interchange
+- [SOURCE_QUERY.md](../SOURCE_QUERY.md) — fontoxpath
+- Example sets: `examples/example-sets.json`
+
+## External links (primary)
+
+- FHIR Mapping Language: https://hl7.org/fhir/mapping-language.html
+- FHIRconnect: https://github.com/SevKohler/FHIRconnect-spec · https://arxiv.org/abs/2511.14618
+- Better FHIRconnect mapping spec: https://github.com/better-care/fhir-connect-mapping-spec
+- JSONata: https://docs.jsonata.org/ · https://github.com/jsonata-js/jsonata
+- XQuery 3.1: https://www.w3.org/TR/xquery-31/
+- fontoxpath: https://github.com/FontoXML/fontoxpath
+- CUE: https://cuelang.org/docs/introduction/
+- CEL: https://cel.dev/overview/cel-overview
+- BlockMirror: https://github.com/blockpy-edu/BlockMirror
+- jq: https://jqlang.org/
+- CQL: https://cql.hl7.org/01-introduction.html
+- FHIRPath: https://hl7.org/fhirpath/

--- a/src/ui_test/test_api.ts
+++ b/src/ui_test/test_api.ts
@@ -54,7 +54,7 @@ export interface IntehrgratorTestApi {
    * where absolute slotIds are long archetype paths).
    */
   findSlotIdBySuffix(suffix: string): string | null;
-  /** CodeMirror Mapping Spec document (full Blockly workspace JSON). */
+  /** Compact Mapping Spec projection currently shown in CodeMirror. */
   getMappingSpecDocument(): string;
   /** Load a Blockly workspace JSON file (same path as Mapping Spec Upload). */
   loadBlocklyJson(filename: string, content: string): void;

--- a/src/workbench/mapping_spec/editor.ts
+++ b/src/workbench/mapping_spec/editor.ts
@@ -3,12 +3,11 @@ import {
   Decoration,
   EditorView,
   ViewPlugin,
-  WidgetType,
+  keymap,
   type DecorationSet,
   type ViewUpdate,
 } from "@codemirror/view";
-import { json } from "@codemirror/lang-json";
-import { editorChromeExtensions } from "../codemirror_setup.ts";
+import { foldGutter, foldKeymap, foldService } from "@codemirror/language";
 import {
   blocklyJsonDocument,
   type BlocklyJsonDocument,
@@ -70,21 +69,17 @@ const specChromeField = StateField.define<SpecChrome>({
   },
 });
 
-class HiddenJsonWidget extends WidgetType {
-  override get estimatedHeight(): number {
-    return 0;
+function warningForLine(line: SpecLine, warnings: Record<string, string>): string | null {
+  if (line.blockId && warnings[line.blockId]) return warnings[line.blockId] ?? null;
+  for (const id of line.aliasIds ?? []) {
+    if (warnings[id]) return warnings[id] ?? null;
   }
+  return null;
+}
 
-  override toDOM(): HTMLElement {
-    const span = document.createElement("span");
-    span.className = "cm-spec-json-chrome";
-    span.hidden = true;
-    return span;
-  }
-
-  override eq(): boolean {
-    return true;
-  }
+function lineIsSelected(line: SpecLine, selectedBlockId: string | null): boolean {
+  if (!selectedBlockId) return false;
+  return line.blockId === selectedBlockId || (line.aliasIds ?? []).includes(selectedBlockId);
 }
 
 /**
@@ -99,44 +94,46 @@ function buildDecorations(state: EditorState): DecorationSet {
   if (!doc.widgets.length) return Decoration.none;
 
   const ranges = [];
-  const text = state.doc.toString();
-  let cursor = 0;
   for (const widget of doc.widgets) {
-    if (widget.from > cursor) {
-      ranges.push(
-        Decoration.replace({
-          widget: new HiddenJsonWidget(),
-          block: true,
-          inclusive: true,
-        }).range(cursor, widget.from),
-      );
-    }
-    const blockId = widget.line.blockId;
     ranges.push(
       Decoration.replace({
         widget: new MappingSpecWidget(
           widget.line,
           onEdit,
           onSelect,
-          blockId ? chrome.warnings[blockId] ?? null : null,
-          Boolean(blockId && chrome.selectedBlockId === blockId),
+          warningForLine(widget.line, chrome.warnings),
+          lineIsSelected(widget.line, chrome.selectedBlockId),
         ),
-        inclusive: true,
+        block: widget.line.editKind === "code",
+        inclusive: widget.line.editKind !== "code",
       }).range(widget.from, widget.to),
-    );
-    cursor = widget.to;
-    if (text[cursor] === "\n") cursor++;
-  }
-  if (cursor < text.length) {
-    ranges.push(
-      Decoration.replace({
-        widget: new HiddenJsonWidget(),
-        block: true,
-        inclusive: true,
-      }).range(cursor, text.length),
     );
   }
   return Decoration.set(ranges, true);
+}
+
+function indentFoldRange(
+  state: EditorState,
+  lineStart: number,
+  _lineEnd: number,
+): { from: number; to: number } | null {
+  const line = state.doc.lineAt(lineStart);
+  if (!line.text.trim()) return null;
+  const indent = /^ */.exec(line.text)?.[0].length ?? 0;
+  let end = line.to;
+  let sawChild = false;
+  for (let n = line.number + 1; n <= state.doc.lines; n++) {
+    const next = state.doc.line(n);
+    if (!next.text.trim()) {
+      end = next.to;
+      continue;
+    }
+    const nextIndent = /^ */.exec(next.text)?.[0].length ?? 0;
+    if (nextIndent <= indent) break;
+    sawChild = true;
+    end = next.to;
+  }
+  return sawChild ? { from: line.to, to: end } : null;
 }
 
 const jsonDecorations = StateField.define<DecorationSet>({
@@ -167,6 +164,11 @@ const specTheme = EditorView.theme({
     padding: "0 2px",
     lineHeight: `${SPEC_LINE_HEIGHT}px`,
     minHeight: `${SPEC_LINE_HEIGHT}px`,
+  },
+  ".cm-line:has(.spec-widget--multiline)": {
+    height: "auto",
+    lineHeight: "normal",
+    overflow: "visible",
   },
   ".cm-gutters": {
     lineHeight: `${SPEC_LINE_HEIGHT}px`,
@@ -213,10 +215,26 @@ const specTheme = EditorView.theme({
     whiteSpace: "nowrap",
   },
   ".spec-widget-attr": {
-    flex: "0 0 auto",
+    flex: "0 1 auto",
     font: "10px ui-monospace, monospace",
     color: "#5c5c5c",
     lineHeight: "14px",
+    maxWidth: "9rem",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  ".spec-widget-attr--edit": {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "1px",
+    maxWidth: "10rem",
+    overflow: "visible",
+  },
+  ".spec-widget-input--attr": {
+    minWidth: "3.5rem",
+    maxWidth: "8rem",
+    flex: "1 1 5rem",
   },
   ".spec-widget-badge": {
     flex: "0 0 auto",
@@ -234,10 +252,58 @@ const specTheme = EditorView.theme({
     color: "#9a4b00",
     background: "#fff4ea",
   },
-  ".spec-widget--dv .spec-widget-badge": {
+  ".spec-widget--dv .spec-widget-badge, .spec-widget--map_lookup .spec-widget-badge, .spec-widget--sheet_lookup .spec-widget-badge": {
     color: "#1e3a5f",
     background: "#e8eef7",
   },
+  ".spec-widget--text_gen .spec-widget-badge": {
+    color: "#6d4c00",
+    background: "#fff6d6",
+  },
+  ".spec-widget--logic .spec-widget-badge": {
+    color: "#4a148c",
+    background: "#f3e5f5",
+  },
+  ".spec-widget-editors": {
+    display: "inline-flex",
+    alignItems: "center",
+    gap: "4px",
+    flex: "1 1 auto",
+    minWidth: "0",
+  },
+  ".spec-widget-editors--stack": {
+    flexDirection: "column",
+    alignItems: "stretch",
+  },
+  ".spec-widget--multiline": {
+    display: "flex",
+    alignItems: "flex-start",
+    height: "auto",
+    minHeight: `${SPEC_LINE_HEIGHT}px`,
+    whiteSpace: "normal",
+    paddingTop: "2px",
+    paddingBottom: "2px",
+  },
+  ".spec-widget-code": {
+    width: "100%",
+    minHeight: "3.2rem",
+    maxHeight: "8.5rem",
+    boxSizing: "border-box",
+    font: "11px ui-monospace, monospace",
+    padding: "2px 4px",
+    border: "1px solid #d9d9d9",
+    borderRadius: "2px",
+    resize: "vertical",
+    lineHeight: "15px",
+  },
+  ".spec-widget-punct": {
+    flex: "0 0 auto",
+    color: "#666",
+    fontSize: "11px",
+  },
+  ".spec-widget-input--name": { maxWidth: "7rem", flex: "0 1 7rem" },
+  ".spec-widget-input--short": { maxWidth: "6rem", flex: "0 1 6rem" },
+  ".spec-widget-select--op": { minWidth: "2.5rem" },
   ".spec-widget-summary": {
     flex: "1 1 auto",
     minWidth: "0",
@@ -306,6 +372,10 @@ const specTheme = EditorView.theme({
     font: "italic bold 9px/12px Georgia, serif",
     cursor: "pointer",
     padding: "0",
+    opacity: "0",
+  },
+  ".spec-widget:hover .spec-widget-info, .spec-widget:focus-within .spec-widget-info": {
+    opacity: "1",
   },
 });
 
@@ -395,8 +465,9 @@ export function createMappingSpecEditor(
     state: EditorState.create({
       doc: empty.text,
       extensions: [
-        ...editorChromeExtensions,
-        json(),
+        foldGutter(),
+        keymap.of(foldKeymap),
+        foldService.of(indentFoldRange),
         jsonDocField.init(() => empty),
         specChromeField.init(() => emptyChrome),
         editFacet.of(options.onFieldEdit),
@@ -442,14 +513,16 @@ export function setMappingSpecChrome(view: EditorView, chrome: SpecChrome): void
 
 export function scrollMappingSpecToBlock(view: EditorView, blockId: string): void {
   const doc = view.state.field(jsonDocField);
-  const widget = doc.widgets.find((item) => item.line.blockId === blockId);
+  const widget = doc.widgets.find((item) =>
+    item.line.blockId === blockId || (item.line.aliasIds ?? []).includes(blockId)
+  );
   if (!widget) return;
   view.dispatch({
     effects: EditorView.scrollIntoView(widget.from, { y: "center" }),
   });
 }
 
-/** The editor document is the full Blockly workspace JSON. */
+/** Compact Spec projection currently shown in the Mapping Spec tab. */
 export function mappingSpecDocumentText(view: EditorView): string {
   return view.state.doc.toString();
 }

--- a/src/workbench/mapping_spec/mod.ts
+++ b/src/workbench/mapping_spec/mod.ts
@@ -3,6 +3,8 @@ export {
   projectBlocklyState,
   slotAttributeFromInputName,
   type BlocklyJsonDocument,
+  type SpecEditFieldName,
+  type SpecEditKind,
   type SpecEditableField,
   type SpecLine,
   type SpecLineKind,

--- a/src/workbench/mapping_spec/overview.ts
+++ b/src/workbench/mapping_spec/overview.ts
@@ -26,11 +26,15 @@ export function specWarningMarkers(
 ): SpecWarningMarker[] {
   const out: SpecWarningMarker[] = [];
   for (const widget of doc.widgets) {
-    const blockId = widget.line.blockId;
-    if (!blockId) continue;
-    const message = warnings[blockId];
-    if (!message) continue;
-    out.push({ blockId, from: widget.from, message });
+    const ids = [widget.line.blockId, ...(widget.line.aliasIds ?? [])].filter(
+      (id): id is string => Boolean(id),
+    );
+    for (const id of ids) {
+      const message = warnings[id];
+      if (!message) continue;
+      out.push({ blockId: widget.line.blockId ?? id, from: widget.from, message });
+      break;
+    }
   }
   return out;
 }

--- a/src/workbench/mapping_spec/project.ts
+++ b/src/workbench/mapping_spec/project.ts
@@ -1,9 +1,12 @@
 /**
- * Project Blockly workspace JSON into a dense, line-numbered Mapping Specification.
- * Coordinates and other layout chrome are omitted from the text; kept in `info` for ⓘ.
+ * Project Blockly workspace JSON into a dense Mapping Spec: one line per
+ * semantic row. Layout chrome stays in ⓘ. Passthrough wrappers and nested
+ * same-operator logic trees are elided so mapping meaning stays visible
+ * without Blockly JSON scaffolding.
  */
 
 import { isRmContainerBlockType } from "../../blockly/blocks/rm_blocks.ts";
+import { MAPS_CREATE_WITH, MAPS_GET } from "../../core/defaults/extract.ts";
 
 export type SpecLineKind =
   | "header"
@@ -11,11 +14,43 @@ export type SpecLineKind =
   | "value"
   | "source_query"
   | "dv"
+  | "map_lookup"
+  | "sheet_lookup"
+  | "literal"
+  | "logic"
+  | "text_gen"
   | "other";
 
+export type SpecEditFieldName =
+  | "EXPRESSION"
+  | "RETURN_TYPE"
+  | "TEXT"
+  | "NUM"
+  | "BOOL"
+  | "LANG"
+  | "PATH"
+  | "VAR"
+  | "NAME"
+  | "OP"
+  | `KEY${string}`;
+
+export type SpecEditKind =
+  | "source_path"
+  | "text"
+  | "code"
+  | "compare"
+  | "map_get"
+  | "sheet_lookup"
+  | "number"
+  | "boolean"
+  | "loop"
+  | "none";
+
 export interface SpecEditableField {
-  field: "EXPRESSION" | "RETURN_TYPE";
+  field: SpecEditFieldName;
   value: string;
+  /** Patch this block when it differs from the row's `blockId`. */
+  targetBlockId?: string;
 }
 
 export interface SpecLine {
@@ -23,6 +58,8 @@ export interface SpecLine {
   indent: number;
   /** Stable Blockly block id when this line maps to a block. */
   blockId?: string;
+  /** Skipped wrapper / nested-logic ids that should scroll/highlight this row. */
+  aliasIds?: string[];
   type: string;
   label: string;
   /**
@@ -31,9 +68,17 @@ export interface SpecLine {
    * Statement-chain siblings keep the same name.
    */
   attribute?: string;
+  /** Elided DATA_VALUE / RM shell type, shown as a badge without a wrapper row. */
+  shell?: string;
+  editKind?: SpecEditKind;
   /** One-line summary shown in the widget chrome. */
   summary: string;
   editable?: SpecEditableField[];
+  /**
+   * The attribute label is itself a Blockly field (map KEY, xml_attribute NAME).
+   * Shown as an input in the attribute column.
+   */
+  attributeEdit?: SpecEditableField;
   /** Hidden details for the info balloon (x/y, raw fields, etc.). */
   info: Record<string, unknown>;
 }
@@ -64,43 +109,27 @@ interface BlocklyWorkspaceJson {
 }
 
 const DV_PREFIX = "dv_";
+const COMPARE_OP: Record<string, string> = {
+  EQ: "=",
+  NEQ: "≠",
+  LT: "<",
+  LTE: "≤",
+  GT: ">",
+  GTE: "≥",
+};
 
 export function projectBlocklyState(state: unknown): SpecProjection {
   const lines: SpecLine[] = [];
-  lines.push({
-    kind: "header",
-    indent: 0,
-    type: "header",
-    label: "Mapping Specification",
-    summary: "Blockly projection · layout chrome omitted · ⓘ for details",
-    info: {
-      note: "Canonical state remains ProjectBundle.mapping.blocklyState (includes x/y).",
-    },
-  });
 
   if (state == null || typeof state !== "object") {
-    lines.push({
-      kind: "other",
-      indent: 0,
-      type: "empty",
-      label: "(empty workspace)",
-      summary: "",
-      info: {},
-    });
+    lines.push(emptyLine("(empty workspace)", {}));
     return toProjection(lines);
   }
 
   const workspace = state as BlocklyWorkspaceJson;
   const roots = workspace.blocks?.blocks ?? [];
   if (!roots.length) {
-    lines.push({
-      kind: "other",
-      indent: 0,
-      type: "empty",
-      label: "(no blocks)",
-      summary: "",
-      info: { languageVersion: workspace.blocks?.languageVersion },
-    });
+    lines.push(emptyLine("(no blocks)", { languageVersion: workspace.blocks?.languageVersion }));
     return toProjection(lines);
   }
 
@@ -110,42 +139,649 @@ export function projectBlocklyState(state: unknown): SpecProjection {
   return toProjection(lines);
 }
 
+function emptyLine(label: string, info: Record<string, unknown>): SpecLine {
+  return {
+    kind: "other",
+    indent: 0,
+    type: "empty",
+    label,
+    summary: "",
+    editKind: "none",
+    info,
+  };
+}
+
+function emit(
+  lines: SpecLine[],
+  line: SpecLine,
+  attributeEdit?: SpecEditableField,
+): void {
+  if (attributeEdit) line.attributeEdit = attributeEdit;
+  lines.push(line);
+}
+
+function withAlias(aliases: string[], id: string | undefined): string[] {
+  return id ? [...aliases, id] : aliases;
+}
+
+function pushAlias(aliases: string[], id: string | undefined): void {
+  if (id) aliases.push(id);
+}
+
 function walkBlock(
   block: BlocklyBlockJson,
   indent: number,
   lines: SpecLine[],
   attribute?: string,
+  extraAliases: string[] = [],
+  shell?: string,
+  attributeEdit?: SpecEditableField,
 ): void {
   const type = block.type ?? "unknown";
-  const fields = block.fields ?? {};
-  const kind = classify(type);
-  const label = pickLabel(type, fields);
-  const editable = editableFields(type, fields);
-  const info = collectInfo(block);
-  if (attribute) info.attribute = attribute;
 
-  lines.push({
+  if (type === "xml_text" || type === "json_value" || type === "target_value") {
+    walkInputs(block, indent, lines, attribute, withAlias(extraAliases, idOf(block)), shell, attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "xml_attribute") {
+    const name = stringField(block, "NAME");
+    const attr = name ? `@${name}` : attribute;
+    const value = inputBlock(block, "VALUE");
+    const nameEdit: SpecEditableField | undefined = name
+      ? { field: "NAME", value: name, targetBlockId: idOf(block) }
+      : attributeEdit;
+    if (value) {
+      walkBlock(value, indent, lines, attr, withAlias(extraAliases, idOf(block)), shell, nameEdit);
+    }
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (isDvShell(type) || type === "code_phrase") {
+    walkInputs(block, indent, lines, attribute, withAlias(extraAliases, idOf(block)), shell ?? type, attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === MAPS_CREATE_WITH && !stringField(block, "NAME")) {
+    walkMapEntries(block, indent, lines, withAlias(extraAliases, idOf(block)));
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "logic_operation") {
+    emitLogicOperation(block, indent, lines, attribute, extraAliases, attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "logic_compare") {
+    emit(lines, compareLine(block, indent, attribute, extraAliases), attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === MAPS_GET) {
+    emit(lines, mapsGetLine(block, indent, attribute, extraAliases, shell), attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "sheet_lookup") {
+    emit(lines, sheetLookupLine(block, indent, attribute, extraAliases, shell), attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (isSourceQuery(type)) {
+    emit(lines, sourceQueryLine(block, indent, attribute, extraAliases, shell), attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "text" || type === "text_literal") {
+    emit(lines, textLine(block, indent, attribute, extraAliases, shell, "text"), attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "text_code") {
+    emit(lines, textLine(block, indent, attribute, extraAliases, shell, "code"), attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "math_number" || type === "number_literal") {
+    emit(lines, numberLine(block, indent, attribute, extraAliases, shell), attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "logic_boolean" || type === "boolean_literal") {
+    emit(lines, booleanLine(block, indent, attribute, extraAliases, shell), attributeEdit);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "for_each_source") {
+    emit(lines, loopLine(block, indent, attribute, extraAliases), attributeEdit);
+    walkNamedInputs(block, indent + 1, lines, ["DO"]);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === "controls_if") {
+    emit(lines, containerLine(block, indent, attribute, extraAliases, "if"), attributeEdit);
+    walkIfInputs(block, indent + 1, lines);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  if (type === MAPS_CREATE_WITH) {
+    emit(
+      lines,
+      containerLine(block, indent, attribute, extraAliases, stringField(block, "NAME") || "map"),
+      attributeEdit,
+    );
+    walkMapEntries(block, indent + 1, lines, extraAliases);
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+    return;
+  }
+
+  emit(lines, genericLine(block, indent, attribute, extraAliases, shell), attributeEdit);
+  walkInputs(block, indent + 1, lines);
+  if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell);
+}
+
+function walkInputs(
+  block: BlocklyBlockJson,
+  indent: number,
+  lines: SpecLine[],
+  inheritAttr?: string,
+  extraAliases: string[] = [],
+  shell?: string,
+  attributeEdit?: SpecEditableField,
+): void {
+  if (!block.inputs) return;
+  if (block.type === MAPS_CREATE_WITH) {
+    walkMapEntries(block, indent, lines, extraAliases);
+    return;
+  }
+  for (const [inputName, input] of Object.entries(block.inputs)) {
+    const child = input?.block ?? input?.shadow;
+    if (!child) continue;
+    const attr = slotAttributeFromInputName(inputName) ?? inheritAttr;
+    walkBlock(child, indent, lines, attr, extraAliases, shell, attributeEdit);
+  }
+}
+
+function walkNamedInputs(
+  block: BlocklyBlockJson,
+  indent: number,
+  lines: SpecLine[],
+  names: string[],
+): void {
+  for (const name of names) {
+    const child = inputBlock(block, name);
+    if (!child) continue;
+    walkBlock(child, indent, lines, slotAttributeFromInputName(name) ?? name.toLowerCase());
+  }
+}
+
+function walkMapEntries(
+  block: BlocklyBlockJson,
+  indent: number,
+  lines: SpecLine[],
+  extraAliases: string[],
+): void {
+  const count = mapItemCount(block);
+  for (let i = 0; i < count; i++) {
+    const key = stringField(block, `KEY${i}`) || `key${i}`;
+    const child = inputBlock(block, `VAL${i}`) ?? inputShadow(block, `VAL${i}`);
+    if (!child) continue;
+    const keyEdit: SpecEditableField | undefined = idOf(block)
+      ? { field: `KEY${i}`, value: key, targetBlockId: idOf(block) }
+      : undefined;
+    walkBlock(child, indent, lines, key, extraAliases, undefined, keyEdit);
+  }
+}
+
+function walkIfInputs(block: BlocklyBlockJson, indent: number, lines: SpecLine[]): void {
+  if (!block.inputs) return;
+  const ifKeys = Object.keys(block.inputs)
+    .filter((name) => /^IF\d+$/.test(name))
+    .sort();
+  for (const ifKey of ifKeys) {
+    const n = ifKey.slice(2);
+    const cond = inputBlock(block, ifKey);
+    const body = inputBlock(block, `DO${n}`);
+    const attr = n === "0" ? "when" : `else when ${n}`;
+    if (cond) walkBlock(cond, indent, lines, attr);
+    if (body) walkBlock(body, indent, lines, n === "0" ? "then" : `then ${n}`);
+  }
+  const elseBody = inputBlock(block, "ELSE");
+  if (elseBody) walkBlock(elseBody, indent, lines, "else");
+}
+
+function emitLogicOperation(
+  block: BlocklyBlockJson,
+  indent: number,
+  lines: SpecLine[],
+  attribute: string | undefined,
+  extraAliases: string[],
+  attributeEdit?: SpecEditableField,
+): void {
+  const op = stringField(block, "OP") || "AND";
+  const leaves = flattenSameOp(block, op);
+  const nestedOps = collectSameOpIds(block, op).filter((id) => id !== idOf(block));
+  const aliases = [...extraAliases, ...nestedOps];
+  if (leaves && leaves.length > 1) {
+    emit(lines, {
+      kind: "logic",
+      indent,
+      blockId: idOf(block),
+      aliasIds: aliases.length ? aliases : undefined,
+      type: "logic_operation",
+      label: op.toLowerCase(),
+      attribute,
+      editKind: "none",
+      summary: op === "AND" ? "all of" : op === "OR" ? "any of" : op,
+      info: collectInfo(block),
+    }, attributeEdit);
+    for (const leaf of leaves) {
+      walkBlock(leaf, indent + 1, lines);
+    }
+    return;
+  }
+  emit(lines, genericLine(block, indent, attribute, extraAliases), attributeEdit);
+  walkInputs(block, indent + 1, lines);
+}
+
+function flattenSameOp(block: BlocklyBlockJson, op: string): BlocklyBlockJson[] | null {
+  if (block.type !== "logic_operation") return null;
+  if (stringField(block, "OP") !== op) return null;
+  const a = inputBlock(block, "A");
+  const b = inputBlock(block, "B");
+  if (!a || !b) return null;
+  const left = a.type === "logic_operation" && stringField(a, "OP") === op
+    ? flattenSameOp(a, op) ?? [a]
+    : [a];
+  const right = b.type === "logic_operation" && stringField(b, "OP") === op
+    ? flattenSameOp(b, op) ?? [b]
+    : [b];
+  return [...left, ...right];
+}
+
+function compareLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+): SpecLine {
+  const op = stringField(block, "OP") || "EQ";
+  const a = inputBlock(block, "A");
+  const b = inputBlock(block, "B");
+  const editable: SpecEditableField[] = [
+    { field: "OP", value: op },
+  ];
+  const aliases = [...extraAliases];
+  let left = "?";
+  let right = "?";
+  if (a && isSourceQuery(a.type ?? "")) {
+    const expr = stringField(a, "EXPRESSION");
+    left = expr;
+    editable.unshift({
+      field: "EXPRESSION",
+      value: expr,
+      targetBlockId: idOf(a),
+    });
+    pushAlias(aliases, idOf(a));
+  } else if (a && (a.type === "text" || a.type === "text_literal")) {
+    left = JSON.stringify(stringField(a, "TEXT"));
+    editable.unshift({ field: "TEXT", value: stringField(a, "TEXT"), targetBlockId: idOf(a) });
+    pushAlias(aliases, idOf(a));
+  } else if (a) {
+    left = a.type ?? "?";
+    pushAlias(aliases, idOf(a));
+  }
+  if (b && (b.type === "text" || b.type === "text_literal")) {
+    right = JSON.stringify(stringField(b, "TEXT"));
+    editable.push({ field: "TEXT", value: stringField(b, "TEXT"), targetBlockId: idOf(b) });
+    pushAlias(aliases, idOf(b));
+  } else if (b && isSourceQuery(b.type ?? "")) {
+    right = stringField(b, "EXPRESSION");
+    editable.push({
+      field: "EXPRESSION",
+      value: stringField(b, "EXPRESSION"),
+      targetBlockId: idOf(b),
+    });
+    pushAlias(aliases, idOf(b));
+  } else if (b && (b.type === "math_number" || b.type === "number_literal")) {
+    right = stringField(b, "NUM") || "0";
+    editable.push({ field: "NUM", value: right, targetBlockId: idOf(b) });
+    pushAlias(aliases, idOf(b));
+  } else if (b) {
+    right = b.type ?? "?";
+    pushAlias(aliases, idOf(b));
+  }
+  const symbol = COMPARE_OP[op] ?? op;
+  return {
+    kind: "logic",
+    indent,
+    blockId: idOf(block),
+    aliasIds: aliases.length ? aliases : undefined,
+    type: "logic_compare",
+    label: symbol,
+    attribute,
+    editKind: "compare",
+    summary: `${left} ${symbol} ${right}`,
+    editable,
+    info: collectInfo(block),
+  };
+}
+
+function mapsGetLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+  shell?: string,
+): SpecLine {
+  const name = stringField(block, "NAME") || "defaults";
+  const keyNode = inputBlock(block, "KEY") ?? inputShadow(block, "KEY");
+  const editable: SpecEditableField[] = [{ field: "NAME", value: name }];
+  const aliases = [...extraAliases];
+  let keyLabel = "?";
+  if (keyNode && (keyNode.type === "text" || keyNode.type === "text_literal")) {
+    keyLabel = stringField(keyNode, "TEXT");
+    editable.push({
+      field: "TEXT",
+      value: keyLabel,
+      targetBlockId: idOf(keyNode),
+    });
+    pushAlias(aliases, idOf(keyNode));
+  } else if (keyNode && isSourceQuery(keyNode.type ?? "")) {
+    keyLabel = stringField(keyNode, "EXPRESSION");
+    editable.push({
+      field: "EXPRESSION",
+      value: keyLabel,
+      targetBlockId: idOf(keyNode),
+    });
+    pushAlias(aliases, idOf(keyNode));
+  } else if (keyNode) {
+    keyLabel = keyNode.type ?? "?";
+    pushAlias(aliases, idOf(keyNode));
+  }
+  return {
+    kind: "map_lookup",
+    indent,
+    blockId: idOf(block),
+    aliasIds: aliases.length ? aliases : undefined,
+    type: MAPS_GET,
+    label: name,
+    attribute,
+    shell,
+    editKind: "map_get",
+    summary: `${name}[${JSON.stringify(keyLabel)}]`,
+    editable,
+    info: collectInfo(block),
+  };
+}
+
+function bindValueInput(
+  node: BlocklyBlockJson | undefined,
+  aliases: string[],
+  editable: SpecEditableField[],
+): string {
+  if (!node) return "?";
+  const id = idOf(node);
+  if (id) aliases.push(id);
+  if (node.type === "text" || node.type === "text_literal") {
+    const text = stringField(node, "TEXT");
+    editable.push({ field: "TEXT", value: text, targetBlockId: id });
+    return text;
+  }
+  if (isSourceQuery(node.type ?? "")) {
+    const expr = stringField(node, "EXPRESSION");
+    editable.push({ field: "EXPRESSION", value: expr, targetBlockId: id });
+    return expr;
+  }
+  if (node.type === "math_number" || node.type === "number_literal") {
+    const num = stringField(node, "NUM") || "0";
+    editable.push({ field: "NUM", value: num, targetBlockId: id });
+    return num;
+  }
+  return node.type ?? "?";
+}
+
+function sheetLookupLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+  shell?: string,
+): SpecLine {
+  const name = stringField(block, "NAME") || "Sheet1";
+  const aliases = [...extraAliases];
+  const editable: SpecEditableField[] = [{ field: "NAME", value: name }];
+  const matchCol = bindValueInput(
+    inputBlock(block, "MATCH_COL") ?? inputShadow(block, "MATCH_COL"),
+    aliases,
+    editable,
+  );
+  const matchVal = bindValueInput(
+    inputBlock(block, "MATCH_VAL") ?? inputShadow(block, "MATCH_VAL"),
+    aliases,
+    editable,
+  );
+  const returnCol = bindValueInput(
+    inputBlock(block, "RETURN_COL") ?? inputShadow(block, "RETURN_COL"),
+    aliases,
+    editable,
+  );
+  return {
+    kind: "sheet_lookup",
+    indent,
+    blockId: idOf(block),
+    aliasIds: aliases.length ? aliases : undefined,
+    type: "sheet_lookup",
+    label: name,
+    attribute,
+    shell,
+    editKind: "sheet_lookup",
+    summary: `${name}[${matchCol}=${matchVal} → ${returnCol}]`,
+    editable,
+    info: collectInfo(block),
+  };
+}
+
+function sourceQueryLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+  shell?: string,
+): SpecLine {
+  const type = block.type ?? "source_query";
+  const expr = stringField(block, "EXPRESSION");
+  const ret = sourceReturnType(type, block.fields ?? {});
+  const editable: SpecEditableField[] = [];
+  if (type === "source_query") {
+    editable.push({ field: "RETURN_TYPE", value: ret });
+  }
+  editable.push({ field: "EXPRESSION", value: expr });
+  return {
+    kind: "source_query",
+    indent,
+    blockId: idOf(block),
+    aliasIds: extraAliases.length ? extraAliases : undefined,
+    type,
+    label: expr || type,
+    attribute,
+    shell,
+    editKind: "source_path",
+    summary: `${ret} · ${expr}`,
+    editable,
+    info: collectInfo(block),
+  };
+}
+
+function textLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+  shell: string | undefined,
+  mode: "text" | "code",
+): SpecLine {
+  const text = stringField(block, "TEXT");
+  const lang = stringField(block, "LANG");
+  const editable: SpecEditableField[] = [];
+  if (mode === "code") {
+    editable.push({ field: "LANG", value: lang || "handlebars" });
+  }
+  editable.push({ field: "TEXT", value: text });
+  const firstLine = text.split("\n")[0] ?? "";
+  return {
+    kind: mode === "code" ? "text_gen" : "literal",
+    indent,
+    blockId: idOf(block),
+    aliasIds: extraAliases.length ? extraAliases : undefined,
+    type: block.type ?? "text",
+    label: firstLine || (mode === "code" ? "code" : "text"),
+    attribute,
+    shell,
+    editKind: mode === "code" ? "code" : "text",
+    summary: mode === "code"
+      ? `${lang || "handlebars"} · ${firstLine}${text.includes("\n") ? "…" : ""}`
+      : JSON.stringify(text),
+    editable,
+    info: collectInfo(block),
+  };
+}
+
+function numberLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+  shell?: string,
+): SpecLine {
+  const num = stringField(block, "NUM") || "0";
+  return {
+    kind: "literal",
+    indent,
+    blockId: idOf(block),
+    aliasIds: extraAliases.length ? extraAliases : undefined,
+    type: block.type ?? "math_number",
+    label: num,
+    attribute,
+    shell,
+    editKind: "number",
+    summary: num,
+    editable: [{ field: "NUM", value: num }],
+    info: collectInfo(block),
+  };
+}
+
+function booleanLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+  shell?: string,
+): SpecLine {
+  const bool = stringField(block, "BOOL") || "FALSE";
+  return {
+    kind: "literal",
+    indent,
+    blockId: idOf(block),
+    aliasIds: extraAliases.length ? extraAliases : undefined,
+    type: block.type ?? "logic_boolean",
+    label: bool,
+    attribute,
+    shell,
+    editKind: "boolean",
+    summary: bool === "TRUE" ? "true" : "false",
+    editable: [{ field: "BOOL", value: bool }],
+    info: collectInfo(block),
+  };
+}
+
+function loopLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+): SpecLine {
+  const name = stringField(block, "VAR") || "item";
+  const path = stringField(block, "PATH");
+  return {
+    kind: "container",
+    indent,
+    blockId: idOf(block),
+    aliasIds: extraAliases.length ? extraAliases : undefined,
+    type: "for_each_source",
+    label: name,
+    attribute,
+    editKind: "loop",
+    summary: `${name} in ${path}`,
+    editable: [
+      { field: "VAR", value: name },
+      { field: "PATH", value: path },
+    ],
+    info: collectInfo(block),
+  };
+}
+
+function containerLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+  label: string,
+): SpecLine {
+  const kind = classify(block.type ?? "");
+  return {
     kind,
     indent,
-    blockId: typeof block.id === "string" ? block.id : undefined,
+    blockId: idOf(block),
+    aliasIds: extraAliases.length ? extraAliases : undefined,
+    type: block.type ?? "unknown",
+    label,
+    attribute,
+    editKind: "none",
+    summary: buildContainerSummary(block, label),
+    info: collectInfo(block),
+  };
+}
+
+function genericLine(
+  block: BlocklyBlockJson,
+  indent: number,
+  attribute: string | undefined,
+  extraAliases: string[],
+  shell?: string,
+): SpecLine {
+  const type = block.type ?? "unknown";
+  const fields = block.fields ?? {};
+  const label = pickLabel(type, fields);
+  const kind = classify(type);
+  return {
+    kind,
+    indent,
+    blockId: idOf(block),
+    aliasIds: extraAliases.length ? extraAliases : undefined,
     type,
     label,
     attribute,
+    shell,
+    editKind: "none",
     summary: buildSummary(kind, type, fields, label),
-    editable: editable.length ? editable : undefined,
-    info,
-  });
-
-  if (block.inputs) {
-    for (const [inputName, input] of Object.entries(block.inputs)) {
-      const child = input?.block ?? input?.shadow;
-      if (!child) continue;
-      walkBlock(child, indent + 1, lines, slotAttributeFromInputName(inputName));
-    }
-  }
-  if (block.next?.block) {
-    walkBlock(block.next.block, indent, lines, attribute);
-  }
+    info: collectInfo(block),
+  };
 }
 
 /**
@@ -158,18 +794,14 @@ export function slotAttributeFromInputName(inputName: string): string | undefine
   if (inputName === "VALUE" || inputName === "MAGNITUDE" || inputName === "KIND") {
     return inputName.toLowerCase();
   }
+  if (/^DO\d*$/.test(inputName) || inputName === "ELSE") return undefined;
+  if (/^IF\d+$/.test(inputName)) return undefined;
+  if (/^VAL\d+$/.test(inputName)) return undefined;
   return undefined;
 }
 
 function classify(type: string): SpecLineKind {
-  if (
-    type === "source_query" ||
-    type === "source_query_number" ||
-    type === "source_query_boolean" ||
-    type === "source_query_node"
-  ) {
-    return "source_query";
-  }
+  if (isSourceQuery(type)) return "source_query";
   if (type === "element" || type === "target_value" || type === "json_value" || type === "xml_text") {
     return "value";
   }
@@ -179,11 +811,20 @@ function classify(type: string): SpecLineKind {
     type === "json_object" ||
     type === "json_array" ||
     type === "xml_element" ||
+    type === "defaults_block" ||
+    type === "for_each_source" ||
+    type === "controls_if" ||
+    type === MAPS_CREATE_WITH ||
     isRmContainerBlockType(type)
   ) {
     return "container";
   }
-  if (type.startsWith(DV_PREFIX) || type.startsWith("DV_")) return "dv";
+  if (isDvShell(type)) return "dv";
+  if (type === MAPS_GET) return "map_lookup";
+  if (type === "sheet_lookup") return "sheet_lookup";
+  if (type === "text_code" || type === "text_handlebars") return "text_gen";
+  if (type === "logic_compare" || type === "logic_operation") return "logic";
+  if (type === "text" || type === "math_number" || type === "logic_boolean") return "literal";
   return "other";
 }
 
@@ -197,30 +838,13 @@ function pickLabel(type: string, fields: Record<string, unknown>): string {
   return type;
 }
 
-function editableFields(
-  type: string,
-  fields: Record<string, unknown>,
-): SpecEditableField[] {
-  if (
-    type !== "source_query" &&
-    type !== "source_query_number" &&
-    type !== "source_query_boolean" &&
-    type !== "source_query_node"
-  ) {
-    return [];
-  }
-  const fieldsOut: SpecEditableField[] = [];
-  if (type === "source_query") {
-    fieldsOut.push({
-      field: "RETURN_TYPE",
-      value: typeof fields["RETURN_TYPE"] === "string" ? fields["RETURN_TYPE"] : "string",
-    });
-  }
-  fieldsOut.push({
-    field: "EXPRESSION",
-    value: typeof fields["EXPRESSION"] === "string" ? fields["EXPRESSION"] : "",
-  });
-  return fieldsOut;
+function buildContainerSummary(block: BlocklyBlockJson, label: string): string {
+  const type = block.type ?? "";
+  const rm = stringField(block, "RM_TYPE") || stringField(block, "TARGET_TYPE");
+  const slot = stringField(block, "SLOT_ID");
+  return [label !== type ? label : "", rm && rm !== label ? rm : "", slot ? `slot ${shortSlot(slot)}` : ""]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function buildSummary(
@@ -237,15 +861,7 @@ function buildSummary(
   const slot = typeof fields["SLOT_ID"] === "string" ? fields["SLOT_ID"] : "";
   if (kind === "source_query") {
     const expr = typeof fields["EXPRESSION"] === "string" ? fields["EXPRESSION"] : "";
-    const ret = type === "source_query_number"
-      ? "number"
-      : type === "source_query_boolean"
-      ? "boolean"
-      : type === "source_query_node"
-      ? "node"
-      : typeof fields["RETURN_TYPE"] === "string"
-      ? fields["RETURN_TYPE"]
-      : "string";
+    const ret = sourceReturnType(type, fields);
     return `${ret} · ${expr}`;
   }
   if (kind === "value" || kind === "container" || kind === "dv") {
@@ -254,6 +870,13 @@ function buildSummary(
       .join(" · ");
   }
   return label !== type ? label : "";
+}
+
+function sourceReturnType(type: string, fields: Record<string, unknown>): string {
+  if (type === "source_query_number") return "number";
+  if (type === "source_query_boolean") return "boolean";
+  if (type === "source_query_node") return "node";
+  return typeof fields["RETURN_TYPE"] === "string" ? fields["RETURN_TYPE"] : "string";
 }
 
 function shortSlot(slotId: string): string {
@@ -278,28 +901,20 @@ export interface BlocklyJsonDocument {
   widgets: Array<{ from: number; to: number; line: SpecLine }>;
 }
 
-/** Pretty-printed Blockly JSON plus widget ranges on each block `"type"` line. */
+/** Compact Spec text plus widget ranges, one range per projected line. */
 export function blocklyJsonDocument(state: unknown): BlocklyJsonDocument {
-  const text = state == null ? "{}" : JSON.stringify(state, null, 2);
-  const specBlocks = projectBlocklyState(state).lines.filter(
-    (line) => line.kind !== "header" && line.type !== "empty",
-  );
+  const projection = projectBlocklyState(state);
+  const text = projection.text;
   const widgets: BlocklyJsonDocument["widgets"] = [];
-  const jsonLines = text.split("\n");
   let offset = 0;
-  let specIdx = 0;
-  for (let i = 0; i < jsonLines.length; i++) {
-    const line = jsonLines[i]!;
+  const rows = text.length ? text.split("\n") : [""];
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i]!;
     const from = offset;
-    const to = from + line.length;
-    offset = to + (i < jsonLines.length - 1 ? 1 : 0);
-    if (specIdx < specBlocks.length && /^\s*"type": /.test(line)) {
-      widgets.push({ from, to, line: specBlocks[specIdx]! });
-      specIdx++;
-    }
-  }
-  if (specIdx !== specBlocks.length) {
-    return { text, widgets: [] };
+    const to = from + row.length;
+    offset = to + (i < rows.length - 1 ? 1 : 0);
+    const line = projection.lines[i];
+    if (line) widgets.push({ from, to, line });
   }
   return { text, widgets };
 }
@@ -316,4 +931,61 @@ function toProjection(lines: SpecLine[]): SpecProjection {
     })
     .join("\n");
   return { text, lines };
+}
+
+function isSourceQuery(type: string): boolean {
+  return (
+    type === "source_query" ||
+    type === "source_query_number" ||
+    type === "source_query_boolean" ||
+    type === "source_query_node"
+  );
+}
+
+function isDvShell(type: string): boolean {
+  return type.startsWith(DV_PREFIX) || type.startsWith("DV_");
+}
+
+function stringField(block: BlocklyBlockJson, name: string): string {
+  const value = block.fields?.[name];
+  return typeof value === "string" ? value : "";
+}
+
+function inputBlock(block: BlocklyBlockJson, name: string): BlocklyBlockJson | undefined {
+  return block.inputs?.[name]?.block;
+}
+
+function inputShadow(block: BlocklyBlockJson, name: string): BlocklyBlockJson | undefined {
+  return block.inputs?.[name]?.shadow;
+}
+
+function idOf(block: BlocklyBlockJson): string | undefined {
+  return typeof block.id === "string" ? block.id : undefined;
+}
+
+function collectSameOpIds(block: BlocklyBlockJson, op: string): string[] {
+  const ids: string[] = [];
+  const walk = (node: BlocklyBlockJson | undefined) => {
+    if (!node || node.type !== "logic_operation") return;
+    if (stringField(node, "OP") !== op) return;
+    const id = idOf(node);
+    if (id) ids.push(id);
+    walk(inputBlock(node, "A"));
+    walk(inputBlock(node, "B"));
+  };
+  walk(block);
+  return ids;
+}
+
+function mapItemCount(block: BlocklyBlockJson): number {
+  const extra = block.extraState;
+  if (extra && typeof extra === "object" && extra !== null && "itemCount" in extra) {
+    const n = (extra as { itemCount?: unknown }).itemCount;
+    if (typeof n === "number") return n;
+  }
+  let count = 0;
+  while (block.fields?.[`KEY${count}`] !== undefined || block.inputs?.[`VAL${count}`]) {
+    count++;
+  }
+  return count;
 }

--- a/src/workbench/mapping_spec/widgets.ts
+++ b/src/workbench/mapping_spec/widgets.ts
@@ -3,15 +3,18 @@ import {
   SOURCE_TYPE_EMOJI,
   type SourceReturnType,
 } from "../../blockly/source_query.ts";
+import { EDITOR_LANGUAGE_OPTIONS } from "../codemirror_setup.ts";
 import { attachInfoTip, detachInfoTip } from "../../ui/info_tip.ts";
-import type { SpecLine } from "./project.ts";
+import type { SpecEditFieldName, SpecEditableField, SpecLine } from "./project.ts";
 
 /** Matching CodeMirror line box — keep Spec rows as dense as a code listing. */
 export const SPEC_LINE_HEIGHT = 18;
+const CODE_ROW_HEIGHT = 15;
+const CODE_MAX_ROWS = 8;
 
 export type SpecFieldEditHandler = (
   blockId: string,
-  field: "EXPRESSION" | "RETURN_TYPE",
+  field: SpecEditFieldName,
   value: string,
 ) => void;
 
@@ -30,6 +33,11 @@ export class MappingSpecWidget extends WidgetType {
   }
 
   override get estimatedHeight(): number {
+    if (this.line.editKind === "code") {
+      const text = this.line.editable?.find((f) => f.field === "TEXT")?.value ?? "";
+      const rows = Math.min(CODE_MAX_ROWS, Math.max(3, text.split("\n").length));
+      return 20 + rows * CODE_ROW_HEIGHT;
+    }
     return SPEC_LINE_HEIGHT;
   }
 
@@ -39,8 +47,12 @@ export class MappingSpecWidget extends WidgetType {
       this.line.kind === other.line.kind &&
       this.line.type === other.line.type &&
       this.line.attribute === other.line.attribute &&
+      this.line.shell === other.line.shell &&
+      this.line.editKind === other.line.editKind &&
       this.line.summary === other.line.summary &&
       JSON.stringify(this.line.editable) === JSON.stringify(other.line.editable) &&
+      JSON.stringify(this.line.attributeEdit) === JSON.stringify(other.line.attributeEdit) &&
+      JSON.stringify(this.line.aliasIds) === JSON.stringify(other.line.aliasIds) &&
       JSON.stringify(this.line.info) === JSON.stringify(other.line.info) &&
       this.warning === other.warning &&
       this.selected === other.selected
@@ -50,6 +62,7 @@ export class MappingSpecWidget extends WidgetType {
   override toDOM(): HTMLElement {
     const row = document.createElement("span");
     row.className = `spec-widget spec-widget--${this.line.kind}`;
+    if (this.line.editKind === "code") row.classList.add("spec-widget--multiline");
     if (this.selected) row.classList.add("spec-widget--selected");
     row.style.paddingLeft = `${4 + this.line.indent * 12}px`;
     if (this.line.blockId) row.dataset.blockId = this.line.blockId;
@@ -67,7 +80,26 @@ export class MappingSpecWidget extends WidgetType {
       row.appendChild(warn);
     }
 
-    if (this.line.attribute) {
+    if (this.line.attributeEdit && this.line.blockId) {
+      const attr = document.createElement("span");
+      attr.className = "spec-widget-attr spec-widget-attr--edit";
+      if (this.line.attribute?.startsWith("@")) {
+        const at = document.createElement("span");
+        at.className = "spec-widget-punct";
+        at.textContent = "@";
+        attr.appendChild(at);
+      }
+      attr.appendChild(
+        textInput(
+          this.line,
+          this.line.attributeEdit,
+          this.onFieldEdit,
+          this.line.attribute?.startsWith("@") ? "Attribute name" : "Map key",
+          "spec-widget-input spec-widget-input--attr",
+        ),
+      );
+      row.appendChild(attr);
+    } else if (this.line.attribute) {
       const attr = document.createElement("span");
       attr.className = "spec-widget-attr";
       attr.textContent = this.line.attribute;
@@ -78,62 +110,15 @@ export class MappingSpecWidget extends WidgetType {
     const badge = document.createElement("span");
     badge.className = "spec-widget-badge";
     badge.textContent = badgeLabel(this.line);
+    if (this.line.shell) badge.title = this.line.shell;
     row.appendChild(badge);
 
-    if (this.line.kind === "source_query" && this.line.blockId && this.line.editable) {
-      const returnField = this.line.editable.find((f) => f.field === "RETURN_TYPE");
-      const exprField = this.line.editable.find((f) => f.field === "EXPRESSION");
-
-      if (returnField) {
-        const select = document.createElement("select");
-        select.className = "spec-widget-select spec-widget-type-select";
-        select.setAttribute("aria-label", "Return type");
-        for (const opt of ["string", "number", "boolean"] as SourceReturnType[]) {
-          const option = document.createElement("option");
-          option.value = opt;
-          option.textContent = `${SOURCE_TYPE_EMOJI[opt]} ${opt}`;
-          if (opt === (returnField.value ?? "string")) option.selected = true;
-          select.appendChild(option);
-        }
-        select.addEventListener("change", () => {
-          if (this.line.blockId) {
-            this.onFieldEdit?.(this.line.blockId, "RETURN_TYPE", select.value);
-          }
-        });
-        row.appendChild(select);
-      } else {
-        const typeHint = document.createElement("span");
-        typeHint.className = "spec-widget-type";
-        const summaryType = sourceReturnTypeFromSummary(this.line.summary);
-        typeHint.textContent = SOURCE_TYPE_EMOJI[summaryType];
-        typeHint.title = summaryType;
-        typeHint.setAttribute("aria-label", summaryType);
-        row.appendChild(typeHint);
-      }
-
-      const input = document.createElement("input");
-      input.type = "text";
-      input.className = "spec-widget-input";
-      input.value = exprField?.value ?? "";
-      input.setAttribute("aria-label", "Source path expression");
-      input.addEventListener("change", () => {
-        if (this.line.blockId) {
-          this.onFieldEdit?.(this.line.blockId, "EXPRESSION", input.value);
-        }
-      });
-      input.addEventListener("keydown", (event) => {
-        if (event.key === "Enter") {
-          event.preventDefault();
-          input.blur();
-        }
-      });
-      row.appendChild(input);
-    } else {
-      const summary = document.createElement("span");
-      summary.className = "spec-widget-summary";
-      summary.textContent = this.line.summary || this.line.label;
-      row.appendChild(summary);
-    }
+    const editors = document.createElement("span");
+    editors.className = this.line.editKind === "code"
+      ? "spec-widget-editors spec-widget-editors--stack"
+      : "spec-widget-editors";
+    renderEditors(editors, this.line, this.onFieldEdit);
+    row.appendChild(editors);
 
     const tip = document.createElement("span");
     tip.className = "info-tip info-tip--end";
@@ -157,7 +142,7 @@ export class MappingSpecWidget extends WidgetType {
         const target = event.target;
         if (
           target instanceof Element &&
-          target.closest("input, select, button, .info-tip, .info-tip-balloon")
+          target.closest("input, select, textarea, button, .info-tip, .info-tip-balloon")
         ) {
           return;
         }
@@ -178,6 +163,272 @@ export class MappingSpecWidget extends WidgetType {
   }
 }
 
+function renderEditors(
+  host: HTMLElement,
+  line: SpecLine,
+  onFieldEdit?: SpecFieldEditHandler,
+): void {
+  const fields = line.editable ?? [];
+  if (!fields.length || line.editKind === "none" || !line.blockId) {
+    const summary = document.createElement("span");
+    summary.className = "spec-widget-summary";
+    summary.textContent = line.summary || line.label;
+    host.appendChild(summary);
+    return;
+  }
+
+  if (line.editKind === "source_path") {
+    const returnField = fields.find((f) => f.field === "RETURN_TYPE");
+    const exprField = fields.find((f) => f.field === "EXPRESSION");
+    if (returnField) {
+      host.appendChild(returnTypeSelect(line, returnField, onFieldEdit));
+    } else {
+      const typeHint = document.createElement("span");
+      typeHint.className = "spec-widget-type";
+      const summaryType = sourceReturnTypeFromSummary(line.summary);
+      typeHint.textContent = SOURCE_TYPE_EMOJI[summaryType];
+      typeHint.title = summaryType;
+      typeHint.setAttribute("aria-label", summaryType);
+      host.appendChild(typeHint);
+    }
+    if (exprField) {
+      host.appendChild(textInput(line, exprField, onFieldEdit, "Source path expression", "spec-widget-input"));
+    }
+    return;
+  }
+
+  if (line.editKind === "map_get") {
+    const name = fields.find((f) => f.field === "NAME");
+    const key = fields.find((f) => f.field === "TEXT" || f.field === "EXPRESSION");
+    if (name) {
+      host.appendChild(textInput(line, name, onFieldEdit, "Map name", "spec-widget-input spec-widget-input--name"));
+    }
+    const lbrack = document.createElement("span");
+    lbrack.className = "spec-widget-punct";
+    lbrack.textContent = "[";
+    host.appendChild(lbrack);
+    if (key) {
+      host.appendChild(textInput(line, key, onFieldEdit, "Map key", "spec-widget-input"));
+    }
+    const rbrack = document.createElement("span");
+    rbrack.className = "spec-widget-punct";
+    rbrack.textContent = "]";
+    host.appendChild(rbrack);
+    return;
+  }
+
+  if (line.editKind === "compare") {
+    for (const field of fields) {
+      if (field.field === "OP") {
+        host.appendChild(opSelect(line, field, onFieldEdit));
+      } else {
+        host.appendChild(textInput(line, field, onFieldEdit, field.field, "spec-widget-input spec-widget-input--short"));
+      }
+    }
+    return;
+  }
+
+  if (line.editKind === "sheet_lookup") {
+    const name = fields.find((f) => f.field === "NAME");
+    const rest = fields.filter((f) => f.field !== "NAME");
+    if (name) {
+      host.appendChild(textInput(line, name, onFieldEdit, "Sheet name", "spec-widget-input spec-widget-input--name"));
+    }
+    const punct = (text: string) => {
+      const el = document.createElement("span");
+      el.className = "spec-widget-punct";
+      el.textContent = text;
+      return el;
+    };
+    if (rest[0]) {
+      host.appendChild(punct("where"));
+      host.appendChild(textInput(line, rest[0], onFieldEdit, "Match column", "spec-widget-input spec-widget-input--short"));
+    }
+    if (rest[1]) {
+      host.appendChild(punct("="));
+      host.appendChild(textInput(line, rest[1], onFieldEdit, "Match value", "spec-widget-input"));
+    }
+    if (rest[2]) {
+      host.appendChild(punct("→"));
+      host.appendChild(textInput(line, rest[2], onFieldEdit, "Return column", "spec-widget-input spec-widget-input--short"));
+    }
+    return;
+  }
+
+  if (line.editKind === "code") {
+    const lang = fields.find((f) => f.field === "LANG");
+    const text = fields.find((f) => f.field === "TEXT");
+    if (lang) host.appendChild(langSelect(line, lang, onFieldEdit));
+    if (text) host.appendChild(codeArea(line, text, onFieldEdit));
+    return;
+  }
+
+  if (line.editKind === "loop") {
+    const name = fields.find((f) => f.field === "VAR");
+    const path = fields.find((f) => f.field === "PATH");
+    const prefix = document.createElement("span");
+    prefix.className = "spec-widget-punct";
+    prefix.textContent = "for each";
+    host.appendChild(prefix);
+    if (name) host.appendChild(textInput(line, name, onFieldEdit, "Loop variable", "spec-widget-input spec-widget-input--name"));
+    const inn = document.createElement("span");
+    inn.className = "spec-widget-punct";
+    inn.textContent = "in";
+    host.appendChild(inn);
+    if (path) host.appendChild(textInput(line, path, onFieldEdit, "Source path", "spec-widget-input"));
+    return;
+  }
+
+  if (line.editKind === "boolean") {
+    const bool = fields.find((f) => f.field === "BOOL");
+    if (bool) host.appendChild(boolSelect(line, bool, onFieldEdit));
+    return;
+  }
+
+  for (const field of fields) {
+    if (field.field === "LANG") {
+      host.appendChild(langSelect(line, field, onFieldEdit));
+      continue;
+    }
+    host.appendChild(textInput(line, field, onFieldEdit, field.field, "spec-widget-input"));
+  }
+}
+
+function editTarget(line: SpecLine, field: SpecEditableField): string | undefined {
+  return field.targetBlockId ?? line.blockId;
+}
+
+function commit(
+  line: SpecLine,
+  field: SpecEditableField,
+  value: string,
+  onFieldEdit?: SpecFieldEditHandler,
+): void {
+  const id = editTarget(line, field);
+  if (id) onFieldEdit?.(id, field.field, value);
+}
+
+function textInput(
+  line: SpecLine,
+  field: SpecEditableField,
+  onFieldEdit: SpecFieldEditHandler | undefined,
+  aria: string,
+  className: string,
+): HTMLInputElement {
+  const input = document.createElement("input");
+  input.type = field.field === "NUM" ? "number" : "text";
+  input.className = className;
+  input.value = field.value;
+  input.setAttribute("aria-label", aria);
+  input.addEventListener("change", () => commit(line, field, input.value, onFieldEdit));
+  input.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      input.blur();
+    }
+  });
+  return input;
+}
+
+function codeArea(
+  line: SpecLine,
+  field: SpecEditableField,
+  onFieldEdit?: SpecFieldEditHandler,
+): HTMLTextAreaElement {
+  const area = document.createElement("textarea");
+  area.className = "spec-widget-code";
+  area.value = field.value;
+  area.setAttribute("aria-label", "Generated text");
+  const rows = Math.min(CODE_MAX_ROWS, Math.max(3, field.value.split("\n").length));
+  area.rows = rows;
+  area.spellcheck = false;
+  area.addEventListener("change", () => commit(line, field, area.value, onFieldEdit));
+  return area;
+}
+
+function returnTypeSelect(
+  line: SpecLine,
+  field: SpecEditableField,
+  onFieldEdit?: SpecFieldEditHandler,
+): HTMLSelectElement {
+  const select = document.createElement("select");
+  select.className = "spec-widget-select spec-widget-type-select";
+  select.setAttribute("aria-label", "Return type");
+  for (const opt of ["string", "number", "boolean"] as SourceReturnType[]) {
+    const option = document.createElement("option");
+    option.value = opt;
+    option.textContent = `${SOURCE_TYPE_EMOJI[opt]} ${opt}`;
+    if (opt === (field.value ?? "string")) option.selected = true;
+    select.appendChild(option);
+  }
+  select.addEventListener("change", () => commit(line, field, select.value, onFieldEdit));
+  return select;
+}
+
+function langSelect(
+  line: SpecLine,
+  field: SpecEditableField,
+  onFieldEdit?: SpecFieldEditHandler,
+): HTMLSelectElement {
+  const select = document.createElement("select");
+  select.className = "spec-widget-select";
+  select.setAttribute("aria-label", "Code language");
+  for (const [label, value] of EDITOR_LANGUAGE_OPTIONS) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    if (value === field.value) option.selected = true;
+    select.appendChild(option);
+  }
+  select.addEventListener("change", () => commit(line, field, select.value, onFieldEdit));
+  return select;
+}
+
+function opSelect(
+  line: SpecLine,
+  field: SpecEditableField,
+  onFieldEdit?: SpecFieldEditHandler,
+): HTMLSelectElement {
+  const select = document.createElement("select");
+  select.className = "spec-widget-select spec-widget-select--op";
+  select.setAttribute("aria-label", "Compare operator");
+  for (const [value, label] of [
+    ["EQ", "="],
+    ["NEQ", "≠"],
+    ["LT", "<"],
+    ["LTE", "≤"],
+    ["GT", ">"],
+    ["GTE", "≥"],
+  ] as const) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    if (value === field.value) option.selected = true;
+    select.appendChild(option);
+  }
+  select.addEventListener("change", () => commit(line, field, select.value, onFieldEdit));
+  return select;
+}
+
+function boolSelect(
+  line: SpecLine,
+  field: SpecEditableField,
+  onFieldEdit?: SpecFieldEditHandler,
+): HTMLSelectElement {
+  const select = document.createElement("select");
+  select.className = "spec-widget-select";
+  select.setAttribute("aria-label", "Boolean");
+  for (const [value, label] of [["TRUE", "true"], ["FALSE", "false"]] as const) {
+    const option = document.createElement("option");
+    option.value = value;
+    option.textContent = label;
+    if (value === field.value) option.selected = true;
+    select.appendChild(option);
+  }
+  select.addEventListener("change", () => commit(line, field, select.value, onFieldEdit));
+  return select;
+}
+
 function sourceReturnTypeFromSummary(summary: string): SourceReturnType {
   const raw = summary.split(" · ")[0] ?? "string";
   if (raw === "number" || raw === "boolean" || raw === "node") return raw;
@@ -185,6 +436,9 @@ function sourceReturnTypeFromSummary(summary: string): SourceReturnType {
 }
 
 function badgeLabel(line: SpecLine): string {
+  if (line.shell) {
+    return line.shell.replace(/^dv_/i, "DV_").toUpperCase();
+  }
   switch (line.kind) {
     case "header":
       return "spec";
@@ -194,8 +448,18 @@ function badgeLabel(line: SpecLine): string {
       return line.type.replace(/^dv_/i, "DV_").toUpperCase();
     case "value":
       return "slot";
+    case "map_lookup":
+      return "map";
+    case "sheet_lookup":
+      return "sheet";
+    case "text_gen":
+      return line.editable?.find((f) => f.field === "LANG")?.value || "code";
+    case "literal":
+      return line.editKind === "number" ? "num" : line.editKind === "boolean" ? "bool" : "text";
+    case "logic":
+      return line.type === "logic_operation" ? line.label : "if";
     case "container":
-      return line.type;
+      return line.type.replace(/^schema_/, "");
     default:
       return line.type;
   }

--- a/test/mapping_spec_project_test.ts
+++ b/test/mapping_spec_project_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import {
   blocklyJsonDocument,
   projectBlocklyState,
@@ -48,6 +48,8 @@ Deno.test("projectBlocklyState compresses nested blocks and omits x/y from text"
   const source = projection.lines.find((line) => line.kind === "source_query");
   assertEquals(source?.blockId, "sq1");
   assertEquals(source?.attribute, "magnitude");
+  assertEquals(source?.shell, "dv_quantity");
+  assertEquals(source?.aliasIds?.includes("dv1"), true);
   assertEquals(
     source?.editable?.find((field) => field.field === "EXPRESSION")?.value,
     "$.systolic",
@@ -58,14 +60,13 @@ Deno.test("projectBlocklyState compresses nested blocks and omits x/y from text"
     projection.lines.find((line) => line.blockId === "el1")?.info.x,
     40,
   );
-  assertEquals(projection.lines.find((line) => line.blockId === "dv1")?.attribute, "value");
-  assertStringIncludes(projection.text, "value  dv_quantity");
+  assertEquals(projection.lines.some((line) => line.blockId === "dv1"), false);
   assertStringIncludes(projection.text, "magnitude  source_query");
 });
 
-Deno.test("empty workspace projects a header and empty marker", () => {
+Deno.test("empty workspace projects an empty marker", () => {
   const projection = projectBlocklyState({ blocks: { languageVersion: 0, blocks: [] } });
-  assertEquals(projection.lines[0]?.kind, "header");
+  assertEquals(projection.lines[0]?.type, "empty");
   assertStringIncludes(projection.text, "no blocks");
 });
 
@@ -139,12 +140,13 @@ Deno.test("projectBlocklyState labels named ATTR_/FLD_ slot fillers and statemen
     },
   });
   assertEquals(projection.lines.find((l) => l.blockId === "c1")?.attribute, undefined);
-  assertEquals(projection.lines.find((l) => l.blockId === "lang")?.attribute, "language");
+  assertEquals(projection.lines.find((l) => l.blockId === "lang"), undefined);
   assertEquals(projection.lines.find((l) => l.blockId === "langq")?.attribute, "code_string");
+  assertEquals(projection.lines.find((l) => l.blockId === "langq")?.aliasIds?.includes("lang"), true);
   assertEquals(projection.lines.find((l) => l.blockId === "obs1")?.attribute, "content");
   assertEquals(projection.lines.find((l) => l.blockId === "obs2")?.attribute, "content");
   assertEquals(projection.lines.find((l) => l.blockId === "fa1")?.attribute, "feeder_audit");
-  assertStringIncludes(projection.text, "language  code_phrase");
+  assertStringIncludes(projection.text, "code_string  source_query");
   assertStringIncludes(projection.text, "content  observation");
 });
 
@@ -160,7 +162,7 @@ Deno.test("slotAttributeFromInputName strips Blockly prefixes", () => {
   assertEquals(slotAttributeFromInputName("DO"), undefined);
 });
 
-Deno.test("blocklyJsonDocument keeps full workspace JSON including coordinates", () => {
+Deno.test("blocklyJsonDocument is a compact projection; coordinates stay in ⓘ info", () => {
   const state = {
     blocks: {
       languageVersion: 0,
@@ -174,14 +176,14 @@ Deno.test("blocklyJsonDocument keeps full workspace JSON including coordinates",
     },
   };
   const doc = blocklyJsonDocument(state);
-  const parsed = JSON.parse(doc.text);
-  assertEquals(parsed.blocks.blocks[0].x, 40);
-  assertEquals(parsed.blocks.blocks[0].y, 80);
-  assertEquals(doc.text.includes('"x": 40'), true);
+  assertEquals(doc.text.includes('"x": 40'), false);
+  assertEquals(doc.text.startsWith("{"), false);
   assertEquals(doc.widgets.some((w) => w.line.blockId === "el1"), true);
+  assertEquals(doc.widgets[0]?.line.info.x, 40);
+  assertEquals(doc.widgets.length, doc.text.split("\n").length);
 });
 
-Deno.test("blocklyJsonDocument widget overlay keeps extraState and coordinates in the document", () => {
+Deno.test("blocklyJsonDocument keeps extraState and coordinates on the widget info balloon", () => {
   const state = {
     blocks: {
       languageVersion: 0,
@@ -196,8 +198,262 @@ Deno.test("blocklyJsonDocument widget overlay keeps extraState and coordinates i
     },
   };
   const doc = blocklyJsonDocument(state);
-  assertEquals(JSON.parse(doc.text).blocks.blocks[0].x, 24);
-  assertStringIncludes(doc.text, '"RM_TYPE": "EVENT"');
-  assertStringIncludes(doc.text, '"extraState"');
+  assertEquals(doc.widgets[0]?.line.info.x, 24);
+  assertEquals(
+    (doc.widgets[0]?.line.info.extraState as { attrs?: string[] })?.attrs,
+    ["time", "data"],
+  );
   assertEquals(doc.widgets.length > 0, true);
+});
+
+Deno.test("projectBlocklyState flattens xml_text + maps_get + text key into one lookup row", () => {
+  const projection = projectBlocklyState({
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: "xml_element",
+        id: "el",
+        fields: { NAME: "Time" },
+        inputs: {
+          TARGET_children: {
+            block: {
+              type: "xml_text",
+              id: "xt",
+              inputs: {
+                VALUE: {
+                  block: {
+                    type: "maps_get",
+                    id: "mg",
+                    fields: { NAME: "defaults" },
+                    inputs: {
+                      KEY: {
+                        block: {
+                          type: "text",
+                          id: "k",
+                          fields: { TEXT: "Time" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }],
+    },
+  });
+  assertEquals(projection.lines.map((l) => l.type), ["xml_element", "maps_get"]);
+  const lookup = projection.lines[1];
+  assertEquals(lookup?.kind, "map_lookup");
+  assertEquals(lookup?.summary, 'defaults["Time"]');
+  assertEquals(lookup?.aliasIds?.includes("xt"), true);
+  assertEquals(lookup?.aliasIds?.includes("k"), true);
+  assertEquals(lookup?.editable?.find((f) => f.field === "TEXT")?.targetBlockId, "k");
+});
+
+Deno.test("projectBlocklyState flattens nested AND compares into one list", () => {
+  const compare = (id: string, path: string, value: string) => ({
+    type: "logic_compare",
+    id,
+    fields: { OP: "NEQ" },
+    inputs: {
+      A: {
+        block: {
+          type: "source_query",
+          id: `${id}a`,
+          fields: { EXPRESSION: path, RETURN_TYPE: "string" },
+        },
+      },
+      B: { block: { type: "text", id: `${id}b`, fields: { TEXT: value } } },
+    },
+  });
+  const projection = projectBlocklyState({
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: "controls_if",
+        id: "if1",
+        extraState: { hasElse: true },
+        inputs: {
+          IF0: {
+            block: {
+              type: "logic_operation",
+              id: "and1",
+              fields: { OP: "AND" },
+              inputs: {
+                A: {
+                  block: {
+                    type: "logic_operation",
+                    id: "and2",
+                    fields: { OP: "AND" },
+                    inputs: {
+                      A: { block: compare("c1", "fatigue|value", "Nej") },
+                      B: { block: compare("c2", "breathing|value", "Nej") },
+                    },
+                  },
+                },
+                B: { block: compare("c3", "heart|value", "Nej") },
+              },
+            },
+          },
+          DO0: {
+            block: {
+              type: "text_code",
+              id: "note",
+              fields: { LANG: "handlebars", TEXT: "{{note}}\nline2" },
+            },
+          },
+          ELSE: {
+            block: { type: "text", id: "else1", fields: { TEXT: "skip" } },
+          },
+        },
+      }],
+    },
+  });
+  const types = projection.lines.map((l) => l.type);
+  assertEquals(types.filter((t) => t === "logic_operation").length, 1);
+  assertEquals(types.filter((t) => t === "logic_compare").length, 3);
+  const andRow = projection.lines.find((l) => l.type === "logic_operation");
+  assertEquals(andRow?.summary, "all of");
+  assertEquals(andRow?.aliasIds?.includes("and2"), true);
+  const note = projection.lines.find((l) => l.blockId === "note");
+  assertEquals(note?.editKind, "code");
+  assertEquals(note?.editable?.find((f) => f.field === "LANG")?.value, "handlebars");
+  assertStringIncludes(note?.editable?.find((f) => f.field === "TEXT")?.value ?? "", "{{note}}");
+});
+
+Deno.test("projectBlocklyState uses map KEY fields as row attributes", () => {
+  const projection = projectBlocklyState({
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: "defaults_block",
+        id: "def",
+        inputs: {
+          MAP: {
+            block: {
+              type: "maps_create_with",
+              id: "map1",
+              extraState: { itemCount: 2 },
+              fields: { KEY0: "language", KEY1: "territory" },
+              inputs: {
+                VAL0: { block: { type: "text", id: "v0", fields: { TEXT: "sv" } } },
+                VAL1: { block: { type: "text", id: "v1", fields: { TEXT: "SE" } } },
+              },
+            },
+          },
+        },
+      }],
+    },
+  });
+  assertEquals(projection.lines.find((l) => l.type === "maps_create_with"), undefined);
+  assertEquals(projection.lines.find((l) => l.blockId === "v0")?.attribute, "language");
+  assertEquals(projection.lines.find((l) => l.blockId === "v1")?.attribute, "territory");
+  assertEquals(
+    projection.lines.find((l) => l.blockId === "v0")?.attributeEdit,
+    { field: "KEY0", value: "language", targetBlockId: "map1" },
+  );
+});
+
+Deno.test("projectBlocklyState flattens xml_attribute to @name on the value", () => {
+  const projection = projectBlocklyState({
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: "xml_attribute",
+        id: "a1",
+        fields: { NAME: "MsgType" },
+        inputs: {
+          VALUE: { block: { type: "text", id: "t1", fields: { TEXT: "Request" } } },
+        },
+      }],
+    },
+  });
+  assertEquals(projection.lines.length, 1);
+  assertEquals(projection.lines[0]?.attribute, "@MsgType");
+  assertEquals(projection.lines[0]?.blockId, "t1");
+  assertEquals(projection.lines[0]?.editKind, "text");
+  assertEquals(projection.lines[0]?.attributeEdit, {
+    field: "NAME",
+    value: "MsgType",
+    targetBlockId: "a1",
+  });
+});
+
+Deno.test("chemo TakeCare mapping spec omits Blockly JSON chrome and nested AND rows", async () => {
+  const raw = await Deno.readTextFile(
+    new URL(
+      "../examples/patient-reported-chemotherapy-symptoms/mapping/mapping.blockly.json",
+      import.meta.url,
+    ),
+  );
+  const state = JSON.parse(raw);
+  const typeCount = [...raw.matchAll(/"type":/g)].length;
+  const projection = projectBlocklyState(state);
+  const andRows = projection.lines.filter((l) => l.type === "logic_operation").length;
+  assertEquals(andRows, 4, `expected 4 flattened AND/OR rows, got ${andRows}`);
+  assert(
+    projection.lines.length / typeCount < 0.6,
+    `expected compact rows (${projection.lines.length}) vs Blockly types (${typeCount})`,
+  );
+  assertEquals(projection.text.includes('"extraState"'), false);
+  assertEquals(projection.lines.some((l) => l.editKind === "code"), true);
+  assertEquals(projection.lines.some((l) => l.editKind === "map_get"), true);
+});
+
+Deno.test("projectBlocklyState flattens sheet_lookup into one editable row", () => {
+  const projection = projectBlocklyState({
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: "sheet_lookup",
+        id: "sh1",
+        fields: { NAME: "ICD" },
+        inputs: {
+          MATCH_COL: { shadow: { type: "text", id: "c1", fields: { TEXT: "code" } } },
+          MATCH_VAL: {
+            block: {
+              type: "source_query",
+              id: "sv",
+              fields: { EXPRESSION: "$.icd", RETURN_TYPE: "string" },
+            },
+          },
+          RETURN_COL: { shadow: { type: "text", id: "r1", fields: { TEXT: "snomed" } } },
+        },
+      }],
+    },
+  });
+  assertEquals(projection.lines.length, 1);
+  assertEquals(projection.lines[0]?.kind, "sheet_lookup");
+  assertEquals(projection.lines[0]?.editKind, "sheet_lookup");
+  assertEquals(projection.lines[0]?.summary, "ICD[code=$.icd → snomed]");
+  assertEquals(projection.lines[0]?.aliasIds?.includes("sv"), true);
+});
+
+Deno.test("compare rows keep left-to-right field order when the left operand is text", () => {
+  const projection = projectBlocklyState({
+    blocks: {
+      languageVersion: 0,
+      blocks: [{
+        type: "logic_compare",
+        id: "cmp",
+        fields: { OP: "EQ" },
+        inputs: {
+          A: { block: { type: "text", id: "left", fields: { TEXT: "yes" } } },
+          B: {
+            block: {
+              type: "source_query",
+              id: "right",
+              fields: { EXPRESSION: "$.flag", RETURN_TYPE: "string" },
+            },
+          },
+        },
+      }],
+    },
+  });
+  const fields = projection.lines[0]?.editable?.map((f) => f.field);
+  assertEquals(fields, ["TEXT", "OP", "EXPRESSION"]);
+  assertEquals(projection.lines[0]?.editable?.[0]?.targetBlockId, "left");
+  assertEquals(projection.lines[0]?.editable?.[2]?.targetBlockId, "right");
 });

--- a/test/ui/mapping_spec_json_test.ts
+++ b/test/ui/mapping_spec_json_test.ts
@@ -1,6 +1,6 @@
 /**
- * Mapping Spec pane stores full Blockly workspace JSON in CodeMirror
- * and Download saves that same JSON (including x/y).
+ * Mapping Spec pane shows a compact projection. Download still saves
+ * full Blockly workspace JSON (including x/y).
  */
 
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
@@ -13,7 +13,7 @@ import {
 import type { IntehrgratorTestApi } from "../../src/ui_test/test_api.ts";
 
 Deno.test({
-  name: "UI: Mapping Spec document and Download are full Blockly JSON",
+  name: "UI: Mapping Spec is a compact projection; Download is full Blockly JSON",
   sanitizeResources: false,
   sanitizeOps: false,
   async fn() {
@@ -30,22 +30,14 @@ Deno.test({
       await downloadBtn.waitFor({ timeout: 10_000 });
       assertEquals(await downloadBtn.isVisible(), true);
       assertEquals(await uploadBtn.isVisible(), true);
-      assertEquals(await downloadBtn.textContent().then((t) => t?.includes("Download")), true);
-      assertEquals(await uploadBtn.textContent().then((t) => t?.includes("Upload")), true);
 
       const doc = await page.evaluate(() => {
         const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
           .intehrgratorTestApi;
         return api.getMappingSpecDocument();
       });
-      const parsed = JSON.parse(doc) as {
-        blocks?: { blocks?: Array<{ type?: string; x?: number; y?: number; fields?: Record<string, unknown> }> };
-      };
-      const roots = parsed.blocks?.blocks ?? [];
-      assert(roots.length > 0, "expected Blockly root blocks in Mapping Spec document");
-      assert(typeof roots[0]?.x === "number", "document must keep block x");
-      assert(typeof roots[0]?.y === "number", "document must keep block y");
-      assertStringIncludes(doc, '"type":');
+      assertEquals(doc.trimStart().startsWith("{"), false, "Spec tab must not show raw Blockly JSON");
+      assertEquals(doc.includes('"x":'), false);
 
       const [download] = await Promise.all([
         page.waitForEvent("download", { timeout: 10_000 }),
@@ -56,12 +48,13 @@ Deno.test({
       const downloadPath = await download.path();
       assert(downloadPath, "expected downloaded file path");
       const downloaded = await Deno.readTextFile(downloadPath);
-      const downloadedJson = JSON.parse(downloaded) as typeof parsed;
-      assertEquals(
-        downloadedJson.blocks?.blocks?.[0]?.type,
-        parsed.blocks?.blocks?.[0]?.type,
-      );
-      assertEquals(downloadedJson.blocks?.blocks?.[0]?.x, parsed.blocks?.blocks?.[0]?.x);
+      const downloadedJson = JSON.parse(downloaded) as {
+        blocks?: { blocks?: Array<{ type?: string; x?: number; y?: number; id?: string }> };
+      };
+      const roots = downloadedJson.blocks?.blocks ?? [];
+      assert(roots.length > 0, "expected Blockly root blocks in download");
+      assert(typeof roots[0]?.x === "number", "download must keep block x");
+      assert(typeof roots[0]?.y === "number", "download must keep block y");
 
       const tweaked = JSON.parse(downloaded) as {
         blocks: { languageVersion?: number; blocks: Array<Record<string, unknown>> };
@@ -80,8 +73,45 @@ Deno.test({
           .intehrgratorTestApi;
         return api.getMappingSpecDocument();
       });
-      assertStringIncludes(after, '"id": "uploaded-root"');
-      assertStringIncludes(after, '"x": 99');
+      assertEquals(after.includes('"id": "uploaded-root"'), false);
+      const snapshot = await page.evaluate(() => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        return api.getSnapshot();
+      });
+      assert(
+        snapshot.blocklyBlocks.some((block) => block.id === "uploaded-root"),
+        "upload must restore Blockly ids",
+      );
+      assertStringIncludes(after, snapshot.blocklyBlocks[0]?.type ?? "composition");
+
+      await page.evaluate(() => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        api.loadBlocklyJson("edit.blockly.json", JSON.stringify({
+          blocks: {
+            languageVersion: 0,
+            blocks: [{
+              type: "source_query",
+              id: "sq-edit",
+              x: 8,
+              y: 8,
+              fields: { EXPRESSION: "$.systolic", RETURN_TYPE: "number" },
+            }],
+          },
+        }));
+      });
+      const pathInput = page.locator('.spec-widget-input[aria-label="Source path expression"]');
+      await pathInput.waitFor({ timeout: 10_000 });
+      await pathInput.fill("$.diastolic");
+      await pathInput.blur();
+      await page.waitForTimeout(200);
+      const edited = await page.evaluate(() => {
+        const api = (globalThis as unknown as { intehrgratorTestApi: IntehrgratorTestApi })
+          .intehrgratorTestApi;
+        return api.getSnapshot().blocklyBlocks.find((b) => b.id === "sq-edit")?.fields.EXPRESSION;
+      });
+      assertEquals(edited, "$.diastolic");
     } finally {
       await browser.close();
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Rebased/merged current `main` into this branch so it can land.

- **Compact editable Mapping Spec projection** (#29, already on this branch): one-row-per-semantic-mapping Spec tab; Download/Upload still round-trip full Blockly JSON (ADR 0006).
- **Textual mapping languages** investigation: `docs/future/textual-mapping-languages.md`.
- **Merge conflict:** `CONTEXT.md` — kept compact Spec + ADR 0006 wording **and** the **Blockly Function** glossary from `main`.

## Test plan
- [x] `deno test` mapping_spec + extract_function (20 passed)
- [ ] Dummy vitals: Mapping Spec tab shows compact rows, not pretty-printed Blockly JSON
- [ ] Edit a source path in a Spec row; canvas and Test Run still agree
- [ ] Download/Upload mapping still restores full Blockly JSON

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c2928d7-7a35-4883-aa10-9c07ea90cd0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c2928d7-7a35-4883-aa10-9c07ea90cd0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

