### PR TITLE
Fix Blockly block layout: remove hidden dummy rows and left icon gap

### DIFF
--- a/src/blockly/blocks/expression_blocks.ts
+++ b/src/blockly/blocks/expression_blocks.ts
@@ -1,5 +1,6 @@
 import { Blockly } from "../blockly_core.ts";
 import { blocklyCheckForReturnType } from "../block_checks.ts";
+import { createHiddenSerializableField } from "../hidden_serializable_field.ts";
 import { msg, detectLocale } from "../i18n/locale.ts";
 import {
   type SourceReturnType,
@@ -61,7 +62,7 @@ function defineSourceQueryBlock(
       if (type === "source_query") {
         // Serializable zero-size label: older workspaces stored RETURN_TYPE here.
         // A FieldTextInput would draw a second "string" box beside the path.
-        row.appendField(hiddenSerializableField(returnType), "RETURN_TYPE");
+        row.appendField(createHiddenSerializableField(returnType), "RETURN_TYPE");
       }
       this.setOutput(true, blocklyCheckForReturnType(returnType));
       this.setColour(SOURCE_COLOUR);
@@ -70,18 +71,4 @@ function defineSourceQueryBlock(
       this.setInputsInline(true);
     },
   };
-}
-
-/** Label that serializes but never occupies Blockly layout or draws a field rect. */
-function hiddenSerializableField(value: string) {
-  const field = new Blockly.FieldLabelSerializable(value);
-  field.EDITABLE = false;
-  field.SERIALIZABLE = true;
-  field.initView = () => {};
-  const sized = field as unknown as { size_?: { width: number; height: number } };
-  if (sized.size_) {
-    sized.size_.width = 0;
-    sized.size_.height = 0;
-  }
-  return field;
 }

--- a/src/blockly/blocks/rm_blocks.ts
+++ b/src/blockly/blocks/rm_blocks.ts
@@ -34,6 +34,10 @@ import {
   type SlotCardinality,
 } from "../slot_cardinality.ts";
 import { appendSlotLabel, isSlotLabelField } from "../slot_label.ts";
+import {
+  appendHiddenSerializable,
+  createHiddenSerializableField,
+} from "../hidden_serializable_field.ts";
 import { registerTermPickBlock } from "./term_pick.ts";
 import {
   appendMutatorCogwheel,
@@ -354,9 +358,7 @@ function definePartyRefBlock(): void {
           rmType: "String",
         });
       }
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldLabelSerializable("PARTY_REF"), "RM_TYPE");
-      this.getField("RM_TYPE")!.setVisible(false);
+      appendHiddenSerializable(this, "RM_TYPE", "PARTY_REF");
       this.setOutput(true, "PARTY_REF");
       this.setColour(STRUCTURE_COLOUR);
       this.setTooltip("openEHR RM PARTY_REF — external party reference");
@@ -995,21 +997,13 @@ function defineContainerBlock(
           }
         }
       }
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldLabelSerializable(""), "SLOT_ID");
-      this.getField("SLOT_ID")!.setVisible(false);
+      appendHiddenSerializable(this, "SLOT_ID", "");
       if (!isEventFamilyType(options.rmType) && !isItemStructureFamilyType(options.rmType)) {
-        this.appendDummyInput()
-          .appendField(new Blockly.FieldLabelSerializable(options.rmType), "RM_TYPE");
-        this.getField("RM_TYPE")!.setVisible(false);
+        appendHiddenSerializable(this, "RM_TYPE", options.rmType);
       }
