### PR TITLE
Versioned GitHub Pages releases alongside desktop tags

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,9 +31,11 @@ jobs:
       - run: deno task vendor
       - run: deno task test
       - run: deno task build
+      - name: Preserve frozen release versions on GitHub Pages
+        run: deno run -A scripts/assemble-pages.ts main dist dist-pages
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:
-          path: dist
+          path: dist-pages
       - id: deployment
         uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,12 +76,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ steps.rel.outputs.tag }}"
+          PAGES_URL="https://regionstockholm.github.io/intehrgrator/${TAG}/"
+          {
+            echo "## intEHRgrator desktop ${TAG#v}"
+            echo
+            echo "Local Integration Workbench as a Deno desktop app (OS webview). Same Mapping Editor as the [Web Shell for this release](${PAGES_URL}), packaged for offline use on \`127.0.0.1\`."
+            echo
+            echo "### Web Shell (frozen for this release)"
+            echo
+            echo "- **This version:** [${PAGES_URL}](${PAGES_URL})"
+            echo "- **Bleeding edge (main):** https://regionstockholm.github.io/intehrgrator/"
+          } > /tmp/release-notes.md
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists — uploading assets only"
           else
             gh release create "$TAG" \
               --title "intEHRgrator desktop ${TAG#v}" \
-              --notes "Desktop binaries and frozen Web Shell at https://regionstockholm.github.io/intehrgrator/${TAG}/"
+              --notes-file /tmp/release-notes.md
           fi
           gh release upload "$TAG" dist/release/intEHRgrator-linux-x64.AppImage --clobber
           gh release upload "$TAG" dist/release/intEHRgrator-windows-x64.zip --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+# Publish desktop binaries and a frozen GitHub Pages subdirectory for each release tag.
+# Triggered by `deno task release` (push annotated tag) or manual tag push.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing release tag (e.g. v0.6)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Resolve release tag
+        id: rel
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Vendor ehrtslib
+        run: deno task vendor
+
+      - name: Test
+        run: deno task test
+
+      - name: Build Web Shell
+        run: deno task build
+
+      - name: Compile desktop binaries
+        run: deno task compile:desktop
+
+      - name: Assemble versioned GitHub Pages tree
+        run: deno run -A scripts/assemble-pages.ts release "${{ steps.rel.outputs.tag }}" dist dist-pages
+
+      - uses: actions/configure-pages@v6
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: dist-pages
+
+      - id: deployment
+        uses: actions/deploy-pages@v5
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.rel.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — uploading assets only"
+          else
+            gh release create "$TAG" \
+              --title "intEHRgrator desktop ${TAG#v}" \
+              --notes "Desktop binaries and frozen Web Shell at https://regionstockholm.github.io/intehrgrator/${TAG}/"
+          fi
+          gh release upload "$TAG" dist/release/intEHRgrator-linux-x64.AppImage --clobber
+          gh release upload "$TAG" dist/release/intEHRgrator-windows-x64.zip --clobber
+          gh release upload "$TAG" dist/release/intEHRgrator-macos-x64.zip --clobber
+          gh release upload "$TAG" dist/release/intEHRgrator-macos-arm64.zip --clobber

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ deno task dev      # serve dist/ on http://localhost:5173
 
 The Web Shell is published on every push to `main` via the **Deploy GitHub Pages** workflow (also runnable manually from Actions). Ensure **Settings → Pages → Build and deployment → Source** is **GitHub Actions**.
 
