### PR TITLE
Extract Blockly blocks to functions from the context menu

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -168,8 +168,12 @@ Optional RM types attachable via Optional RM Insertion (cogwheel mutator / conte
 _Avoid_: Primer-only RM list, toolbox free-build of LOCATABLE extras, library-level attachment picker API
 
 **Mapping Specification**:
-Canonical interchange is native Blockly workspace JSON (`ProjectBundle.mapping.blocklyState`). The Mapping Spec tab shows a compact projection of that JSON, not the JSON document itself. Blockly is used **declaratively**: the canvas is a slot tree plus constructors (including a **Defaults Map**) and lookups — not an imperative program with statement order. See `docs/MAPPING_SPECIFICATION.md`, ADR 0001, and ADR 0006.
+Canonical interchange is native Blockly workspace JSON (`ProjectBundle.mapping.blocklyState`). The Mapping Spec tab shows a compact projection of that JSON, not the JSON document itself. Blockly is used **declaratively**: the canvas is a slot tree plus constructors (including a **Defaults Map**) and lookups — not an imperative program with statement order. Optional **Blockly Function**s are reusable fragments of that tree, not a sequential script. See `docs/MAPPING_SPECIFICATION.md`, ADR 0001, and ADR 0006.
 _Avoid_: Private `@template` DSL, Mapping script as a third language, treating the canvas as a sequential script
+
+**Blockly Function**:
+A stock Blockly procedure (Functions drawer): a definition block plus call sites. **Extract to function** on a block context menu moves that subtree onto a new definition and leaves a call in place. Still Mapping Specification (Blockly JSON), not a Conversion script function.
+_Avoid_: TypeScript/Java export function, Conversion script, custom DSL subroutine
 
 **Mapping Spec Widget**:
 One projected row in the Mapping Spec tab: a compact, indented view of one semantic mapping (source path, map lookup, sheet lookup, literal, text generation, flattened condition, or container). Safe Blockly fields are editable in the row (paths, map keys, literals, compare operands, loop VAR/PATH, `text_code` LANG/TEXT). Wrappers that do not change mapping meaning (`xml_text`, `DV_*` shells, unnamed maps) are omitted; their Blockly ids stay on the visible row. Download/Upload still round-trip the **full Blockly JSON document**.

--- a/src/blockly/extract_function.ts
+++ b/src/blockly/extract_function.ts
@@ -38,10 +38,19 @@ const PROCEDURE_TYPES = new Set([
   "procedures_ifreturn",
 ]);
 
+function blockFlag(block: Blockly.Block, name: "isInFlyout" | "isShadow" | "isMovable"): boolean {
+  const value = (block as unknown as Record<string, unknown>)[name];
+  if (typeof value === "function") return Boolean((value as () => unknown).call(block));
+  return Boolean(value);
+}
+
 export function canExtractToFunction(block: Blockly.Block | null | undefined): boolean {
-  if (!block || block.isInFlyout || block.isShadow?.()) return false;
+  if (!block || blockFlag(block, "isInFlyout") || blockFlag(block, "isShadow")) return false;
   if (block.workspace?.options?.readOnly) return false;
-  if (typeof block.isMovable === "function" && !block.isMovable()) return false;
+  if (typeof (block as { isMovable?: () => boolean }).isMovable === "function" &&
+    !(block as { isMovable: () => boolean }).isMovable()) {
+    return false;
+  }
   if (PROCEDURE_TYPES.has(block.type)) return false;
   return Boolean(block.outputConnection || block.previousConnection);
 }
@@ -104,20 +113,101 @@ export function extractBlockToFunction(
   return call;
 }
 
+type ContextMenuOption = {
+  text?: string;
+  enabled?: boolean;
+  callback?: () => void;
+  weight?: number;
+};
+
+type GenerateContextMenuFn = (this: Blockly.Block) => ContextMenuOption[] | null;
+
+const EXTRACT_MENU_PATCHED = "__intehrExtractToFunctionMenu";
+
+function contextMenuRegistry(): {
+  registry: { getItem: (id: string) => unknown; register: (item: Record<string, unknown>) => void };
+  ScopeType: { BLOCK: string };
+} | null {
+  const candidates = [
+    Blockly.ContextMenuRegistry,
+    (Blockly as unknown as { default?: { ContextMenuRegistry?: typeof Blockly.ContextMenuRegistry } })
+      .default?.ContextMenuRegistry,
+  ];
+  for (const candidate of candidates) {
+    if (candidate?.registry) {
+      return candidate as unknown as {
+        registry: { getItem: (id: string) => unknown; register: (item: Record<string, unknown>) => void };
+        ScopeType: { BLOCK: string };
+      };
+    }
+  }
+  return null;
+}
+
 export function registerExtractToFunctionMenu(): void {
-  const registry = Blockly.ContextMenuRegistry?.registry;
-  if (!registry) return;
-  if (registry.getItem(EXTRACT_TO_FUNCTION_MENU_ID)) return;
-  registry.register({
+  const ctx = contextMenuRegistry();
+  if (!ctx) return;
+  if (ctx.registry.getItem(EXTRACT_TO_FUNCTION_MENU_ID)) return;
+  ctx.registry.register({
     id: EXTRACT_TO_FUNCTION_MENU_ID,
-    scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+    scopeType: ctx.ScopeType?.BLOCK ?? "block",
     weight: 6,
     displayText: () => msg(detectLocale()).EXTRACT_TO_FUNCTION,
-    preconditionFn: (scope) => canExtractToFunction(scope.block) ? "enabled" : "hidden",
-    callback: (scope) => {
+    preconditionFn: (scope: { block?: Blockly.Block }) =>
+      canExtractToFunction(scope.block) ? "enabled" : "hidden",
+    callback: (scope: { block?: Blockly.Block }) => {
       if (scope.block) extractBlockToFunction(scope.block);
     },
   });
+}
+
+/**
+ * Ensure the canvas BlockSvg context menu shows Extract to function.
+ * The esbuild `import *` snapshot of Blockly can miss `ContextMenuRegistry`
+ * even though the live BlockSvg prototype uses the compressed singleton;
+ * patching `generateContextMenu` on a real workspace block covers that path.
+ */
+export function installExtractToFunctionOnWorkspace(workspace: Blockly.Workspace): void {
+  registerExtractToFunctionMenu();
+  const proto = blockSvgPrototypeOf(workspace) as
+    | (object & { generateContextMenu?: GenerateContextMenuFn; [EXTRACT_MENU_PATCHED]?: boolean })
+    | null;
+  if (!proto || typeof proto.generateContextMenu !== "function") return;
+  if (proto[EXTRACT_MENU_PATCHED]) return;
+  const original = proto.generateContextMenu;
+  proto.generateContextMenu = function (this: Blockly.Block) {
+    const menu = original.call(this) ?? [];
+    const label = msg(detectLocale()).EXTRACT_TO_FUNCTION;
+    if (canExtractToFunction(this) && !menu.some((item) => item.text === label)) {
+      menu.push({
+        text: label,
+        enabled: true,
+        callback: () => extractBlockToFunction(this),
+        weight: 6,
+      });
+    }
+    return menu;
+  };
+  proto[EXTRACT_MENU_PATCHED] = true;
+}
+
+function blockSvgPrototypeOf(workspace: Blockly.Workspace): object | null {
+  const BlockSvg = (Blockly as unknown as { BlockSvg?: { prototype: object } }).BlockSvg;
+  if (BlockSvg?.prototype) return BlockSvg.prototype;
+  const existing = workspace.getAllBlocks(false)[0];
+  if (existing) return Object.getPrototypeOf(existing) as object;
+  const disabled = typeof Blockly.Events.disable === "function";
+  if (disabled) Blockly.Events.disable();
+  try {
+    const probe = workspace.newBlock("text");
+    const proto = Object.getPrototypeOf(probe) as object;
+    probe.dispose(false);
+    return proto;
+  } catch {
+    return null;
+  } finally {
+    if (disabled) Blockly.Events.enable();
+  }
 }
 
 function createProcedureCall(

--- a/src/blockly/extract_function.ts
+++ b/src/blockly/extract_function.ts
@@ -1,0 +1,154 @@
+/**
+ * Blockly context-menu refactoring: extract a block subtree into a function
+ * (`procedures_defreturn` / `procedures_defnoreturn`) and leave a call in place.
+ *
+ * Blockly procedure *call* blocks run `renameProcedure` → tooltip `.replace`
+ * on stock `Msg.PROCEDURES_CALL*RETURN_TOOLTIP`. Headless tests (and any
+ * workspace created before `loadBlocklyLocale`) may lack those keys; fill
+ * them before creating a call so extract cannot crash on i18n.
+ */
+
+import { Blockly } from "./blockly_core.ts";
+import { withBlocklyUndoGroup } from "./blockly_events.ts";
+import { detectLocale, msg } from "./i18n/locale.ts";
+
+export const EXTRACT_TO_FUNCTION_MENU_ID = "intehrgrator_extract_to_function";
+
+const PROCEDURE_CALL_MSG: Record<string, string> = {
+  PROCEDURES_CALLRETURN_TOOLTIP:
+    "Run the user-defined function '%1' and use its output.",
+  PROCEDURES_CALLNORETURN_TOOLTIP: "Run the user-defined function '%1'.",
+  PROCEDURES_CALL_DISABLED_DEF_WARNING:
+    "Can't run the user-defined function '%1' because the definition block is disabled.",
+};
+
+function ensureProcedureCallMessages(): void {
+  const Msg = (Blockly as unknown as { Msg?: Record<string, string | undefined> }).Msg;
+  if (!Msg) return;
+  for (const [key, fallback] of Object.entries(PROCEDURE_CALL_MSG)) {
+    if (!Msg[key]) Msg[key] = fallback;
+  }
+}
+
+const PROCEDURE_TYPES = new Set([
+  "procedures_defnoreturn",
+  "procedures_defreturn",
+  "procedures_callnoreturn",
+  "procedures_callreturn",
+  "procedures_ifreturn",
+]);
+
+export function canExtractToFunction(block: Blockly.Block | null | undefined): boolean {
+  if (!block || block.isInFlyout || block.isShadow?.()) return false;
+  if (block.workspace?.options?.readOnly) return false;
+  if (typeof block.isMovable === "function" && !block.isMovable()) return false;
+  if (PROCEDURE_TYPES.has(block.type)) return false;
+  return Boolean(block.outputConnection || block.previousConnection);
+}
+
+/**
+ * Replace `block` with a procedure call and move the subtree onto a new
+ * function definition. Returns the call block.
+ */
+export function extractBlockToFunction(
+  block: Blockly.Block,
+  nameHint = "helper",
+): Blockly.Block {
+  if (!canExtractToFunction(block)) {
+    throw new Error("Block cannot be extracted to a function");
+  }
+  ensureProcedureCallMessages();
+  const workspace = block.workspace;
+  const hasOutput = Boolean(block.outputConnection);
+  const defType = hasOutput ? "procedures_defreturn" : "procedures_defnoreturn";
+  const callType = hasOutput ? "procedures_callreturn" : "procedures_callnoreturn";
+  const parentConnection = hasOutput
+    ? block.outputConnection?.targetConnection
+    : block.previousConnection?.targetConnection;
+
+  let call!: Blockly.Block;
+  withBlocklyUndoGroup(() => {
+    const def = workspace.newBlock(defType);
+    const name = Blockly.Procedures.findLegalName(nameHint, def);
+    def.setFieldValue(name, "NAME");
+    const xy = typeof block.getRelativeToSurfaceXY === "function"
+      ? block.getRelativeToSurfaceXY()
+      : { x: 0, y: 0 };
+    if (typeof def.moveBy === "function") {
+      def.moveBy((xy.x ?? 0) + 240, xy.y ?? 0);
+    }
+
+    block.unplug(true);
+
+    const bodyInput = hasOutput
+      ? (def.getInput("RETURN") ?? def.getInput("VALUE"))
+      : (def.getInput("STACK") ?? def.getInput("STATEMENT_INPUT"));
+    const bodyConn = bodyInput?.connection;
+    if (hasOutput && block.outputConnection && bodyConn) {
+      bodyConn.connect(block.outputConnection);
+    } else if (!hasOutput && block.previousConnection && bodyConn) {
+      bodyConn.connect(block.previousConnection);
+    }
+    initAndRender(def);
+
+    call = createProcedureCall(workspace, callType, name);
+    if (parentConnection) {
+      if (hasOutput && call.outputConnection) {
+        parentConnection.connect(call.outputConnection);
+      } else if (!hasOutput && call.previousConnection) {
+        parentConnection.connect(call.previousConnection);
+      }
+    }
+    initAndRender(call);
+  });
+  return call;
+}
+
+export function registerExtractToFunctionMenu(): void {
+  const registry = Blockly.ContextMenuRegistry?.registry;
+  if (!registry) return;
+  if (registry.getItem(EXTRACT_TO_FUNCTION_MENU_ID)) return;
+  registry.register({
+    id: EXTRACT_TO_FUNCTION_MENU_ID,
+    scopeType: Blockly.ContextMenuRegistry.ScopeType.BLOCK,
+    weight: 6,
+    displayText: () => msg(detectLocale()).EXTRACT_TO_FUNCTION,
+    preconditionFn: (scope) => canExtractToFunction(scope.block) ? "enabled" : "hidden",
+    callback: (scope) => {
+      if (scope.block) extractBlockToFunction(scope.block);
+    },
+  });
+}
+
+function createProcedureCall(
+  workspace: Blockly.Workspace,
+  callType: string,
+  name: string,
+): Blockly.Block {
+  const disabled = typeof Blockly.Events.disable === "function";
+  if (disabled) Blockly.Events.disable();
+  try {
+    const call = workspace.newBlock(callType);
+    // NAME is enough for a no-arg call. Avoid `domToMutation`/`loadExtraState`:
+    // those always hit `renameProcedure`, which `.replace`s stock Blockly
+    // tooltip messages that are missing until `loadBlocklyLocale`.
+    call.setFieldValue(name, "NAME");
+    const tooltipKey = call.outputConnection
+      ? "PROCEDURES_CALLRETURN_TOOLTIP"
+      : "PROCEDURES_CALLNORETURN_TOOLTIP";
+    const Msg = (Blockly as unknown as { Msg?: Record<string, string | undefined> }).Msg;
+    const template = Msg?.[tooltipKey];
+    if (template && typeof call.setTooltip === "function") {
+      call.setTooltip(template.replace("%1", name));
+    }
+    return call;
+  } finally {
+    if (disabled) Blockly.Events.enable();
+  }
+}
+
+function initAndRender(block: Blockly.Block): void {
+  const svg = block as Blockly.Block & { initSvg?: () => void; render?: () => void };
+  svg.initSvg?.();
+  svg.render?.();
+}

--- a/src/blockly/i18n/custom_msg.ts
+++ b/src/blockly/i18n/custom_msg.ts
@@ -34,6 +34,7 @@ export interface IntehrMessages {
   CAT_SHEETS: string;
   CAT_VARIABLES: string;
   CAT_PROCEDURES: string;
+  EXTRACT_TO_FUNCTION: string;
   SOURCE_QUERY: string;
   SOURCE_QUERY_TOOLTIP: string;
   SOURCE_NODE_TOOLTIP: string;
@@ -73,6 +74,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_SHEETS: "Sheets",
     CAT_VARIABLES: "Variables",
     CAT_PROCEDURES: "Functions",
+    EXTRACT_TO_FUNCTION: "Extract to function",
     SOURCE_QUERY: "source",
     SOURCE_QUERY_TOOLTIP: "XPath/XQuery against the loaded source (fontoxpath)",
     SOURCE_NODE_TOOLTIP:
@@ -114,6 +116,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_SHEETS: "Kalkylblad",
     CAT_VARIABLES: "Variabler",
     CAT_PROCEDURES: "Funktioner",
+    EXTRACT_TO_FUNCTION: "Bryt ut till funktion",
     SOURCE_QUERY: "källa",
     SOURCE_QUERY_TOOLTIP: "XPath/XQuery mot laddad källdata (fontoxpath)",
     SOURCE_NODE_TOOLTIP:
@@ -155,6 +158,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_SHEETS: "Tabellen",
     CAT_VARIABLES: "Variablen",
     CAT_PROCEDURES: "Funktionen",
+    EXTRACT_TO_FUNCTION: "In Funktion auslagern",
     SOURCE_QUERY: "Quelle",
     SOURCE_QUERY_TOOLTIP: "XPath/XQuery gegen die geladene Quelle (fontoxpath)",
     SOURCE_NODE_TOOLTIP:
@@ -196,6 +200,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_SHEETS: "Hojas",
     CAT_VARIABLES: "Variables",
     CAT_PROCEDURES: "Funciones",
+    EXTRACT_TO_FUNCTION: "Extraer a función",
     SOURCE_QUERY: "origen",
     SOURCE_QUERY_TOOLTIP: "XPath/XQuery sobre el origen cargado (fontoxpath)",
     SOURCE_NODE_TOOLTIP:
@@ -237,6 +242,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_SHEETS: "Fulls",
     CAT_VARIABLES: "Variables",
     CAT_PROCEDURES: "Funcions",
+    EXTRACT_TO_FUNCTION: "Extreure a funció",
     SOURCE_QUERY: "origen",
     SOURCE_QUERY_TOOLTIP: "XPath/XQuery sobre l'origen carregat (fontoxpath)",
     SOURCE_NODE_TOOLTIP:
@@ -278,6 +284,7 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     CAT_SHEETS: "Feuilles",
     CAT_VARIABLES: "Variables",
     CAT_PROCEDURES: "Fonctions",
+    EXTRACT_TO_FUNCTION: "Extraire vers une fonction",
     SOURCE_QUERY: "source",
     SOURCE_QUERY_TOOLTIP: "XPath/XQuery sur la source chargée (fontoxpath)",
     SOURCE_NODE_TOOLTIP:

--- a/src/blockly/mod.ts
+++ b/src/blockly/mod.ts
@@ -109,6 +109,7 @@ export { setSheetFocusHandler } from "./blocks/sheet_blocks.ts";
 export {
   canExtractToFunction,
   extractBlockToFunction,
+  installExtractToFunctionOnWorkspace,
   registerExtractToFunctionMenu,
   EXTRACT_TO_FUNCTION_MENU_ID,
 } from "./extract_function.ts";

--- a/src/blockly/mod.ts
+++ b/src/blockly/mod.ts
@@ -15,6 +15,7 @@ import { registerExpressionBlocks } from "./blocks/expression_blocks.ts";
 import { registerMapBlocks } from "./blocks/map_blocks.ts";
 import { registerSheetBlocks } from "./blocks/sheet_blocks.ts";
 import { registerTextBlocks } from "./blocks/text_blocks.ts";
+import { registerExtractToFunctionMenu } from "./extract_function.ts";
 import { registerTypeScriptExportAdapter } from "./typescript_codegen.ts";
 import { blockToExpression } from "./expression_serialize.ts";
 import { attributesFor, dataValueLeafTypes, blockTypeForRm, isPrimitiveRmType } from "../core/rm_meta.ts";
@@ -105,6 +106,12 @@ export {
 } from "./defaults_canvas.ts";
 export { setDefaultsMapPickHandler, setDefaultsMapInfoHandler } from "./blocks/map_blocks.ts";
 export { setSheetFocusHandler } from "./blocks/sheet_blocks.ts";
+export {
+  canExtractToFunction,
+  extractBlockToFunction,
+  registerExtractToFunctionMenu,
+  EXTRACT_TO_FUNCTION_MENU_ID,
+} from "./extract_function.ts";
 export { installBlocklyFloatingOverlays } from "./floating_overlays.ts";
 export {
   generateTypeScriptFromBlocklyState,
@@ -119,6 +126,7 @@ export function initBlocklyGenerators(): void {
   registerMapBlocks();
   registerSheetBlocks();
   registerTextBlocks();
+  registerExtractToFunctionMenu();
   registerGenerators();
   registerTypeScriptExportAdapter();
 }

--- a/test/extract_function_test.ts
+++ b/test/extract_function_test.ts
@@ -1,0 +1,102 @@
+import { assert, assertEquals } from "@std/assert";
+import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
+import { initBlocklyGenerators } from "@intehrgrator/blockly/mod.ts";
+import {
+  canExtractToFunction,
+  extractBlockToFunction,
+  EXTRACT_TO_FUNCTION_MENU_ID,
+  registerExtractToFunctionMenu,
+} from "@intehrgrator/blockly/extract_function.ts";
+
+let ready = false;
+function ensure(): void {
+  if (ready) return;
+  initBlocklyGenerators();
+  registerExtractToFunctionMenu();
+  ready = true;
+}
+
+Deno.test("stock procedure blocks are registered", () => {
+  ensure();
+  for (const type of [
+    "procedures_defreturn",
+    "procedures_defnoreturn",
+    "procedures_callreturn",
+    "procedures_callnoreturn",
+  ]) {
+    assert(Blockly.Blocks[type], `missing ${type}`);
+  }
+});
+
+Deno.test("extract to function replaces a value block with a call and keeps the subtree on the definition", () => {
+  ensure();
+  const workspace = new Blockly.Workspace();
+  const cmp = workspace.newBlock("logic_compare");
+  const left = workspace.newBlock("text");
+  left.setFieldValue("hello", "TEXT");
+  cmp.getInput("A")!.connection!.connect(left.outputConnection!);
+
+  const call = extractBlockToFunction(left, "greet");
+  assertEquals(call.type, "procedures_callreturn");
+  assertEquals(call.getFieldValue("NAME"), "greet");
+  assertEquals(cmp.getInput("A")!.connection!.targetBlock()?.type, "procedures_callreturn");
+  const defs = workspace.getTopBlocks(false).filter((b) => b.type === "procedures_defreturn");
+  assertEquals(defs.length, 1);
+  const body = defs[0]!.getInput("RETURN")?.connection?.targetBlock()
+    ?? defs[0]!.getInput("VALUE")?.connection?.targetBlock();
+  assertEquals(body?.id, left.id);
+  assertEquals(left.getFieldValue("TEXT"), "hello");
+  workspace.dispose();
+});
+
+Deno.test("extract to function replaces a statement block with a no-return call", () => {
+  ensure();
+  const workspace = new Blockly.Workspace();
+  const loop = workspace.newBlock("for_each_source");
+  const inner = workspace.newBlock("controls_if");
+  loop.getInput("DO")!.connection!.connect(inner.previousConnection!);
+
+  const call = extractBlockToFunction(inner, "maybe");
+  assertEquals(call.type, "procedures_callnoreturn");
+  assertEquals(call.getFieldValue("NAME"), "maybe");
+  assertEquals(loop.getInput("DO")!.connection!.targetBlock()?.type, "procedures_callnoreturn");
+  const defs = workspace.getTopBlocks(false).filter((b) => b.type === "procedures_defnoreturn");
+  assertEquals(defs.length, 1);
+  const body = defs[0]!.getInput("STACK")?.connection?.targetBlock()
+    ?? defs[0]!.getInput("STATEMENT_INPUT")?.connection?.targetBlock();
+  assertEquals(body?.id, inner.id);
+  workspace.dispose();
+});
+
+Deno.test("extract to function disambiguates colliding names", () => {
+  ensure();
+  const workspace = new Blockly.Workspace();
+  const cmp = workspace.newBlock("logic_compare");
+  const left = workspace.newBlock("text");
+  const right = workspace.newBlock("text");
+  left.setFieldValue("a", "TEXT");
+  right.setFieldValue("b", "TEXT");
+  cmp.getInput("A")!.connection!.connect(left.outputConnection!);
+  cmp.getInput("B")!.connection!.connect(right.outputConnection!);
+
+  const first = extractBlockToFunction(left, "piece");
+  const second = extractBlockToFunction(right, "piece");
+  assertEquals(first.getFieldValue("NAME"), "piece");
+  assertEquals(second.getFieldValue("NAME"), "piece2");
+  workspace.dispose();
+});
+
+Deno.test("procedure definitions cannot be extracted", () => {
+  ensure();
+  const workspace = new Blockly.Workspace();
+  const def = workspace.newBlock("procedures_defreturn");
+  assertEquals(canExtractToFunction(def), false);
+  workspace.dispose();
+});
+
+Deno.test("extract to function is on the Blockly block context menu", () => {
+  ensure();
+  const item = Blockly.ContextMenuRegistry.registry.getItem(EXTRACT_TO_FUNCTION_MENU_ID);
+  assert(item, "context menu item registered");
+  assertEquals(item?.scopeType, Blockly.ContextMenuRegistry.ScopeType.BLOCK);
+});

--- a/web/main.ts
+++ b/web/main.ts
@@ -68,6 +68,7 @@ import {
   setDefaultsMapPickHandler,
   setDefaultsMapInfoHandler,
   setSheetFocusHandler,
+  installExtractToFunctionOnWorkspace,
 } from "../src/blockly/mod.ts";
 import { attachWorkspaceMinimap } from "../src/blockly/minimap.ts";
 import { installBlocklyFloatingOverlays } from "../src/blockly/floating_overlays.ts";
@@ -364,6 +365,7 @@ async function bootBlockly(): Promise<void> {
     trashcan: false,
     renderer: registerCompactThrasosRenderer(),
   });
+  installExtractToFunctionOnWorkspace(workspace);
   installBlocklyFloatingOverlays();
 
   const loadOnce = takeLoadOnceBlocks();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds **Extract to function** on the Blockly block context menu so a value or statement subtree becomes a stock Blockly procedure (Functions drawer), with a call left at the original site.

## Why
Informaticians reuse mapping fragments (especially source queries and text-generation) without duplicating subtrees. This is a Blockly-native refactor: the Mapping Specification stays Blockly JSON (ADR 0001). A **Blockly Function** is not a Conversion script function.

## Behavior
- Right-click a movable value or statement block → **Extract to function**
- Hidden for procedure defs/calls, shadows, flyout, read-only, and immovable blocks
- Value blocks become `procedures_defreturn` + `procedures_callreturn`
- Statement blocks become `procedures_defnoreturn` + `procedures_callnoreturn`
- Names are uniqued via Blockly `findLegalName` (`helper`, `helper2`, …)
- One undo group

Procedure-call creation sets the `NAME` field and does not use `domToMutation`/`loadExtraState`, because those paths call `renameProcedure` and crash when stock Blockly tooltip messages are not loaded yet (headless tests and pre-locale UI).

The Web Shell also patches `generateContextMenu` on the live BlockSvg prototype after inject. esbuild’s `import *` snapshot of Blockly can omit `ContextMenuRegistry`, so registry-only registration never appeared in the browser menu.

## Tests
- `test/extract_function_test.ts` — value extract, statement extract, name collision, menu registration
- `deno task test` — 422 passed
- Browser: Dummy vitals example, drag a text block, right-click → Extract to function → `to helper` definition with the text as return, plus a leftover call

[Blockly context menu with Extract to function](https://cursor.com/agents/bc-6c2928d7-7a35-4883-aa10-9c07ea90cd0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextract_to_function_menu.png)
[Helper function definition after extract](https://cursor.com/agents/bc-6c2928d7-7a35-4883-aa10-9c07ea90cd0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextract_to_function_helper.png)
[extract_to_function_context_menu.mp4](https://cursor.com/agents/bc-6c2928d7-7a35-4883-aa10-9c07ea90cd0d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextract_to_function_context_menu.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c2928d7-7a35-4883-aa10-9c07ea90cd0d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c2928d7-7a35-4883-aa10-9c07ea90cd0d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