-      appendHiddenLabel(this, "MANDATORY", "");
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldTextInput(""), "ARCHETYPE_NODE_ID");
-      this.getField("ARCHETYPE_NODE_ID")!.setVisible(false);
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldTextInput(""), "ARCHETYPE_CTX");
-      this.getField("ARCHETYPE_CTX")!.setVisible(false);
+      appendHiddenSerializable(this, "MANDATORY", "");
+      appendHiddenSerializable(this, "ARCHETYPE_NODE_ID", "");
+      appendHiddenSerializable(this, "ARCHETYPE_CTX", "");
       this.setColour(colour);
       this.setTooltip(`openEHR RM ${options.rmType}`);
       if (isPartyProxyType(options.rmType)) {
@@ -1041,19 +1035,11 @@ function defineValueElementBlock(): void {
         card: { min: 1, max: 1 },
         rmType: slotRmTypeForAttr("ELEMENT", "value"),
       });
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldLabelSerializable("ELEMENT"), "RM_TYPE");
-      this.getField("RM_TYPE")!.setVisible(false);
-      appendHiddenLabel(this, "MANDATORY", "");
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldTextInput(""), "SLOT_ID");
-      this.getField("SLOT_ID")!.setVisible(false);
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldTextInput(""), "ARCHETYPE_NODE_ID");
-      this.getField("ARCHETYPE_NODE_ID")!.setVisible(false);
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldTextInput(""), "ARCHETYPE_CTX");
-      this.getField("ARCHETYPE_CTX")!.setVisible(false);
+      appendHiddenSerializable(this, "RM_TYPE", "ELEMENT");
+      appendHiddenSerializable(this, "MANDATORY", "");
+      appendHiddenSerializable(this, "SLOT_ID", "");
+      appendHiddenSerializable(this, "ARCHETYPE_NODE_ID", "");
+      appendHiddenSerializable(this, "ARCHETYPE_CTX", "");
       this.setPreviousStatement(true, ["ITEM", "ELEMENT", "CLUSTER"]);
       this.setNextStatement(true, ["ITEM", "ELEMENT", "CLUSTER"]);
       this.setColour(ELEMENT_COLOUR);
@@ -1082,13 +1068,9 @@ function defineDataValueBlock(rmType: string): void {
       if (optionalAttributes(rmType).some((a) => isMappableField(a))) {
         appendMutatorCogwheel(header);
       }
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldLabelSerializable(""), "SLOT_ID");
-      this.getField("SLOT_ID")!.setVisible(false);
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldLabelSerializable(rmType), "RM_TYPE");
-      this.getField("RM_TYPE")!.setVisible(false);
-      appendHiddenLabel(this, "MANDATORY", "");
+      appendHiddenSerializable(this, "SLOT_ID", "");
+      appendHiddenSerializable(this, "RM_TYPE", rmType);
+      appendHiddenSerializable(this, "MANDATORY", "");
 
       const mandatory = mandatoryAttributes(rmType).filter((a) =>
         isMappableField(a)
@@ -1186,12 +1168,8 @@ function defineCodePhraseBlock(): void {
       this.setOutput(true, "CODE_PHRASE");
       this.setColour(DV_COLOUR);
       enforceOpenEhrBlockLayout(this);
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldLabelSerializable("CODE_PHRASE"), "RM_TYPE");
-      this.getField("RM_TYPE")!.setVisible(false);
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldTextInput(""), "SLOT_ID");
-      this.getField("SLOT_ID")!.setVisible(false);
+      appendHiddenSerializable(this, "RM_TYPE", "CODE_PHRASE");
+      appendHiddenSerializable(this, "SLOT_ID", "");
     },
   };
 }
@@ -1350,7 +1328,7 @@ function defineMutatorItemBlock(type: string, colour: string): void {
       // Single row: a second dummy input for hidden ATTR doubled block height (~59px).
       this.appendDummyInput()
         .appendField(new Blockly.FieldLabelSerializable(""), "LABEL")
-        .appendField(zeroSizeSerializableField(""), "ATTR");
+        .appendField(createHiddenSerializableField(""), "ATTR");
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setColour(colour);
@@ -1373,21 +1351,6 @@ function defineMutatorItemBlock(type: string, colour: string): void {
       };
     },
   };
-}
-
-/** Serializable ATTR that does not contribute to block layout size. */
-function zeroSizeSerializableField(value: string) {
-  const field = new Blockly.FieldLabelSerializable(value);
-  field.EDITABLE = false;
-  field.SERIALIZABLE = true;
-  field.initView = () => {};
-  const sized = field as unknown as { size_?: { width: number; height: number }; getSize?: () => { width: number; height: number } };
-  if (sized.size_) {
-    sized.size_.width = 0;
-    sized.size_.height = 0;
-  }
-  sized.getSize = () => ({ width: 0, height: 0 });
-  return field;
 }
 
 function initSvgIfPresent(block: Blockly.Block): void {
@@ -1678,9 +1641,3 @@ declare module "blockly/core" {
   }
 }
 