+Bleeding-edge builds stay at the site root. Each desktop release from `deno task release` also publishes an immutable copy under a version subdirectory (for example `https://regionstockholm.github.io/intehrgrator/v0.5/`). Available frozen versions are listed in [`versions.json`](https://regionstockholm.github.io/intehrgrator/versions.json) on the live site.
+
+```bash
+deno task release -- --version 0.6.0   # bump, tag, push; Actions publishes desktop + Pages /v0.6/
+deno task release -- --current         # tag the version already in deno.json
+```
+
 CI (`vendor` → test → build) always checks out **ehrtslib `origin/main`**, so upstream module moves fail tests instead of shipping against a stale pin.
 
 Open `dist/index.html` (or use `deno task dev`) to use the Web Shell locally.

--- a/deno.json
+++ b/deno.json
@@ -60,6 +60,7 @@
     "desktop": "deno task build && deno desktop -A --no-check --config deno.json --backend webview --hmr src/desktop/main.ts",
     "compile:desktop": "deno run -A scripts/compile-desktop.ts",
     "compile:ehrtslib": "deno run -A scripts/compile-ehrtslib.ts",
+    "release": "deno run -A scripts/release.ts",
     "mcp": "deno run -A src/agent/mcp_stdio.ts"
   },
   "lint": {

--- a/scripts/assemble-pages.ts
+++ b/scripts/assemble-pages.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env -S deno run -A
+/**
+ * CLI for GitHub Actions Pages deploy assembly.
+ *
+ *   deno run -A scripts/assemble-pages.ts main <root-dist> <out-dir>
+ *   deno run -A scripts/assemble-pages.ts release <version-tag> <version-dist> <out-dir>
+ */
+import { dirname, fromFileUrl, join } from "@std/path";
+import {
+  assembleMainPagesSite,
+  assembleReleasePagesSite,
+  PAGES_SITE_URL,
+} from "./pages_site.ts";
+
+const root = join(dirname(fromFileUrl(import.meta.url)), "..");
+const baseUrl = Deno.env.get("PAGES_SITE_URL") ?? PAGES_SITE_URL;
+
+const [mode, ...rest] = Deno.args;
+if (!mode || (mode !== "main" && mode !== "release")) {
+  console.error("Usage: assemble-pages.ts main <root-dist> <out-dir>");
+  console.error("       assemble-pages.ts release <version-tag> <version-dist> <out-dir>");
+  Deno.exit(1);
+}
+
+if (mode === "main") {
+  const [rootDist, outDir] = rest;
+  if (!rootDist || !outDir) {
+    console.error("Usage: assemble-pages.ts main <root-dist> <out-dir>");
+    Deno.exit(1);
+  }
+  const manifest = await assembleMainPagesSite({
+    baseUrl,
+    rootDist: join(root, rootDist),
+    outDir: join(root, outDir),
+  });
+  console.log(`Assembled main Pages site at ${outDir} (${manifest.versions.length} frozen versions)`);
+} else {
+  const [versionTag, versionDist, outDir] = rest;
+  if (!versionTag || !versionDist || !outDir) {
+    console.error("Usage: assemble-pages.ts release <version-tag> <version-dist> <out-dir>");
+    Deno.exit(1);
+  }
+  const manifest = await assembleReleasePagesSite({
+    baseUrl,
+    versionTag,
+    versionDist: join(root, versionDist),
+    outDir: join(root, outDir),
+  });
+  console.log(
+    `Assembled release Pages site at ${outDir} (added ${versionTag}; ${manifest.versions.length} total versions)`,
+  );
+}

--- a/scripts/pages_site.ts
+++ b/scripts/pages_site.ts
@@ -1,0 +1,165 @@
+/**
+ * Assemble GitHub Pages deploy trees with immutable version subdirectories.
+ */
+import { copy, ensureDir, emptyDir, walk } from "@std/fs";
+import { dirname, join } from "@std/path";
+
+export const PAGES_SITE_URL = "https://regionstockholm.github.io/intehrgrator";
+export const VERSIONS_MANIFEST = "versions.json";
+
+export interface VersionsManifest {
+  versions: string[];
+}
+
+export function emptyManifest(): VersionsManifest {
+  return { versions: [] };
+}
+
+export function normalizeManifest(raw: unknown): VersionsManifest {
+  if (!raw || typeof raw !== "object") return emptyManifest();
+  const versions = (raw as VersionsManifest).versions;
+  if (!Array.isArray(versions)) return emptyManifest();
+  return {
+    versions: [...new Set(versions.filter((v) => typeof v === "string" && v.startsWith("v")))]
+      .sort()
+      .reverse(),
+  };
+}
+
+export async function readVersionsManifest(path: string): Promise<VersionsManifest> {
+  try {
+    const text = await Deno.readTextFile(path);
+    return normalizeManifest(JSON.parse(text));
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return emptyManifest();
+    throw error;
+  }
+}
+
+export async function writeVersionsManifest(path: string, manifest: VersionsManifest): Promise<void> {
+  const normalized = normalizeManifest(manifest);
+  await ensureDir(dirname(path));
+  await Deno.writeTextFile(path, `${JSON.stringify(normalized, null, 2)}\n`);
+}
+
+export async function fetchVersionsManifest(baseUrl: string): Promise<VersionsManifest> {
+  try {
+    const res = await fetch(`${baseUrl}/${VERSIONS_MANIFEST}`);
+    if (!res.ok) return emptyManifest();
+    return normalizeManifest(await res.json());
+  } catch {
+    return emptyManifest();
+  }
+}
+
+async function runWget(args: string[]): Promise<void> {
+  const status = await new Deno.Command("wget", {
+    args,
+    stdout: "inherit",
+    stderr: "inherit",
+  }).output();
+  // 8 = some files missing on partial mirrors; acceptable for Pages trees.
+  if (!status.success && status.code !== 8) {
+    throw new Error(`wget failed (exit ${status.code})`);
+  }
+}
+
+/** Flatten wget output when it nests under the final URL path segment. */
+async function flattenWgetNest(dest: string, nestedName: string): Promise<void> {
+  const nested = join(dest, nestedName);
+  try {
+    await Deno.stat(nested);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    throw error;
+  }
+  for await (const entry of walk(nested, { includeDirs: false })) {
+    const rel = entry.path.slice(nested.length + 1);
+    const target = join(dest, rel);
+    await ensureDir(dirname(target));
+    await Deno.rename(entry.path, target);
+  }
+  await Deno.remove(nested, { recursive: true });
+}
+
+/** Mirror the live Pages site (root + frozen versions) into dest. */
+export async function mirrorLiveSite(baseUrl: string, dest: string): Promise<void> {
+  await emptyDir(dest);
+  await ensureDir(dest);
+  await runWget(["-q", "-r", "-np", "-nH", "-P", dest, `${baseUrl}/`]);
+  await flattenWgetNest(dest, "intehrgrator");
+}
+
+/** Mirror a single frozen version subdirectory from the live Pages site. */
+export async function mirrorVersionSubdir(
+  baseUrl: string,
+  tag: string,
+  destRoot: string,
+): Promise<void> {
+  const dest = join(destRoot, tag);
+  await emptyDir(dest);
+  await ensureDir(dest);
+  await runWget(["-q", "-r", "-np", "-nH", "-P", dest, `${baseUrl}/${tag}/`]);
+  await flattenWgetNest(dest, tag);
+}
+
+async function copyDistContents(src: string, dest: string): Promise<void> {
+  await ensureDir(dest);
+  await copy(src, dest, { overwrite: true, recursive: true });
+}
+
+/**
+ * Main-branch deploy: publish bleeding-edge root and keep frozen version subdirs.
+ */
+export async function assembleMainPagesSite(opts: {
+  baseUrl: string;
+  rootDist: string;
+  outDir: string;
+}): Promise<VersionsManifest> {
+  await emptyDir(opts.outDir);
+  await copyDistContents(opts.rootDist, opts.outDir);
+
+  const manifest = await fetchVersionsManifest(opts.baseUrl);
+  for (const tag of manifest.versions) {
+    await mirrorVersionSubdir(opts.baseUrl, tag, opts.outDir);
+  }
+
+  await writeVersionsManifest(join(opts.outDir, VERSIONS_MANIFEST), manifest);
+  return manifest;
+}
+
+/**
+ * Release deploy: add an immutable version subdirectory without changing site root.
+ */
+export async function assembleReleasePagesSite(opts: {
+  baseUrl: string;
+  versionTag: string;
+  versionDist: string;
+  outDir: string;
+}): Promise<VersionsManifest> {
+  const manifest = await fetchVersionsManifest(opts.baseUrl);
+  if (manifest.versions.includes(opts.versionTag)) {
+    throw new Error(
+      `GitHub Pages version ${opts.versionTag} already exists — release web builds are immutable`,
+    );
+  }
+
+  await mirrorLiveSite(opts.baseUrl, opts.outDir);
+
+  try {
+    await Deno.stat(join(opts.outDir, opts.versionTag));
+    throw new Error(
+      `GitHub Pages path /${opts.versionTag}/ already exists — release web builds are immutable`,
+    );
+  } catch (error) {
+    if (!(error instanceof Deno.errors.NotFound)) throw error;
+  }
+
+  await copyDistContents(opts.versionDist, join(opts.outDir, opts.versionTag));
+
+  const next: VersionsManifest = {
+    versions: normalizeManifest({ versions: [...manifest.versions, opts.versionTag] }).versions,
+  };
+  await writeVersionsManifest(join(opts.outDir, VERSIONS_MANIFEST), next);
+  return next;
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env -S deno run -A
+/**
+ * Cut a desktop + GitHub Pages release.
+ *
+ * Bumps version files (unless --current), runs tests/build, commits, tags, and pushes.
+ * GitHub Actions (release.yml) publishes desktop binaries and a frozen Pages subdirectory.
+ *
+ * Usage:
+ *   deno task release -- --version 0.6.0
+ *   deno task release -- --current          # tag current deno.json version
+ *   deno task release -- --version 0.6.0 --dry-run
+ */
+import {
+  assertCleanGitTree,
+  assertGhAuth,
+  assertReleasePrerequisites,
+  bumpVersionFiles,
+  readCurrentVersion,
+  releaseTagForVersion,
+  run,
+} from "./release_version.ts";
+
+function usage(): void {
+  console.log(`Usage:
+  deno task release -- --version <semver> [--message <tag message>] [--dry-run]
+  deno task release -- --current [--message <tag message>] [--dry-run]
+
+Options:
+  --version   New package version to write before releasing
+  --current   Release the version already in deno.json (no bump)
+  --message   Annotated tag message (default: intEHRgrator desktop <version>)
+  --dry-run   Validate and build, but do not commit, tag, or push
+`);
+}
+
+function parseArgs(argv: string[]) {
+  let version: string | undefined;
+  let useCurrent = false;
+  let dryRun = false;
+  let message: string | undefined;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--version") {
+      version = argv[++i];
+      continue;
+    }
+    if (arg === "--current") {
+      useCurrent = true;
+      continue;
+    }
+    if (arg === "--message") {
+      message = argv[++i];
+      continue;
+    }
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      usage();
+      Deno.exit(0);
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (version && useCurrent) throw new Error("Use either --version or --current, not both");
+  if (!version && !useCurrent) throw new Error("Pass --version <semver> or --current");
+
+  return { version, useCurrent, dryRun, message };
+}
+
+const args = parseArgs(Deno.args);
+
+await assertReleasePrerequisites();
+if (!args.dryRun) {
+  await assertGhAuth();
+  await assertCleanGitTree();
+}
+
+let releaseVersion = args.version;
+if (args.useCurrent) {
+  releaseVersion = await readCurrentVersion();
+}
+if (!releaseVersion) throw new Error("Release version is required");
+
+const releaseTag = releaseTagForVersion(releaseVersion);
+const tagMessage = args.message ?? `intEHRgrator desktop ${releaseVersion}`;
+
+console.log(`Preparing release ${releaseVersion} (${releaseTag})`);
+
+if (args.version) {
+  console.log(`Bumping version files to ${args.version}`);
+  await bumpVersionFiles(args.version);
+  releaseVersion = args.version;
+}
+
+await run("deno", ["task", "vendor"]);
+await run("deno", ["task", "test"]);
+await run("deno", ["task", "build"]);
+
+if (args.dryRun) {
+  console.log("Dry run complete — no commit, tag, or push performed.");
+  console.log(`Would tag ${releaseTag} and push to origin; Actions publishes desktop + Pages /${releaseTag}/`);
+  Deno.exit(0);
+}
+
+if (args.version) {
+  await run("git", ["add", ...[
+    "deno.json",
+    "package.json",
+    "scripts/desktop.compile.json",
+    "src/core/persistence/mod.ts",
+  ]]);
+  await run("git", ["commit", "-m", `chore: release ${releaseVersion}`]);
+}
+
+await run("git", ["tag", "-a", releaseTag, "-m", tagMessage]);
+await run("git", ["push", "origin", "HEAD"]);
+await run("git", ["push", "origin", releaseTag]);
+
+console.log(`Pushed ${releaseTag}.`);
+console.log(`GitHub Actions will publish desktop binaries and https://regionstockholm.github.io/intehrgrator/${releaseTag}/`);

--- a/scripts/release_version.ts
+++ b/scripts/release_version.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared release version helpers for desktop tags and GitHub Pages paths.
+ */
+import { dirname, fromFileUrl, join } from "@std/path";
+
+const root = join(dirname(fromFileUrl(import.meta.url)), "..");
+
+export const VERSION_FILES = [
+  join(root, "deno.json"),
+  join(root, "package.json"),
+  join(root, "scripts/desktop.compile.json"),
+  join(root, "src/core/persistence/mod.ts"),
+] as const;
+
+/** Map package version to release tag (matches existing tags v0.5, v0.2.1). */
+export function releaseTagForVersion(version: string): string {
+  const parts = version.split(".");
+  if (parts.length < 2 || parts.length > 3 || parts.some((p) => p === "" || !/^\d+$/.test(p))) {
+    throw new Error(`Invalid semver version: ${version}`);
+  }
+  const [major, minor, patch = "0"] = parts;
+  if (patch === "0") return `v${major}.${minor}`;
+  return `v${major}.${minor}.${patch}`;
+}
+
+export function readVersionFromDenoJson(text: string): string {
+  const parsed = JSON.parse(text) as { version?: string };
+  if (!parsed.version) throw new Error("deno.json is missing version");
+  return parsed.version;
+}
+
+export async function readCurrentVersion(): Promise<string> {
+  const denoJson = await Deno.readTextFile(join(root, "deno.json"));
+  return readVersionFromDenoJson(denoJson);
+}
+
+export async function bumpVersionFiles(version: string): Promise<void> {
+  for (const path of VERSION_FILES) {
+    let text = await Deno.readTextFile(path);
+    if (path.endsWith("mod.ts")) {
+      text = text.replace(/export const APP_VERSION = "[^"]+";/, `export const APP_VERSION = "${version}";`);
+    } else {
+      text = text.replace(/"version": "[^"]+"/, `"version": "${version}"`);
+    }
+    await Deno.writeTextFile(path, text);
+  }
+}
+
+async function run(cmd: string, args: string[]): Promise<void> {
+  const status = await new Deno.Command(cmd, {
+    args,
+    cwd: root,
+    stdout: "inherit",
+    stderr: "inherit",
+  }).output();
+  if (!status.success) {
+    throw new Error(`${cmd} ${args.join(" ")} failed (exit ${status.code})`);
+  }
+}
+
+export async function assertReleasePrerequisites(): Promise<void> {
+  for (const cmd of ["git", "gh"]) {
+    const status = await new Deno.Command(cmd, { args: ["--version"], stdout: "null", stderr: "null" }).output();
+    if (!status.success) throw new Error(`${cmd} is required for deno task release`);
+  }
+}
+
+export async function assertCleanGitTree(): Promise<void> {
+  const status = await new Deno.Command("git", {
+    args: ["status", "--porcelain"],
+    cwd: root,
+    stdout: "piped",
+  }).output();
+  const dirty = new TextDecoder().decode(status.stdout).trim();
+  if (dirty) {
+    throw new Error("Working tree is not clean — commit or stash changes before releasing");
+  }
+}
+
+export async function assertGhAuth(): Promise<void> {
+  const status = await new Deno.Command("gh", {
+    args: ["auth", "status"],
+    cwd: root,
+    stdout: "inherit",
+    stderr: "inherit",
+  }).output();
+  if (!status.success) throw new Error("gh is not authenticated");
+}
+
+export { run };

--- a/test/release_pages_test.ts
+++ b/test/release_pages_test.ts
@@ -1,0 +1,85 @@
+import { assertEquals, assertRejects } from "@std/assert";
+import { join } from "@std/path";
+import {
+  assembleMainPagesSite,
+  assembleReleasePagesSite,
+  normalizeManifest,
+  VERSIONS_MANIFEST,
+} from "../scripts/pages_site.ts";
+import {
+  readVersionFromDenoJson,
+  releaseTagForVersion,
+} from "../scripts/release_version.ts";
+
+Deno.test("releaseTagForVersion matches existing tag scheme", () => {
+  assertEquals(releaseTagForVersion("0.5.0"), "v0.5");
+  assertEquals(releaseTagForVersion("0.2.1"), "v0.2.1");
+  assertEquals(releaseTagForVersion("1.0.0"), "v1.0");
+});
+
+Deno.test("readVersionFromDenoJson", () => {
+  assertEquals(readVersionFromDenoJson(`{"version":"0.6.0"}`), "0.6.0");
+});
+
+Deno.test("normalizeManifest deduplicates and sorts versions", () => {
+  assertEquals(
+    normalizeManifest({ versions: ["v0.4", "v0.5", "v0.5", "bad", 3] }),
+    { versions: ["v0.5", "v0.4"] },
+  );
+});
+
+Deno.test("assembleMainPagesSite copies root dist and writes manifest", async () => {
+  const dir = await Deno.makeTempDir();
+  const rootDist = join(dir, "root-dist");
+  const outDir = join(dir, "out");
+  await Deno.mkdir(rootDist, { recursive: true });
+  await Deno.writeTextFile(join(rootDist, "index.html"), "<html>main</html>");
+
+  const manifest = await assembleMainPagesSite({
+    baseUrl: "https://example.invalid/intehrgrator",
+    rootDist,
+    outDir,
+  });
+
+  assertEquals(manifest.versions, []);
+  assertEquals(await Deno.readTextFile(join(outDir, "index.html")), "<html>main</html>");
+  assertEquals(
+    JSON.parse(await Deno.readTextFile(join(outDir, VERSIONS_MANIFEST))).versions,
+    [],
+  );
+});
+
+Deno.test("assembleReleasePagesSite rejects duplicate version tags", async () => {
+  const dir = await Deno.makeTempDir();
+  const versionDist = join(dir, "version-dist");
+  const outDir = join(dir, "out");
+  await Deno.mkdir(versionDist, { recursive: true });
+  await Deno.writeTextFile(join(versionDist, "index.html"), "<html>v0.6</html>");
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = ((input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    if (url.endsWith("/versions.json")) {
+      return Promise.resolve(
+        new Response(JSON.stringify({ versions: ["v0.6"] }), { status: 200 }),
+      );
+    }
+    return originalFetch(input);
+  }) as typeof fetch;
+
+  try {
+    await assertRejects(
+      () =>
+        assembleReleasePagesSite({
+          baseUrl: "https://example.invalid/intehrgrator",
+          versionTag: "v0.6",
+          versionDist,
+          outDir,
+        }),
+      Error,
+      "already exists",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Formalizes the desktop release flow as `deno task release` and extends it so each release also publishes an **immutable** Web Shell copy on GitHub Pages under the same tag path (for example `/v0.6/`), while `main` continues to deploy bleeding-edge builds at the site root.

## Changes

- **`deno task release`** — bump version files (optional), run vendor/test/build, commit, annotated tag (`v0.6` for `0.6.0`), push; Actions handles publishing
- **`scripts/pages_site.ts`** — assemble Pages trees, track frozen versions in `versions.json`, refuse to overwrite an existing version subdirectory
- **`.github/workflows/release.yml`** — on tag push: compile desktop binaries, upload GitHub Release assets, deploy frozen Pages subdirectory
- **`.github/workflows/pages.yml`** — main deploy now preserves existing frozen `/v*/` trees when updating the root site
- **Tests** — version tag mapping, manifest normalization, pages assembly helpers

## Usage

```bash
deno task release -- --version 0.6.0   # bump, tag, push
deno task release -- --current         # tag current deno.json version
deno task release -- --version 0.6.0 --dry-run
```

After release:
- Bleeding edge: `https://regionstockholm.github.io/intehrgrator/`
- Frozen web build: `https://regionstockholm.github.io/intehrgrator/v0.6/`
- Version index: `https://regionstockholm.github.io/intehrgrator/versions.json`

## Testing

- `deno test -A --no-check test/release_pages_test.ts` (5 tests)
- Full suite: `deno task test` (427 passed)
- Local Pages assembly smoke test: `deno run -A scripts/assemble-pages.ts main dist dist-pages`

## Notes

- Prior releases (for example `v0.5`) are **not** backfilled automatically; only releases cut after this lands get frozen web copies.
- Release web builds are immutable: re-publishing the same tag path fails by design.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39943ea0-dd4c-42e5-89bd-d9de88a45b52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39943ea0-dd4c-42e5-89bd-d9de88a45b52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