-function appendHiddenLabel(block: Blockly.Block, name: string, value: string): void {
-  if (block.getField(name)) return;
-  block.appendDummyInput()
-    .appendField(new Blockly.FieldLabelSerializable(value), name);
-  block.getField(name)?.setVisible(false);
-}

--- a/src/blockly/blocks/schema_mutator.ts
+++ b/src/blockly/blocks/schema_mutator.ts
@@ -21,6 +21,7 @@ import {
   targetChildInputName,
 } from "./target_blocks.ts";
 import { specForChild, type SchemaInputSpec } from "../../core/target/schema_block_ids.ts";
+import { createHiddenSerializableField } from "../hidden_serializable_field.ts";
 
 const TARGET_CHILD_PREFIX = "TARGET_";
 
@@ -28,24 +29,6 @@ export const SCHEMA_FIELDS_MUTATOR = "schema_fields_mutator";
 export const SCHEMA_MUTATOR_CONTAINER = "schema_fields_mutator_container";
 export const SCHEMA_MUTATOR_ITEM = "schema_fields_mutator_item";
 const SCHEMA_OPTIONAL_PREFIX = "SCHEMA_OPT_";
-
-/** Serializable ATTR that does not contribute to block layout size. */
-function zeroSizeAttrField(value: string) {
-  const field = new Blockly.FieldLabelSerializable(value);
-  field.EDITABLE = false;
-  field.SERIALIZABLE = true;
-  field.initView = () => {};
-  const sized = field as unknown as {
-    size_?: { width: number; height: number };
-    getSize?: () => { width: number; height: number };
-  };
-  if (sized.size_) {
-    sized.size_.width = 0;
-    sized.size_.height = 0;
-  }
-  sized.getSize = () => ({ width: 0, height: 0 });
-  return field;
-}
 
 export type SchemaMutatorChange = {
   parent: Block;
@@ -151,7 +134,7 @@ function defineSchemaMutatorQuarks(): void {
       init: function (this: Block) {
         this.appendDummyInput()
           .appendField(new Blockly.FieldLabelSerializable(""), "LABEL")
-          .appendField(zeroSizeAttrField(""), "ATTR");
+          .appendField(createHiddenSerializableField(""), "ATTR");
         this.setPreviousStatement(true);
         this.setNextStatement(true);
         this.setColour("#4B5563");

--- a/src/blockly/blocks/target_blocks.ts
+++ b/src/blockly/blocks/target_blocks.ts
@@ -1,6 +1,7 @@
 import { Blockly } from "../blockly_core.ts";
 import type { Block } from "blockly/core";
 import { FieldSkeletonTitle } from "../field_skeleton_title.ts";
+import { appendHiddenSerializable } from "../hidden_serializable_field.ts";
 import { findSkeletonNode } from "../schema_catalog.ts";
 import { appendSlotLabel } from "../slot_label.ts";
 import { registerSchemaFieldsMutator, SCHEMA_FIELDS_MUTATOR } from "./schema_mutator.ts";
@@ -103,11 +104,8 @@ function defineStructureBlock(
       } else {
         header.appendField(new FieldSkeletonTitle("", defaultName), "NAME");
       }
-      header.appendField(new Blockly.FieldLabelSerializable(""), "TARGET_TYPE");
-      this.getField("TARGET_TYPE")?.setVisible(false);
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldTextInput(""), "SLOT_ID");
-      this.getField("SLOT_ID")?.setVisible(false);
+      appendHiddenSerializable(this, "TARGET_TYPE", "");
+      appendHiddenSerializable(this, "SLOT_ID", "");
       if (defaultChildGroup) {
         this.appendStatementInput(targetChildInputName(defaultChildGroup))
           .setAlign(inputAlignRight())
@@ -164,14 +162,11 @@ function defineValueBlock(
   Blockly.Blocks[type] = {
     init: function (this: Block) {
       this.appendDummyInput("HEADER")
-        .appendField(new FieldSkeletonTitle("", defaultName), "NAME")
-        .appendField(new Blockly.FieldLabelSerializable(""), "TARGET_TYPE");
-      this.getField("TARGET_TYPE")?.setVisible(false);
+        .appendField(new FieldSkeletonTitle("", defaultName), "NAME");
+      appendHiddenSerializable(this, "TARGET_TYPE", "");
       this.appendValueInput("VALUE").setCheck(null).appendField("value");
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldTextInput(""), "SLOT_ID");
-      this.getField("SLOT_ID")?.setVisible(false);
-      appendHiddenTargetMandatory(this);
+      appendHiddenSerializable(this, "SLOT_ID", "");
+      appendHiddenSerializable(this, "MANDATORY", "");
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setColour(colour);
@@ -187,14 +182,11 @@ function defineXmlAttribute(): void {
     init: function (this: Block) {
       this.appendDummyInput("HEADER")
         .appendField("XML attr")
-        .appendField(new Blockly.FieldTextInput("attr"), "NAME")
-        .appendField(new Blockly.FieldLabelSerializable(""), "TARGET_TYPE");
-      this.getField("TARGET_TYPE")?.setVisible(false);
+        .appendField(new Blockly.FieldTextInput("attr"), "NAME");
+      appendHiddenSerializable(this, "TARGET_TYPE", "");
       this.appendValueInput("VALUE").setCheck(null).appendField("value");
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldTextInput(""), "SLOT_ID");
-      this.getField("SLOT_ID")?.setVisible(false);
-      appendHiddenTargetMandatory(this);
+      appendHiddenSerializable(this, "SLOT_ID", "");
+      appendHiddenSerializable(this, "MANDATORY", "");
       this.setPreviousStatement(true);
       this.setNextStatement(true);
       this.setColour(XML_COLOUR);
@@ -202,13 +194,6 @@ function defineXmlAttribute(): void {
       this.setInputsInline(true);
     },
   };
-}
-
-function appendHiddenTargetMandatory(block: Block): void {
-  if (block.getField("MANDATORY")) return;
-  block.appendDummyInput()
-    .appendField(new Blockly.FieldLabelSerializable(""), "MANDATORY");
-  block.getField("MANDATORY")?.setVisible(false);
 }
 
 /** Blockly Align.RIGHT — attribute captions sit just left of their mouth. */

--- a/src/blockly/blocks/term_pick.ts
+++ b/src/blockly/blocks/term_pick.ts
@@ -1,4 +1,5 @@
 import { Blockly } from "../blockly_core.ts";
+import { appendHiddenSerializable } from "../hidden_serializable_field.ts";
 import type { BlockSvg } from "blockly/core";
 import {
   TERM_PICK_NONE,
@@ -48,17 +49,9 @@ export function registerTermPickBlock(): void {
           "CODE",
         );
 
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldLabelSerializable(""), "SLOT_ID");
-      this.getField("SLOT_ID")!.setVisible(false);
-      this.appendDummyInput()
-        .appendField(new Blockly.FieldLabelSerializable("CODE_PHRASE"), "RM_TYPE");
-      this.getField("RM_TYPE")!.setVisible(false);
-      if (!this.getField("MANDATORY")) {
-        this.appendDummyInput()
-          .appendField(new Blockly.FieldLabelSerializable(""), "MANDATORY");
-        this.getField("MANDATORY")!.setVisible(false);
-      }
+      appendHiddenSerializable(this, "SLOT_ID", "");
+      appendHiddenSerializable(this, "RM_TYPE", "CODE_PHRASE");
+      appendHiddenSerializable(this, "MANDATORY", "");
 
       this.setOutput(true, ["CODE_PHRASE", "DV_CODED_TEXT"]);
       this.setColour(TERM_COLOUR);

--- a/src/blockly/compact_renderer.ts
+++ b/src/blockly/compact_renderer.ts
@@ -41,6 +41,12 @@ export function registerCompactThrasosRenderer(): string {
     // deno-lint-ignore no-explicit-any
     getInRowSpacing_(prev: any, next: any) {
       const spacing = super.getInRowSpacing_(prev, next);
+      if (isZeroSizeMeasurable(prev) || isZeroSizeMeasurable(next)) return 0;
+      // Class chrome sits against the left body edge / output notch.
+      if (!prev && isClassChromeMeasurable(next)) return 0;
+      if (isClassChromeMeasurable(next) && !prev?.field) {
+        return Math.min(spacing, 1);
+      }
       if (
         isRmEmojiMeasurable(prev) || isRmEmojiMeasurable(next) ||
         isSlotCardMeasurable(prev) || isSlotCardMeasurable(next) ||
@@ -96,12 +102,14 @@ export function registerCompactThrasosRenderer(): string {
 
     // deno-lint-ignore no-explicit-any
     makeRenderInfo_(block: any) {
+      // deno-lint-ignore no-explicit-any
       if (BaseInfo) return new (CompactRenderInfo as any)(this, block);
       return super.makeRenderInfo_(block);
     }
 
     // deno-lint-ignore no-explicit-any
     makeDrawer_(block: any, info: any) {
+      // deno-lint-ignore no-explicit-any
       if (BaseDrawer) return new (CompactDrawer as any)(block, info);
       return super.makeDrawer_(block, info);
     }
@@ -136,8 +144,10 @@ function applyCompactConstants(constants: any): void {
   const tabHeight = Number(constants.TAB_HEIGHT ?? 15);
   const tabRoom = tabHeight + 11;
   constants.MIN_BLOCK_HEIGHT = Math.max(24, tabRoom);
-  constants.DUMMY_INPUT_MIN_HEIGHT = Math.max(tabRoom, Number(constants.DUMMY_INPUT_MIN_HEIGHT ?? 0));
-  constants.EMPTY_INLINE_INPUT_HEIGHT = Math.max(tabRoom, Number(constants.EMPTY_INLINE_INPUT_HEIGHT ?? 0));
+  // Assign (do not Math.max with theme): init() inflates dummy/inline mins
+  // from TAB_HEIGHT and would keep that extra vertical gap under HEADER.
+  constants.DUMMY_INPUT_MIN_HEIGHT = tabRoom;
+  constants.EMPTY_INLINE_INPUT_HEIGHT = tabRoom;
 }
 
 // deno-lint-ignore no-explicit-any
@@ -173,11 +183,7 @@ export function shouldPinSlotCaptionToMouth_(row: any, elem: any): boolean {
 
 /** Centerline Y for a slot caption pinned to the input mouth / notch. */
 // deno-lint-ignore no-explicit-any
-export function pinnedSlotCaptionCenterline_(
-  row: any,
-  elem: any,
-  constants: any,
-): number {
+export function pinnedSlotCaptionCenterline_(row: any, elem: any, constants: any): number {
   const y = Number(row?.yPos ?? 0);
   if (row?.hasStatement) {
     // Match Zelos: empty statement mouth height, not the connected stack.
@@ -200,10 +206,26 @@ function isRmEmojiMeasurable(elem: any): boolean {
   return isRmTypeEmojiField(elem?.field ?? null);
 }
 
+// deno-lint-ignore no-explicit-any
+function isClassChromeMeasurable(elem: any): boolean {
+  const field = elem?.field;
+  if (!field) return false;
+  if (isRmTypeEmojiField(field) && field.name === BLOCK_OUT_EMOJI_FIELD) return true;
+  if (isSkeletonTitleField(field)) return true;
+  return field.name === "MUTATOR_COG";
+}
+
+// deno-lint-ignore no-explicit-any
+function isZeroSizeMeasurable(elem: any): boolean {
+  return Boolean(elem?.field) && Number(elem?.width ?? 0) === 0 && Number(elem?.height ?? 0) === 0;
+}
+
+// deno-lint-ignore no-explicit-any
 function isSlotCardMeasurable(elem: any): boolean {
   return isSlotCardinalityField(elem?.field ?? null);
 }
 
+// deno-lint-ignore no-explicit-any
 function isSlotLabelMeasurable(elem: any): boolean {
   return isSlotLabelField(elem?.field ?? null);
 }

--- a/src/blockly/dynamic_mutator.ts
+++ b/src/blockly/dynamic_mutator.ts
@@ -258,6 +258,16 @@ export class DynamicFlyoutMutatorIcon extends MutatorIcon {
     return getCogwheelAnchorLocation(this.sourceBlock as BlockSvg);
   }
 
+  /**
+   * Header cogwheel is the visible control. A non-zero mutator icon size
+   * indents the class emoji/title away from the top-left corner.
+   */
+  override getSize(): Blockly.utils.Size {
+    const Size = Blockly.utils?.Size;
+    if (Size) return new Size(0, 0);
+    return { width: 0, height: 0 } as Blockly.utils.Size;
+  }
+
   override setBubbleVisible(visible: boolean): Promise<void> {
     const block = this.sourceBlock as BlockSvg;
     const self = this as unknown as Record<string, unknown>;

--- a/src/blockly/hidden_serializable_field.ts
+++ b/src/blockly/hidden_serializable_field.ts
@@ -1,0 +1,56 @@
+/**
+ * Blockly dummy inputs always consume DUMMY_INPUT_MIN_HEIGHT, even when every
+ * field is setVisible(false). Hidden SLOT_ID / RM_TYPE / … must live on an
+ * existing visible row (HEADER) with a zero size so they serialize without
+ * stretching the block.
+ */
+import { Blockly } from "./blockly_core.ts";
+
+export function createHiddenSerializableField(value = "") {
+  const field = new Blockly.FieldLabelSerializable(value);
+  field.EDITABLE = false;
+  field.SERIALIZABLE = true;
+  const mutable = field as unknown as {
+    initView?: () => void;
+    render_?: () => void;
+    updateSize_?: () => void;
+    size_?: { width: number; height: number };
+    getSize?: () => { width: number; height: number };
+  };
+  mutable.initView = () => {};
+  mutable.render_ = () => {};
+  mutable.updateSize_ = () => {
+    if (mutable.size_) {
+      mutable.size_.width = 0;
+      mutable.size_.height = 0;
+    }
+  };
+  if (mutable.size_) {
+    mutable.size_.width = 0;
+    mutable.size_.height = 0;
+  }
+  mutable.getSize = () => ({ width: 0, height: 0 });
+  mutable.updateSize_?.();
+  return field;
+}
+
+/** Append a serializable field that does not create a new dummy row. */
+export function appendHiddenSerializable(
+  block: Blockly.Block,
+  name: string,
+  value = "",
+): void {
+  if (block.getField(name)) return;
+  const field = createHiddenSerializableField(value);
+  const header = block.getInput("HEADER");
+  if (header) {
+    header.appendField(field, name);
+    return;
+  }
+  const dummy = block.inputList.find((input) => !input.connection);
+  if (dummy) {
+    dummy.appendField(field, name);
+    return;
+  }
+  block.appendDummyInput("HEADER").appendField(field, name);
+}

--- a/test/blockly_rm_blocks_test.ts
+++ b/test/blockly_rm_blocks_test.ts
@@ -126,6 +126,76 @@ Deno.test("orderedRmAttributes puts mandatory RM attrs first", () => {
   );
 });
 
+/** Dummy inputs with no connection sit as empty rows in Thrasos. */
+function dummyRowsAfterHeader(block: Blockly.Block): number {
+  const inputs = block.inputList;
+  const headerIdx = inputs.findIndex((input) => input.name === "HEADER");
+  const start = headerIdx >= 0 ? headerIdx + 1 : 0;
+  let n = 0;
+  for (let i = start; i < inputs.length; i++) {
+    const input = inputs[i]!;
+    if (input.connection) break;
+    n++;
+  }
+  return n;
+}
+
+function inputNames(block: Blockly.Block): string {
+  return block.inputList.map((input) => input.name || "(dummy)").join(",");
+}
+
+Deno.test("hidden metadata is not extra dummy rows under HEADER", () => {
+  ensureBlocks();
+  const workspace = new Blockly.Workspace();
+
+  const phrase = workspace.newBlock("code_phrase");
+  assertEquals(
+    dummyRowsAfterHeader(phrase),
+    0,
+    `code_phrase extra dummy rows, inputs=${inputNames(phrase)}`,
+  );
+  assert(phrase.getField("SLOT_ID"), "code_phrase keeps SLOT_ID");
+  assertEquals(phrase.getFieldValue("RM_TYPE"), "CODE_PHRASE");
+  phrase.setFieldValue("slot/encoding", "SLOT_ID");
+  const saved = Blockly.serialization.blocks.save(phrase) as {
+    fields?: Record<string, string>;
+  };
+  assertEquals(saved.fields?.SLOT_ID, "slot/encoding");
+
+  const qty = workspace.newBlock("dv_quantity");
+  assertEquals(
+    dummyRowsAfterHeader(qty),
+    0,
+    `dv_quantity extra dummy rows, inputs=${inputNames(qty)}`,
+  );
+
+  const obs = workspace.newBlock("observation");
+  syncRmAttributeInputs(obs, "OBSERVATION", ["data", "encoding", "language"]);
+  assertEquals(
+    dummyRowsAfterHeader(obs),
+    0,
+    `observation extra dummy rows after sync, inputs=${inputNames(obs)}`,
+  );
+  const header = obs.getInput("HEADER");
+  assertEquals(header?.fieldRow[0]?.name, BLOCK_OUT_EMOJI_FIELD);
+
+  const element = workspace.newBlock("element");
+  assertEquals(
+    dummyRowsAfterHeader(element),
+    0,
+    `element extra dummy rows, inputs=${inputNames(element)}`,
+  );
+
+  const pick = workspace.newBlock("term_pick");
+  assertEquals(
+    dummyRowsAfterHeader(pick),
+    0,
+    `term_pick extra dummy rows, inputs=${inputNames(pick)}`,
+  );
+
+  workspace.dispose();
+});
+
 Deno.test("syncRmAttributeInputs labels statement mouths with RM attribute names", () => {
   ensureBlocks();
   const workspace = new Blockly.Workspace();

--- a/test/hidden_serializable_field_test.ts
+++ b/test/hidden_serializable_field_test.ts
@@ -1,0 +1,37 @@
+import { assertEquals } from "@std/assert";
+import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
+import {
+  appendHiddenSerializable,
+  createHiddenSerializableField,
+} from "@intehrgrator/blockly/hidden_serializable_field.ts";
+
+Deno.test("hidden serializable fields report zero layout size", () => {
+  const field = createHiddenSerializableField("CODE_PHRASE");
+  const size = field.getSize?.() ?? { width: -1, height: -1 };
+  assertEquals(size.width, 0);
+  assertEquals(size.height, 0);
+});
+
+Deno.test("appendHiddenSerializable reuses HEADER instead of a new dummy row", () => {
+  Blockly.Blocks["hidden_field_probe"] = {
+    init: function (this: Blockly.Block) {
+      this.appendDummyInput("HEADER").appendField("title");
+      this.appendValueInput("VALUE");
+      appendHiddenSerializable(this, "SLOT_ID", "slot/x");
+      appendHiddenSerializable(this, "RM_TYPE", "OBSERVATION");
+    },
+  };
+  const workspace = new Blockly.Workspace();
+  const block = workspace.newBlock("hidden_field_probe");
+  assertEquals(block.getFieldValue("SLOT_ID"), "slot/x");
+  assertEquals(block.getFieldValue("RM_TYPE"), "OBSERVATION");
+  const dummyAfterHeader = block.inputList.filter((input) => !input.connection && input.name !== "HEADER");
+  assertEquals(dummyAfterHeader.length, 0);
+  const saved = Blockly.serialization.blocks.save(block) as {
+    fields?: Record<string, string>;
+  };
+  assertEquals(saved.fields?.SLOT_ID, "slot/x");
+  assertEquals(saved.fields?.RM_TYPE, "OBSERVATION");
+  workspace.dispose();
+  delete Blockly.Blocks["hidden_field_probe"];
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes excessive vertical spacing under the HEADER row and left-side whitespace before class-block emoji/title on custom openEHR Blockly blocks.

## Problem

Hidden serializable metadata (`SLOT_ID`, `RM_TYPE`, `MANDATORY`, archetype fields, etc.) was appended as separate dummy inputs with `setVisible(false)`. Blockly still reserves `DUMMY_INPUT_MIN_HEIGHT` for dummy rows, so blocks gained tall empty gaps between the header line pair and the first real input.

The default mutator icon was CSS-hidden (replaced by the header cogwheel) but still reported non-zero layout size, indenting the class emoji away from the top-left corner.

## Fix

- Add `hidden_serializable_field.ts` with zero-size serializable fields on the existing `HEADER` row
- Move hidden metadata onto HEADER across RM, target, term_pick, and source_query blocks
- Report `0×0` from `DynamicFlyoutMutatorIcon.getSize()` so icon space is not reserved
- Tighten compact renderer spacing for class chrome and zero-size fields

## Tests

- `test/hidden_serializable_field_test.ts` — zero-size fields and no extra dummy rows
- `test/blockly_rm_blocks_test.ts` — regression for observation/code_phrase/element/term_pick blocks
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a7410f0-d066-43e8-ad1e-364b6f1c79db?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a7410f0-d066-43e8-ad1e-364b6f1c79db&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

