### PR TITLE
Add Description Logic list blocks to Blockly Logic

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -148,8 +148,16 @@ A typed Blockly shell for an openEHR `DV_*` (e.g. `DV_QUANTITY`) that wraps Mapp
 _Avoid_: Value constructor block, DV builder, free-form RM block, “+ fields” image button
 
 **Mapping Expression**:
-Editable fragment inside a value slot in the Mapping Specification — XPath via fontoxpath builtins (`xpathNumber`, `xpathString`, …) plus JS-shaped helpers (`trim`, `concat`, `if`). Not TypeScript/Java export code.
+Editable fragment inside a value slot in the Mapping Specification — XPath via fontoxpath builtins (`xpathNumber`, `xpathString`, …) plus JS-shaped helpers (`trim`, `concat`, `if`) and Description-Logic list restrictions (`all_of` / `any_of` / `none_of` / `at_least` / `at_most` / `exactly`) plus class operators (`intersection`, `union`, `difference`). Not TypeScript/Java export code.
 _Avoid_: Value mapping, get_source
+
+**DL restriction**:
+A Logic-category Blockly value (Boolean) that evaluates a list the way OWL Manchester Syntax evaluates a role: `only` (∀ *R.C*, all_of), `some` (∃ *R.C*, any_of), `none` (∀ *R.*¬*C*, none_of), and `min`/`max`/`exactly` n (cardinality). The list input is the related individuals; the predicate is class *C*, with a named item variable and relative Source Paths evaluated against that item. An empty list makes `only` and `none` true and `some` false.
+_Avoid_: treating this as a statement loop (`for_each_source`), Open-World “unknown” (Test Run is closed-world over the loaded example)
+
+**Set class operator**:
+A Logic-category Blockly value (Array) that combines two lists as OWL classes: `and` (intersection ∩), `or` (union ∪), `not … in …` (complement relative to a universe). Distinct from Boolean `logic_operation` / `logic_negate`.
+_Avoid_: Boolean AND/OR/NOT, Map merge
 
 **Constraint warning**:
 A yellow warning triangle on a Blockly block (and the matching **Mapping Spec Widget**) when a contained constraint is unmet — unmapped mandatory value, abstract EVENT, or unmet slot cardinality. It does not light up merely because a node is template/RM-mandatory.

--- a/docs/AI_SUGGESTION_FORMAT.md
+++ b/docs/AI_SUGGESTION_FORMAT.md
@@ -89,6 +89,10 @@ Blockly JSON (`type`, `fields`, `inputs`, `extraState` only). No `id`/`x`/`y`/`s
 | Text | `text_trim`, `text_join` | `MODE`; `text_join` may need `extraState.itemCount` + `ADD0`… |
 | Math | `math_arithmetic` | `OP`: `ADD`\|`MINUS`\|`MULTIPLY`\|`DIVIDE`; inputs `A`,`B` |
 | Logic | `logic_ternary` | inputs `IF`,`THEN`,`ELSE` |
+| Logic compare | `logic_compare`, `logic_operation`, `logic_negate` | `OP` `EQ`/`NEQ`/`LT`/`LTE`/`GT`/`GTE` or `AND`/`OR`; inputs `A`,`B` / `BOOL` |
+| DL restriction | `logic_quantify` | `OP` `ONLY`/`SOME`/`NONE` (Manchester; ∀/∃/∀¬). Inputs `LIST`, `PRED`; field `VAR` (item name). Emits `all_of`/`any_of`/`none_of`. Empty list: `only`/`none` true, `some` false. |
+| DL cardinality | `logic_cardinality` | `OP` `MIN`/`MAX`/`EXACTLY`; inputs `LIST`,`N`,`PRED`; field `VAR`. Emits `at_least`/`at_most`/`exactly`. |
+| Set class ops | `logic_set_operation`, `logic_set_not` | `and`/`or` = intersection/union; `not SET in UNIVERSE` = complement. |
 
 No JS wrappers (`xpathNumber("…")`). No RM containers, `DV_*` shells, Optional RM, Handlebars text, or list-construction blocks (`lists_*`) in this envelope — list-valued RM slots stay structural on the canvas.
 

--- a/docs/AI_SUGGESTION_FORMAT.schema.json
+++ b/docs/AI_SUGGESTION_FORMAT.schema.json
@@ -150,7 +150,14 @@
             "text_trim",
             "text_join",
             "math_arithmetic",
-            "logic_ternary"
+            "logic_ternary",
+            "logic_compare",
+            "logic_operation",
+            "logic_negate",
+            "logic_quantify",
+            "logic_cardinality",
+            "logic_set_operation",
+            "logic_set_not"
           ]
         },
         "fields": {

--- a/docs/BLOCKLY_INTEGRATION.md
+++ b/docs/BLOCKLY_INTEGRATION.md
@@ -69,6 +69,12 @@ including custom Source, openEHR types, Maps (`maps_*` in **Lists & maps**), and
 
 - **Stock Blockly:** `controls_if`, `controls_whileUntil`, `controls_repeat_ext`,
   `math_arithmetic`, `text_join`, `text_trim`, `logic_ternary`, variables, procedures, …
+- **Logic (DL restrictions):** `logic_quantify` (Manchester `only`/`some`/`none` over a
+  list — ∀/∃/∀¬), `logic_cardinality` (`min`/`max`/`exactly` n), `logic_set_operation`
+  (class `and`/`or` = intersection/union), `logic_set_not` (complement relative to a
+  universe). The list is the fillers of a role; the predicate is class *C*, evaluated
+  with the bound variable and relative source paths against each item. Empty-list
+  `only`/`none` are vacuously true (closed-world data, same truth table as OWL).
 - **Source:** `source_query` — XPath/XQuery via [fontoxpath](https://github.com/FontoXML/fontoxpath);
   typed `evaluateXPathTo*` from target slot `DV_*` type (see [SOURCE_QUERY.md](SOURCE_QUERY.md))
 - **Loops (custom):** `for_each_source` — iterate nodes from a multi-valued source path

--- a/src/blockly/blocks/logic_blocks.ts
+++ b/src/blockly/blocks/logic_blocks.ts
@@ -1,0 +1,145 @@
+import { Blockly } from "../blockly_core.ts";
+import { FieldDropdownHug } from "../field_dropdown_hug.ts";
+import { msg, detectLocale } from "../i18n/locale.ts";
+
+const LOGIC_COLOUR = "#D1C4E9";
+
+export const LOGIC_QUANTIFY_BLOCK = "logic_quantify";
+export const LOGIC_CARDINALITY_BLOCK = "logic_cardinality";
+export const LOGIC_SET_OPERATION_BLOCK = "logic_set_operation";
+export const LOGIC_SET_NOT_BLOCK = "logic_set_not";
+
+export const LOGIC_DL_BLOCK_TYPES = [
+  LOGIC_QUANTIFY_BLOCK,
+  LOGIC_CARDINALITY_BLOCK,
+  LOGIC_SET_OPERATION_BLOCK,
+  LOGIC_SET_NOT_BLOCK,
+] as const;
+
+const LIST_CHECK = ["Array", "Source"];
+
+/**
+ * Description-Logic-inspired Logic blocks for evaluating lists/sets:
+ * Manchester `only`/`some`/`none` (∀/∃), `min`/`max`/`exactly` (cardinality),
+ * and class operators `and`/`or`/`not` (intersection/union/complement).
+ */
+export function registerLogicBlocks(): void {
+  const m = msg(detectLocale());
+
+  Blockly.Blocks[LOGIC_QUANTIFY_BLOCK] = {
+    init: function (this: Blockly.Block) {
+      this.appendValueInput("LIST")
+        .setCheck(LIST_CHECK);
+      this.appendDummyInput()
+        .appendField(
+          new FieldDropdownHug([
+            [m.LOGIC_ONLY, "ONLY"],
+            [m.LOGIC_SOME, "SOME"],
+            [m.LOGIC_NONE, "NONE"],
+          ]),
+          "OP",
+        )
+        .appendField(m.LOGIC_AS)
+        .appendField(new Blockly.FieldVariable("item"), "VAR");
+      this.appendValueInput("PRED")
+        .setCheck("Boolean");
+      this.setInputsInline(true);
+      this.setOutput(true, "Boolean");
+      this.setColour(LOGIC_COLOUR);
+      this.setTooltip(m.LOGIC_QUANTIFY_TOOLTIP);
+      this.setStyle?.("logic_blocks");
+    },
+  };
+
+  Blockly.Blocks[LOGIC_CARDINALITY_BLOCK] = {
+    init: function (this: Blockly.Block) {
+      this.appendValueInput("LIST")
+        .setCheck(LIST_CHECK);
+      this.appendValueInput("N")
+        .setCheck("Number")
+        .appendField(
+          new FieldDropdownHug([
+            [m.LOGIC_MIN, "MIN"],
+            [m.LOGIC_MAX, "MAX"],
+            [m.LOGIC_EXACTLY, "EXACTLY"],
+          ]),
+          "OP",
+        );
+      this.appendDummyInput()
+        .appendField(m.LOGIC_AS)
+        .appendField(new Blockly.FieldVariable("item"), "VAR");
+      this.appendValueInput("PRED")
+        .setCheck("Boolean");
+      this.setInputsInline(true);
+      this.setOutput(true, "Boolean");
+      this.setColour(LOGIC_COLOUR);
+      this.setTooltip(m.LOGIC_CARDINALITY_TOOLTIP);
+      this.setStyle?.("logic_blocks");
+    },
+  };
+
+  Blockly.Blocks[LOGIC_SET_OPERATION_BLOCK] = {
+    init: function (this: Blockly.Block) {
+      this.appendValueInput("A")
+        .setCheck(LIST_CHECK);
+      this.appendValueInput("B")
+        .setCheck(LIST_CHECK)
+        .appendField(
+          new FieldDropdownHug([
+            [m.LOGIC_SET_AND, "AND"],
+            [m.LOGIC_SET_OR, "OR"],
+          ]),
+          "OP",
+        );
+      this.setInputsInline(true);
+      this.setOutput(true, "Array");
+      this.setColour(LOGIC_COLOUR);
+      this.setTooltip(m.LOGIC_SET_OP_TOOLTIP);
+      this.setStyle?.("logic_blocks");
+    },
+  };
+
+  Blockly.Blocks[LOGIC_SET_NOT_BLOCK] = {
+    init: function (this: Blockly.Block) {
+      this.appendValueInput("SET")
+        .setCheck(LIST_CHECK)
+        .appendField(m.LOGIC_SET_NOT);
+      this.appendValueInput("UNIVERSE")
+        .setCheck(LIST_CHECK)
+        .appendField(m.LOGIC_SET_IN);
+      this.setInputsInline(true);
+      this.setOutput(true, "Array");
+      this.setColour(LOGIC_COLOUR);
+      this.setTooltip(m.LOGIC_SET_NOT_TOOLTIP);
+      this.setStyle?.("logic_blocks");
+    },
+  };
+}
+
+export function quantifyOpToCall(op: string): "all_of" | "any_of" | "none_of" {
+  if (op === "SOME") return "any_of";
+  if (op === "NONE") return "none_of";
+  return "all_of";
+}
+
+export function callToQuantifyOp(name: string): "ONLY" | "SOME" | "NONE" {
+  if (name === "any_of") return "SOME";
+  if (name === "none_of") return "NONE";
+  return "ONLY";
+}
+
+export function cardinalityOpToCall(op: string): "at_least" | "at_most" | "exactly" {
+  if (op === "MAX") return "at_most";
+  if (op === "EXACTLY") return "exactly";
+  return "at_least";
+}
+
+export function callToCardinalityOp(name: string): "MIN" | "MAX" | "EXACTLY" {
+  if (name === "at_most") return "MAX";
+  if (name === "exactly") return "EXACTLY";
+  return "MIN";
+}
+
+export function variableFieldName(block: Blockly.Block, field = "VAR"): string {
+  return block.getField(field)?.getText() ?? "item";
+}

--- a/src/blockly/expression_serialize.ts
+++ b/src/blockly/expression_serialize.ts
@@ -7,6 +7,18 @@ import {
   xpathEvaluatorForReturnType,
 } from "./source_query.ts";
 import { createMapsGetBlock, registerMapBlocks } from "./blocks/map_blocks.ts";
+import {
+  callToCardinalityOp,
+  callToQuantifyOp,
+  cardinalityOpToCall,
+  LOGIC_CARDINALITY_BLOCK,
+  LOGIC_QUANTIFY_BLOCK,
+  LOGIC_SET_NOT_BLOCK,
+  LOGIC_SET_OPERATION_BLOCK,
+  quantifyOpToCall,
+  registerLogicBlocks,
+  variableFieldName,
+} from "./blocks/logic_blocks.ts";
 
 type BlockSvg = import("blockly/core").BlockSvg;
 type Workspace = import("blockly/core").Workspace;
@@ -150,6 +162,64 @@ export function blockToExpression(block: Block | null): string | null {
     }
     case "mapping_var_get":
       return `var(${JSON.stringify(block.getFieldValue("VAR") ?? "v")})`;
+    case "logic_compare": {
+      const a = blockToExpression(block.getInputTargetBlock("A")) ?? "false";
+      const b = blockToExpression(block.getInputTargetBlock("B")) ?? "false";
+      const opMap: Record<string, string> = {
+        EQ: "eq",
+        NEQ: "ne",
+        LT: "lt",
+        LTE: "le",
+        GT: "gt",
+        GTE: "ge",
+      };
+      const fn = opMap[String(block.getFieldValue("OP") ?? "EQ")] ?? "eq";
+      return `${fn}(${a}, ${b})`;
+    }
+    case "logic_operation": {
+      const a = blockToExpression(block.getInputTargetBlock("A")) ?? "false";
+      const b = blockToExpression(block.getInputTargetBlock("B")) ?? "false";
+      const fn = String(block.getFieldValue("OP") ?? "AND") === "OR" ? "or" : "and";
+      return `${fn}(${a}, ${b})`;
+    }
+    case "logic_negate": {
+      const inner = blockToExpression(block.getInputTargetBlock("BOOL")) ?? "false";
+      return `not(${inner})`;
+    }
+    case "lists_create_with": {
+      const count = Number((block as Block & { itemCount_?: number }).itemCount_ ?? 0);
+      const parts: string[] = [];
+      for (let i = 0; i < count; i++) {
+        parts.push(blockToExpression(block.getInputTargetBlock(`ADD${i}`)) ?? "false");
+      }
+      return `list(${parts.join(", ")})`;
+    }
+    case "logic_quantify": {
+      const list = blockToExpression(block.getInputTargetBlock("LIST")) ?? "list()";
+      const pred = blockToExpression(block.getInputTargetBlock("PRED")) ?? "true";
+      const name = JSON.stringify(variableFieldName(block));
+      const fn = quantifyOpToCall(String(block.getFieldValue("OP") ?? "ONLY"));
+      return `${fn}(${list}, ${name}, ${pred})`;
+    }
+    case "logic_cardinality": {
+      const list = blockToExpression(block.getInputTargetBlock("LIST")) ?? "list()";
+      const n = blockToExpression(block.getInputTargetBlock("N")) ?? "0";
+      const pred = blockToExpression(block.getInputTargetBlock("PRED")) ?? "true";
+      const name = JSON.stringify(variableFieldName(block));
+      const fn = cardinalityOpToCall(String(block.getFieldValue("OP") ?? "MIN"));
+      return `${fn}(${list}, ${n}, ${name}, ${pred})`;
+    }
+    case "logic_set_operation": {
+      const a = blockToExpression(block.getInputTargetBlock("A")) ?? "list()";
+      const b = blockToExpression(block.getInputTargetBlock("B")) ?? "list()";
+      const fn = String(block.getFieldValue("OP") ?? "AND") === "OR" ? "union" : "intersection";
+      return `${fn}(${a}, ${b})`;
+    }
+    case "logic_set_not": {
+      const set = blockToExpression(block.getInputTargetBlock("SET")) ?? "list()";
+      const universe = blockToExpression(block.getInputTargetBlock("UNIVERSE")) ?? "list()";
+      return `difference(${universe}, ${set})`;
+    }
     default:
       return null;
   }
@@ -265,7 +335,148 @@ export function astToExpressionBlock(
       }
       return finalize(block);
     }
+    if (
+      ast.name === "eq" || ast.name === "ne" || ast.name === "lt" ||
+      ast.name === "le" || ast.name === "gt" || ast.name === "ge"
+    ) {
+      const block = workspace.newBlock("logic_compare") as BlockSvg;
+      const opMap: Record<string, string> = {
+        eq: "EQ",
+        ne: "NEQ",
+        lt: "LT",
+        le: "LTE",
+        gt: "GT",
+        ge: "GTE",
+      };
+      block.setFieldValue(opMap[ast.name] ?? "EQ", "OP");
+      if (ast.args[0]) {
+        block.getInput("A")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[0], returnType, finalize).outputConnection!,
+        );
+      }
+      if (ast.args[1]) {
+        block.getInput("B")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[1], returnType, finalize).outputConnection!,
+        );
+      }
+      return finalize(block);
+    }
+    if (ast.name === "and" || ast.name === "or") {
+      const block = workspace.newBlock("logic_operation") as BlockSvg;
+      block.setFieldValue(ast.name === "or" ? "OR" : "AND", "OP");
+      if (ast.args[0]) {
+        block.getInput("A")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[0], "boolean", finalize).outputConnection!,
+        );
+      }
+      if (ast.args[1]) {
+        block.getInput("B")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[1], "boolean", finalize).outputConnection!,
+        );
+      }
+      return finalize(block);
+    }
+    if (ast.name === "not" && ast.args[0]) {
+      const block = workspace.newBlock("logic_negate") as BlockSvg;
+      block.getInput("BOOL")!.connection!.connect(
+        astToExpressionBlock(workspace, ast.args[0], "boolean", finalize).outputConnection!,
+      );
+      return finalize(block);
+    }
+    if (ast.name === "list") {
+      const block = workspace.newBlock("lists_create_with") as BlockSvg;
+      // deno-lint-ignore no-explicit-any
+      const list = block as any;
+      list.itemCount_ = ast.args.length;
+      list.updateShape_?.();
+      for (let i = 0; i < ast.args.length; i++) {
+        const child = astToExpressionBlock(workspace, ast.args[i]!, returnType, finalize);
+        block.getInput(`ADD${i}`)?.connection?.connect(child.outputConnection!);
+      }
+      return finalize(block);
+    }
+    if (ast.name === "all_of" || ast.name === "any_of" || ast.name === "none_of") {
+      registerLogicBlocks();
+      const block = workspace.newBlock(LOGIC_QUANTIFY_BLOCK) as BlockSvg;
+      block.setFieldValue(callToQuantifyOp(ast.name), "OP");
+      bindVariableField(workspace, block, ast.args[1]);
+      if (ast.args[0]) {
+        block.getInput("LIST")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[0], "node", finalize).outputConnection!,
+        );
+      }
+      if (ast.args[2]) {
+        block.getInput("PRED")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[2], "boolean", finalize).outputConnection!,
+        );
+      }
+      return finalize(block);
+    }
+    if (ast.name === "at_least" || ast.name === "at_most" || ast.name === "exactly") {
+      registerLogicBlocks();
+      const block = workspace.newBlock(LOGIC_CARDINALITY_BLOCK) as BlockSvg;
+      block.setFieldValue(callToCardinalityOp(ast.name), "OP");
+      bindVariableField(workspace, block, ast.args[2]);
+      if (ast.args[0]) {
+        block.getInput("LIST")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[0], "node", finalize).outputConnection!,
+        );
+      }
+      if (ast.args[1]) {
+        block.getInput("N")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[1], "number", finalize).outputConnection!,
+        );
+      }
+      if (ast.args[3]) {
+        block.getInput("PRED")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[3], "boolean", finalize).outputConnection!,
+        );
+      }
+      return finalize(block);
+    }
+    if (ast.name === "intersection" || ast.name === "union") {
+      registerLogicBlocks();
+      const block = workspace.newBlock(LOGIC_SET_OPERATION_BLOCK) as BlockSvg;
+      block.setFieldValue(ast.name === "union" ? "OR" : "AND", "OP");
+      if (ast.args[0]) {
+        block.getInput("A")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[0], "node", finalize).outputConnection!,
+        );
+      }
+      if (ast.args[1]) {
+        block.getInput("B")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[1], "node", finalize).outputConnection!,
+        );
+      }
+      return finalize(block);
+    }
+    if (ast.name === "difference") {
+      registerLogicBlocks();
+      const block = workspace.newBlock(LOGIC_SET_NOT_BLOCK) as BlockSvg;
+      if (ast.args[1]) {
+        block.getInput("SET")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[1], "node", finalize).outputConnection!,
+        );
+      }
+      if (ast.args[0]) {
+        block.getInput("UNIVERSE")!.connection!.connect(
+          astToExpressionBlock(workspace, ast.args[0], "node", finalize).outputConnection!,
+        );
+      }
+      return finalize(block);
+    }
   }
 
   return finalize(createSourceQueryBlock(workspace, serialize(ast), returnType));
+}
+
+function bindVariableField(workspace: Workspace, block: BlockSvg, ast: ExprAst | undefined): void {
+  const name = ast?.kind === "literal" ? String(ast.value) : "item";
+  // deno-lint-ignore no-explicit-any
+  const ws = workspace as any;
+  let variable = ws.getVariable?.(name);
+  if (!variable && typeof ws.createVariable === "function") {
+    variable = ws.createVariable(name);
+  }
+  if (variable) block.setFieldValue(variable.getId(), "VAR");
 }

--- a/src/blockly/i18n/custom_msg.ts
+++ b/src/blockly/i18n/custom_msg.ts
@@ -48,6 +48,21 @@ export interface IntehrMessages {
   FOR_EACH_SOURCE_NODES: string;
   FOR_EACH_SOURCE_DO: string;
   FOR_EACH_SOURCE_TOOLTIP: string;
+  LOGIC_AS: string;
+  LOGIC_ONLY: string;
+  LOGIC_SOME: string;
+  LOGIC_NONE: string;
+  LOGIC_MIN: string;
+  LOGIC_MAX: string;
+  LOGIC_EXACTLY: string;
+  LOGIC_SET_AND: string;
+  LOGIC_SET_OR: string;
+  LOGIC_SET_NOT: string;
+  LOGIC_SET_IN: string;
+  LOGIC_QUANTIFY_TOOLTIP: string;
+  LOGIC_CARDINALITY_TOOLTIP: string;
+  LOGIC_SET_OP_TOOLTIP: string;
+  LOGIC_SET_NOT_TOOLTIP: string;
   LANGUAGE_LABEL: string;
   UI_LANGUAGE_LABEL: string;
   MODEL_LANGUAGE_LABEL: string;
@@ -92,6 +107,25 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     FOR_EACH_SOURCE_DO: "do",
     FOR_EACH_SOURCE_TOOLTIP:
       "Loop over every node matched by a source path. Current node is stored in the named variable.",
+    LOGIC_AS: "as",
+    LOGIC_ONLY: "only",
+    LOGIC_SOME: "some",
+    LOGIC_NONE: "none",
+    LOGIC_MIN: "min",
+    LOGIC_MAX: "max",
+    LOGIC_EXACTLY: "exactly",
+    LOGIC_SET_AND: "and",
+    LOGIC_SET_OR: "or",
+    LOGIC_SET_NOT: "not",
+    LOGIC_SET_IN: "in",
+    LOGIC_QUANTIFY_TOOLTIP:
+      "Evaluate a list like OWL Manchester only/some/none (∀/∃). Empty list: only and none are true; some is false.",
+    LOGIC_CARDINALITY_TOOLTIP:
+      "Count list items matching a predicate: min n (≥), max n (≤), or exactly n.",
+    LOGIC_SET_OP_TOOLTIP:
+      "Combine two lists as classes: and = intersection, or = union.",
+    LOGIC_SET_NOT_TOOLTIP:
+      "Complement: items of the universe that are not in the set (Manchester not).",
     LANGUAGE_LABEL: "Language",
     UI_LANGUAGE_LABEL: "UI",
     MODEL_LANGUAGE_LABEL: "Model",
@@ -134,6 +168,25 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     FOR_EACH_SOURCE_DO: "gör",
     FOR_EACH_SOURCE_TOOLTIP:
       "Loopa över varje nod som matchas av en källsökväg. Aktuell nod lagras i den namngivna variabeln.",
+    LOGIC_AS: "som",
+    LOGIC_ONLY: "only",
+    LOGIC_SOME: "some",
+    LOGIC_NONE: "none",
+    LOGIC_MIN: "min",
+    LOGIC_MAX: "max",
+    LOGIC_EXACTLY: "exactly",
+    LOGIC_SET_AND: "and",
+    LOGIC_SET_OR: "or",
+    LOGIC_SET_NOT: "not",
+    LOGIC_SET_IN: "i",
+    LOGIC_QUANTIFY_TOOLTIP:
+      "Utvärdera en lista som OWL Manchester only/some/none (∀/∃). Tom lista: only och none är sanna; some är falsk.",
+    LOGIC_CARDINALITY_TOOLTIP:
+      "Räkna listobjekt som matchar ett predikat: min n (≥), max n (≤) eller exactly n.",
+    LOGIC_SET_OP_TOOLTIP:
+      "Kombinera två listor som klasser: and = snitt, or = union.",
+    LOGIC_SET_NOT_TOOLTIP:
+      "Komplement: objekt i universum som inte finns i mängden (Manchester not).",
     LANGUAGE_LABEL: "Språk",
     UI_LANGUAGE_LABEL: "UI",
     MODEL_LANGUAGE_LABEL: "Modell",
@@ -176,6 +229,25 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     FOR_EACH_SOURCE_DO: "mache",
     FOR_EACH_SOURCE_TOOLTIP:
       "Schleife über jeden Knoten eines Quellpfads. Der aktuelle Knoten wird in der genannten Variable gespeichert.",
+    LOGIC_AS: "als",
+    LOGIC_ONLY: "only",
+    LOGIC_SOME: "some",
+    LOGIC_NONE: "none",
+    LOGIC_MIN: "min",
+    LOGIC_MAX: "max",
+    LOGIC_EXACTLY: "exactly",
+    LOGIC_SET_AND: "and",
+    LOGIC_SET_OR: "or",
+    LOGIC_SET_NOT: "not",
+    LOGIC_SET_IN: "in",
+    LOGIC_QUANTIFY_TOOLTIP:
+      "Liste wie OWL Manchester only/some/none (∀/∃) auswerten. Leere Liste: only und none wahr; some falsch.",
+    LOGIC_CARDINALITY_TOOLTIP:
+      "Listenelemente zählen, die ein Prädikat erfüllen: min n (≥), max n (≤) oder exactly n.",
+    LOGIC_SET_OP_TOOLTIP:
+      "Zwei Listen als Klassen kombinieren: and = Schnitt, or = Vereinigung.",
+    LOGIC_SET_NOT_TOOLTIP:
+      "Komplement: Elemente des Universums, die nicht in der Menge sind (Manchester not).",
     LANGUAGE_LABEL: "Sprache",
     UI_LANGUAGE_LABEL: "UI",
     MODEL_LANGUAGE_LABEL: "Modell",
@@ -218,6 +290,25 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     FOR_EACH_SOURCE_DO: "hacer",
     FOR_EACH_SOURCE_TOOLTIP:
       "Recorre cada nodo coincidente con una ruta de origen. El nodo actual se guarda en la variable indicada.",
+    LOGIC_AS: "como",
+    LOGIC_ONLY: "only",
+    LOGIC_SOME: "some",
+    LOGIC_NONE: "none",
+    LOGIC_MIN: "min",
+    LOGIC_MAX: "max",
+    LOGIC_EXACTLY: "exactly",
+    LOGIC_SET_AND: "and",
+    LOGIC_SET_OR: "or",
+    LOGIC_SET_NOT: "not",
+    LOGIC_SET_IN: "en",
+    LOGIC_QUANTIFY_TOOLTIP:
+      "Evalúa una lista como OWL Manchester only/some/none (∀/∃). Lista vacía: only y none verdaderos; some falso.",
+    LOGIC_CARDINALITY_TOOLTIP:
+      "Cuenta elementos de la lista que cumplen un predicado: min n (≥), max n (≤) o exactly n.",
+    LOGIC_SET_OP_TOOLTIP:
+      "Combina dos listas como clases: and = intersección, or = unión.",
+    LOGIC_SET_NOT_TOOLTIP:
+      "Complemento: elementos del universo que no están en el conjunto (Manchester not).",
     LANGUAGE_LABEL: "Idioma",
     UI_LANGUAGE_LABEL: "IU",
     MODEL_LANGUAGE_LABEL: "Modelo",
@@ -260,6 +351,25 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     FOR_EACH_SOURCE_DO: "fes",
     FOR_EACH_SOURCE_TOOLTIP:
       "Recorre cada node que coincideix amb un camí d'origen. El node actual es desa a la variable indicada.",
+    LOGIC_AS: "com",
+    LOGIC_ONLY: "only",
+    LOGIC_SOME: "some",
+    LOGIC_NONE: "none",
+    LOGIC_MIN: "min",
+    LOGIC_MAX: "max",
+    LOGIC_EXACTLY: "exactly",
+    LOGIC_SET_AND: "and",
+    LOGIC_SET_OR: "or",
+    LOGIC_SET_NOT: "not",
+    LOGIC_SET_IN: "en",
+    LOGIC_QUANTIFY_TOOLTIP:
+      "Avalua una llista com OWL Manchester only/some/none (∀/∃). Llista buida: only i none verdaders; some fals.",
+    LOGIC_CARDINALITY_TOOLTIP:
+      "Compta elements de la llista que compleixen un predicat: min n (≥), max n (≤) o exactly n.",
+    LOGIC_SET_OP_TOOLTIP:
+      "Combina dues llistes com a classes: and = intersecció, or = unió.",
+    LOGIC_SET_NOT_TOOLTIP:
+      "Complement: elements de l'univers que no són al conjunt (Manchester not).",
     LANGUAGE_LABEL: "Idioma",
     UI_LANGUAGE_LABEL: "IU",
     MODEL_LANGUAGE_LABEL: "Model",
@@ -302,6 +412,25 @@ const TABLE: Record<IntehrLocale, IntehrMessages> = {
     FOR_EACH_SOURCE_DO: "faire",
     FOR_EACH_SOURCE_TOOLTIP:
       "Boucle sur chaque nœud correspondant à un chemin source. Le nœud courant est stocké dans la variable nommée.",
+    LOGIC_AS: "comme",
+    LOGIC_ONLY: "only",
+    LOGIC_SOME: "some",
+    LOGIC_NONE: "none",
+    LOGIC_MIN: "min",
+    LOGIC_MAX: "max",
+    LOGIC_EXACTLY: "exactly",
+    LOGIC_SET_AND: "and",
+    LOGIC_SET_OR: "or",
+    LOGIC_SET_NOT: "not",
+    LOGIC_SET_IN: "dans",
+    LOGIC_QUANTIFY_TOOLTIP:
+      "Évalue une liste comme OWL Manchester only/some/none (∀/∃). Liste vide : only et none vrais ; some faux.",
+    LOGIC_CARDINALITY_TOOLTIP:
+      "Compte les éléments de liste qui satisfont un prédicat : min n (≥), max n (≤) ou exactly n.",
+    LOGIC_SET_OP_TOOLTIP:
+      "Combine deux listes comme des classes : and = intersection, or = union.",
+    LOGIC_SET_NOT_TOOLTIP:
+      "Complément : éléments de l'univers absents de l'ensemble (Manchester not).",
     LANGUAGE_LABEL: "Langue",
     UI_LANGUAGE_LABEL: "IU",
     MODEL_LANGUAGE_LABEL: "Modèle",

--- a/src/blockly/mod.ts
+++ b/src/blockly/mod.ts
@@ -15,6 +15,7 @@ import { registerExpressionBlocks } from "./blocks/expression_blocks.ts";
 import { registerMapBlocks } from "./blocks/map_blocks.ts";
 import { registerSheetBlocks } from "./blocks/sheet_blocks.ts";
 import { registerTextBlocks } from "./blocks/text_blocks.ts";
+import { registerLogicBlocks } from "./blocks/logic_blocks.ts";
 import { registerExtractToFunctionMenu } from "./extract_function.ts";
 import { registerTypeScriptExportAdapter } from "./typescript_codegen.ts";
 import { blockToExpression } from "./expression_serialize.ts";
@@ -127,6 +128,7 @@ export function initBlocklyGenerators(): void {
   registerMapBlocks();
   registerSheetBlocks();
   registerTextBlocks();
+  registerLogicBlocks();
   registerExtractToFunctionMenu();
   registerGenerators();
   registerTypeScriptExportAdapter();
@@ -311,6 +313,58 @@ function registerGenerators(): void {
     const script = javascriptGenerator.valueToCode(block, "SCRIPT", Order.NONE) || '""';
     const context = javascriptGenerator.valueToCode(block, "CONTEXT", Order.NONE) || "{}";
     return [`renderHandlebars(${script}, ${context})`, Order.FUNCTION_CALL] as [string, number];
+  };
+
+  javascriptGenerator.forBlock["logic_quantify"] = (block) => {
+    const list = javascriptGenerator.valueToCode(block, "LIST", Order.NONE) || "[]";
+    const pred = javascriptGenerator.valueToCode(block, "PRED", Order.NONE) || "true";
+    const name = block.getField("VAR")?.getText() ?? "item";
+    const ident = /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : "_item";
+    const bind = `(__vars[${JSON.stringify(name)}] = ${ident}, ${pred})`;
+    const arr = `asList(${list})`;
+    const op = String(block.getFieldValue("OP") ?? "ONLY");
+    const code = op === "SOME"
+      ? `${arr}.some((${ident}) => ${bind})`
+      : op === "NONE"
+      ? `${arr}.every((${ident}) => !${bind})`
+      : `${arr}.every((${ident}) => ${bind})`;
+    return [code, Order.FUNCTION_CALL] as [string, number];
+  };
+
+  javascriptGenerator.forBlock["logic_cardinality"] = (block) => {
+    const list = javascriptGenerator.valueToCode(block, "LIST", Order.NONE) || "[]";
+    const n = javascriptGenerator.valueToCode(block, "N", Order.NONE) || "0";
+    const pred = javascriptGenerator.valueToCode(block, "PRED", Order.NONE) || "true";
+    const name = block.getField("VAR")?.getText() ?? "item";
+    const ident = /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) ? name : "_item";
+    const bind = `(__vars[${JSON.stringify(name)}] = ${ident}, ${pred})`;
+    const count = `asList(${list}).filter((${ident}) => ${bind}).length`;
+    const op = String(block.getFieldValue("OP") ?? "MIN");
+    const code = op === "MAX"
+      ? `${count} <= ${n}`
+      : op === "EXACTLY"
+      ? `${count} === ${n}`
+      : `${count} >= ${n}`;
+    return [code, Order.FUNCTION_CALL] as [string, number];
+  };
+
+  javascriptGenerator.forBlock["logic_set_operation"] = (block) => {
+    const a = javascriptGenerator.valueToCode(block, "A", Order.NONE) || "[]";
+    const b = javascriptGenerator.valueToCode(block, "B", Order.NONE) || "[]";
+    const op = String(block.getFieldValue("OP") ?? "AND");
+    const code = op === "OR"
+      ? `setUnion(asList(${a}), asList(${b}))`
+      : `setIntersection(asList(${a}), asList(${b}))`;
+    return [code, Order.FUNCTION_CALL] as [string, number];
+  };
+
+  javascriptGenerator.forBlock["logic_set_not"] = (block) => {
+    const set = javascriptGenerator.valueToCode(block, "SET", Order.NONE) || "[]";
+    const universe = javascriptGenerator.valueToCode(block, "UNIVERSE", Order.NONE) || "[]";
+    return [
+      `setDifference(asList(${universe}), asList(${set}))`,
+      Order.FUNCTION_CALL,
+    ] as [string, number];
   };
 
   javascriptGenerator.forBlock["composition"] = (block) => {

--- a/src/blockly/toolbox_demo.ts
+++ b/src/blockly/toolbox_demo.ts
@@ -254,6 +254,47 @@ export function buildDemoToolbox(locale: string, context: ToolboxContext = {}): 
           { kind: "block", type: "logic_negate" },
           { kind: "block", type: "logic_boolean" },
           { kind: "block", type: "logic_ternary" },
+          {
+            kind: "block",
+            type: "logic_quantify",
+            fields: { OP: "ONLY" },
+          },
+          {
+            kind: "block",
+            type: "logic_quantify",
+            fields: { OP: "SOME" },
+          },
+          {
+            kind: "block",
+            type: "logic_quantify",
+            fields: { OP: "NONE" },
+          },
+          {
+            kind: "block",
+            type: "logic_cardinality",
+            fields: { OP: "MIN" },
+            inputs: {
+              N: { shadow: { type: "math_number", fields: { NUM: 1 } } },
+            },
+          },
+          {
+            kind: "block",
+            type: "logic_cardinality",
+            fields: { OP: "MAX" },
+            inputs: {
+              N: { shadow: { type: "math_number", fields: { NUM: 1 } } },
+            },
+          },
+          {
+            kind: "block",
+            type: "logic_cardinality",
+            fields: { OP: "EXACTLY" },
+            inputs: {
+              N: { shadow: { type: "math_number", fields: { NUM: 1 } } },
+            },
+          },
+          { kind: "block", type: "logic_set_operation" },
+          { kind: "block", type: "logic_set_not" },
         ],
       },
       {

--- a/src/core/ai/mod.ts
+++ b/src/core/ai/mod.ts
@@ -73,6 +73,13 @@ const VALUE_BLOCK_TYPES = new Set([
   "text_join",
   "math_arithmetic",
   "logic_ternary",
+  "logic_compare",
+  "logic_operation",
+  "logic_negate",
+  "logic_quantify",
+  "logic_cardinality",
+  "logic_set_operation",
+  "logic_set_not",
 ]);
 
 const MULTIPART_BOUNDARY = "intehrgrator-part";
@@ -1044,6 +1051,73 @@ function blockJsonToExpression(
       };
       const op = opMap[String(fields.OP ?? "ADD")] ?? "+";
       return `(${a} ${op} ${b})`;
+    }
+    case "logic_compare": {
+      const a = child("A") ? blockJsonToExpression(child("A")!, rewriteSourcePath) : "false";
+      const b = child("B") ? blockJsonToExpression(child("B")!, rewriteSourcePath) : "false";
+      const opMap: Record<string, string> = {
+        EQ: "eq",
+        NEQ: "ne",
+        LT: "lt",
+        LTE: "le",
+        GT: "gt",
+        GTE: "ge",
+      };
+      const fn = opMap[String(fields.OP ?? "EQ")] ?? "eq";
+      return `${fn}(${a}, ${b})`;
+    }
+    case "logic_operation": {
+      const a = child("A") ? blockJsonToExpression(child("A")!, rewriteSourcePath) : "false";
+      const b = child("B") ? blockJsonToExpression(child("B")!, rewriteSourcePath) : "false";
+      const fn = String(fields.OP ?? "AND") === "OR" ? "or" : "and";
+      return `${fn}(${a}, ${b})`;
+    }
+    case "logic_negate": {
+      const inner = child("BOOL")
+        ? blockJsonToExpression(child("BOOL")!, rewriteSourcePath)
+        : "false";
+      return `not(${inner})`;
+    }
+    case "logic_quantify": {
+      const list = child("LIST")
+        ? blockJsonToExpression(child("LIST")!, rewriteSourcePath)
+        : "list()";
+      const pred = child("PRED")
+        ? blockJsonToExpression(child("PRED")!, rewriteSourcePath)
+        : "true";
+      const name = JSON.stringify(String(fields.VAR ?? "item"));
+      const fn = String(fields.OP ?? "ONLY") === "SOME"
+        ? "any_of"
+        : String(fields.OP ?? "ONLY") === "NONE"
+        ? "none_of"
+        : "all_of";
+      return `${fn}(${list}, ${name}, ${pred})`;
+    }
+    case "logic_cardinality": {
+      const list = child("LIST")
+        ? blockJsonToExpression(child("LIST")!, rewriteSourcePath)
+        : "list()";
+      const n = child("N") ? blockJsonToExpression(child("N")!, rewriteSourcePath) : "0";
+      const pred = child("PRED")
+        ? blockJsonToExpression(child("PRED")!, rewriteSourcePath)
+        : "true";
+      const name = JSON.stringify(String(fields.VAR ?? "item"));
+      const op = String(fields.OP ?? "MIN");
+      const fn = op === "MAX" ? "at_most" : op === "EXACTLY" ? "exactly" : "at_least";
+      return `${fn}(${list}, ${n}, ${name}, ${pred})`;
+    }
+    case "logic_set_operation": {
+      const a = child("A") ? blockJsonToExpression(child("A")!, rewriteSourcePath) : "list()";
+      const b = child("B") ? blockJsonToExpression(child("B")!, rewriteSourcePath) : "list()";
+      const fn = String(fields.OP ?? "AND") === "OR" ? "union" : "intersection";
+      return `${fn}(${a}, ${b})`;
+    }
+    case "logic_set_not": {
+      const set = child("SET") ? blockJsonToExpression(child("SET")!, rewriteSourcePath) : "list()";
+      const universe = child("UNIVERSE")
+        ? blockJsonToExpression(child("UNIVERSE")!, rewriteSourcePath)
+        : "list()";
+      return `difference(${universe}, ${set})`;
     }
     default:
       return null;

--- a/src/core/codegen/go_template.ts
+++ b/src/core/codegen/go_template.ts
@@ -459,6 +459,16 @@ export function emitGoExpr(ast: ExprAst): string {
           const els = ast.args[2] ? emitGoExpr(ast.args[2]) : '""';
           return `if ${cond} }}{{ ${then} }}{{ else }}{{ ${els} }}{{ end`;
         }
+        case "eq":
+          return `eq ${emitGoExpr(ast.args[0]!)} ${emitGoExpr(ast.args[1]!)}`;
+        case "ne":
+          return `ne ${emitGoExpr(ast.args[0]!)} ${emitGoExpr(ast.args[1]!)}`;
+        case "and":
+          return `and (${emitGoExpr(ast.args[0]!)}) (${emitGoExpr(ast.args[1]!)})`;
+        case "or":
+          return `or (${emitGoExpr(ast.args[0]!)}) (${emitGoExpr(ast.args[1]!)})`;
+        case "not":
+          return `not (${emitGoExpr(ast.args[0]!)})`;
         default:
           return `/* unsupported: ${ast.name} */`;
       }

--- a/src/core/codegen/typescript.ts
+++ b/src/core/codegen/typescript.ts
@@ -13,7 +13,7 @@
  */
 
 import type { MappingLoop, MappingModel, MappingSlot, SkeletonNode } from "../../types/mod.ts";
-import { parseExpression, type ExprAst } from "../expression/mod.ts";
+import { parseExpression, type ExprAst, isQuantifyCall } from "../expression/mod.ts";
 import { isAutoFixedValueSlot, LOCATABLE_TYPES } from "../rm_mandatory.ts";
 import { attributesFor } from "../rm_meta.ts";
 
@@ -40,7 +40,7 @@ export interface TsEmitContext {
   /** When set, relative source paths evaluate against this loop node. */
   loopVar?: string;
   types: Set<string>;
-  helpers: Set<"string" | "number" | "boolean" | "nodes" | "rm" | "node" | "handlebars" | "sheets">;
+  helpers: Set<"string" | "number" | "boolean" | "nodes" | "rm" | "node" | "handlebars" | "sheets" | "logic">;
 }
 
 export function createTsEmitContext(sourceVar = "sourceCtx.data"): TsEmitContext {
@@ -55,6 +55,7 @@ export function emitTsExpression(ast: ExprAst, ctx: TsEmitContext): string {
     case "binary":
       return `(${emitTsExpression(ast.left, ctx)} ${ast.op} ${emitTsExpression(ast.right, ctx)})`;
     case "call": {
+      if (isQuantifyCall(ast.name)) return emitQuantifierTs(ast, ctx);
       const args = ast.args.map((a) => emitTsExpression(a, ctx));
       switch (ast.name) {
         case "trim":
@@ -66,7 +67,39 @@ export function emitTsExpression(ast: ExprAst, ctx: TsEmitContext): string {
         case "switch":
           return emitSwitchTs(args);
         case "var":
+          ctx.helpers.add("logic");
           return `__vars[${args[0]}]`;
+        case "eq":
+          ctx.helpers.add("logic");
+          return `sameItem(${args[0]}, ${args[1]})`;
+        case "ne":
+          ctx.helpers.add("logic");
+          return `!sameItem(${args[0]}, ${args[1]})`;
+        case "lt":
+          return `(Number(${args[0]}) < Number(${args[1]}))`;
+        case "le":
+          return `(Number(${args[0]}) <= Number(${args[1]}))`;
+        case "gt":
+          return `(Number(${args[0]}) > Number(${args[1]}))`;
+        case "ge":
+          return `(Number(${args[0]}) >= Number(${args[1]}))`;
+        case "and":
+          return `(${args[0]} && ${args[1]})`;
+        case "or":
+          return `(${args[0]} || ${args[1]})`;
+        case "not":
+          return `!(${args[0]})`;
+        case "list":
+          return `[${args.join(", ")}]`;
+        case "intersection":
+          ctx.helpers.add("logic");
+          return `setIntersection(asList(${args[0]}), asList(${args[1]}))`;
+        case "union":
+          ctx.helpers.add("logic");
+          return `setUnion(asList(${args[0]}), asList(${args[1]}))`;
+        case "difference":
+          ctx.helpers.add("logic");
+          return `setDifference(asList(${args[0]}), asList(${args[1]}))`;
         case "maps_get":
           return emitMapsGet(ast, args);
         case "sheet_get_cell":
@@ -149,6 +182,40 @@ function emitXpathCall(
   return `${fn}(${pathCode}, ${node})`;
 }
 
+function emitQuantifierTs(
+  ast: Extract<ExprAst, { kind: "call" }>,
+  ctx: TsEmitContext,
+): string {
+  ctx.helpers.add("logic");
+  const card = ast.name === "at_least" || ast.name === "at_most" || ast.name === "exactly";
+  const listCode = emitTsExpression(ast.args[0]!, ctx);
+  const nCode = card ? emitTsExpression(ast.args[1]!, ctx) : "0";
+  const varAst = card ? ast.args[2] : ast.args[1];
+  const predAst = card ? ast.args[3] : ast.args[2];
+  const varName = varAst?.kind === "literal" ? String(varAst.value) : "item";
+  const ident = /^[A-Za-z_][A-Za-z0-9_]*$/.test(varName) ? varName : "_item";
+  const innerCtx: TsEmitContext = { ...ctx, loopVar: ident };
+  const predCode = predAst ? emitTsExpression(predAst, innerCtx) : "true";
+  const bind = `(__vars[${JSON.stringify(varName)}] = ${ident}, ${predCode})`;
+  const arr = `asList(${listCode})`;
+  switch (ast.name) {
+    case "all_of":
+      return `${arr}.every((${ident}) => ${bind})`;
+    case "any_of":
+      return `${arr}.some((${ident}) => ${bind})`;
+    case "none_of":
+      return `${arr}.every((${ident}) => !${bind})`;
+    case "at_least":
+      return `${arr}.filter((${ident}) => ${bind}).length >= ${nCode}`;
+    case "at_most":
+      return `${arr}.filter((${ident}) => ${bind}).length <= ${nCode}`;
+    case "exactly":
+      return `${arr}.filter((${ident}) => ${bind}).length === ${nCode}`;
+    default:
+      return "false";
+  }
+}
+
 function emitSwitchTs(args: string[]): string {
   if (args.length < 2) return "null";
   const discriminant = args[0];
@@ -184,7 +251,7 @@ export interface TypeScriptModuleParts {
   templateId: string;
   body: string;
   types: Set<string>;
-  helpers: Set<"string" | "number" | "boolean" | "nodes" | "rm" | "node" | "handlebars" | "sheets">;
+  helpers: Set<"string" | "number" | "boolean" | "nodes" | "rm" | "node" | "handlebars" | "sheets" | "logic">;
   rootType?: string;
   /** Where the RM tree was walked from. */
   source?: "blockly" | "skeleton" | "slots";
@@ -256,6 +323,11 @@ export function wrapTypeScriptModule(parts: TypeScriptModuleParts): string {
   }
   if (parts.helpers.has("sheets")) {
     lines.push(...indentLines(sheetHelpers(), 1));
+    lines.push("");
+  }
+  if (parts.helpers.has("logic")) {
+    lines.push("  const __vars: Record<string, unknown> = {};");
+    lines.push(...indentLines(logicHelpers(), 1));
     lines.push("");
   }
   for (const line of parts.body.split("\n")) {
@@ -346,6 +418,36 @@ function xpathHelpers(helpers: Set<string>): string[] {
   }
   while (lines.at(-1) === "") lines.pop();
   return lines;
+}
+
+function logicHelpers(): string[] {
+  return [
+    "function asList(value: unknown): unknown[] {",
+    "  if (Array.isArray(value)) return value;",
+    "  if (value == null) return [];",
+    "  return [value];",
+    "}",
+    "function sameItem(a: unknown, b: unknown): boolean {",
+    "  if (Object.is(a, b)) return true;",
+    "  if (a && b && typeof a === \"object\" && typeof b === \"object\") {",
+    "    try { return JSON.stringify(a) === JSON.stringify(b); } catch { return false; }",
+    "  }",
+    "  return false;",
+    "}",
+    "function setIntersection(a: unknown[], b: unknown[]): unknown[] {",
+    "  return a.filter((item) => b.some((other) => sameItem(item, other)));",
+    "}",
+    "function setUnion(a: unknown[], b: unknown[]): unknown[] {",
+    "  const out = [...a];",
+    "  for (const item of b) {",
+    "    if (!out.some((other) => sameItem(item, other))) out.push(item);",
+    "  }",
+    "  return out;",
+    "}",
+    "function setDifference(universe: unknown[], excluded: unknown[]): unknown[] {",
+    "  return universe.filter((item) => !excluded.some((other) => sameItem(item, other)));",
+    "}",
+  ];
 }
 
 function sheetHelpers(): string[] {

--- a/src/core/codegen/xquery.ts
+++ b/src/core/codegen/xquery.ts
@@ -8,7 +8,7 @@
  * See docs/future/xquery-export-investigation.md.
  */
 import type { MappingModel, MappingSlot } from "../../types/mod.ts";
-import { parseExpression, type ExprAst } from "../expression/mod.ts";
+import { parseExpression, type ExprAst, isQuantifyCall } from "../expression/mod.ts";
 
 export function generateXQuery(model: MappingModel): string {
   const slotBlocks = model.slots.map((slot) =>
@@ -202,16 +202,17 @@ function emitSlot(slot: MappingSlot): string[] {
 }
 
 /** Map Mapping Expression AST → XQuery 3.1 fragment (context variable `$source`). */
-export function emitXQueryExpr(ast: ExprAst): string {
+export function emitXQueryExpr(ast: ExprAst, env: { bind?: Record<string, string> } = {}): string {
   switch (ast.kind) {
     case "literal":
       if (typeof ast.value === "string") return xqString(ast.value);
       if (typeof ast.value === "boolean") return ast.value ? "true()" : "false()";
       return String(ast.value);
     case "binary":
-      return `(${emitXQueryExpr(ast.left)} ${ast.op} ${emitXQueryExpr(ast.right)})`;
+      return `(${emitXQueryExpr(ast.left, env)} ${ast.op} ${emitXQueryExpr(ast.right, env)})`;
     case "call": {
-      const args = ast.args.map(emitXQueryExpr);
+      if (isQuantifyCall(ast.name)) return emitQuantifierXq(ast, env);
+      const args = ast.args.map((a) => emitXQueryExpr(a, env));
       switch (ast.name) {
         case "trim":
           return `normalize-space(${args[0]})`;
@@ -221,9 +222,38 @@ export function emitXQueryExpr(ast: ExprAst): string {
           return `(if (${args[0]}) then ${args[1]} else ${args[2]})`;
         case "switch":
           return emitSwitchXq(args);
-        case "var":
+        case "var": {
+          const name = ast.args[0]?.kind === "literal" ? String(ast.args[0].value) : "";
+          if (name && env.bind?.[name]) return `$${env.bind[name]}`;
           return `$vars(${args[0]})`;
-    case "maps_get":
+        }
+        case "eq":
+          return `deep-equal(${args[0]}, ${args[1]})`;
+        case "ne":
+          return `not(deep-equal(${args[0]}, ${args[1]}))`;
+        case "lt":
+          return `(${args[0]} lt ${args[1]})`;
+        case "le":
+          return `(${args[0]} le ${args[1]})`;
+        case "gt":
+          return `(${args[0]} gt ${args[1]})`;
+        case "ge":
+          return `(${args[0]} ge ${args[1]})`;
+        case "and":
+          return `(${args[0]} and ${args[1]})`;
+        case "or":
+          return `(${args[0]} or ${args[1]})`;
+        case "not":
+          return `not(${args[0]})`;
+        case "list":
+          return `(${args.join(", ")})`;
+        case "intersection":
+          return `(${args[0]}[some $b in ${args[1]} satisfies deep-equal(., $b)])`;
+        case "union":
+          return `(${args[0]}, ${args[1]}[not(some $a in ${args[0]} satisfies deep-equal(., $a))])`;
+        case "difference":
+          return `(${args[0]}[not(some $b in ${args[1]} satisfies deep-equal(., $b))])`;
+        case "maps_get":
           return `(if (${args[0]} eq "defaults") then map:get($defaults, ${args[1]}) else ())`;
         case "sheet_get_cell":
         case "sheet_get_xy":
@@ -254,6 +284,38 @@ export function emitXQueryExpr(ast: ExprAst): string {
           return emitXPathCall("string-at", ast.args[0]);
       }
     }
+  }
+}
+
+function emitQuantifierXq(
+  ast: Extract<ExprAst, { kind: "call" }>,
+  env: { bind?: Record<string, string> },
+): string {
+  const card = ast.name === "at_least" || ast.name === "at_most" || ast.name === "exactly";
+  const list = emitXQueryExpr(ast.args[0]!, env);
+  const n = card ? emitXQueryExpr(ast.args[1]!, env) : "0";
+  const varAst = card ? ast.args[2] : ast.args[1];
+  const predAst = card ? ast.args[3] : ast.args[2];
+  const varName = varAst?.kind === "literal" ? String(varAst.value) : "item";
+  const ident = /^[A-Za-z_][A-Za-z0-9_]*$/.test(varName) ? varName : "item";
+  const inner = { bind: { ...env.bind, [varName]: ident } };
+  const pred = predAst ? emitXQueryExpr(predAst, inner) : "true()";
+  const counted = `count(for $${ident} in ${list} where ${pred} return $${ident})`;
+  switch (ast.name) {
+    case "all_of":
+      return `(every $${ident} in ${list} satisfies ${pred})`;
+    case "any_of":
+      return `(some $${ident} in ${list} satisfies ${pred})`;
+    case "none_of":
+      return `(every $${ident} in ${list} satisfies not(${pred}))`;
+    case "at_least":
+      return `(${counted} ge ${n})`;
+    case "at_most":
+      return `(${counted} le ${n})`;
+    case "exactly":
+      return `(${counted} eq ${n})`;
+    default:
+      return "false()";
   }
 }
 

--- a/src/core/expression/mod.ts
+++ b/src/core/expression/mod.ts
@@ -1,5 +1,20 @@
 import { SHEET_ACCESSOR_NAMES, type SheetAccessorName } from "../sheets/evaluate.ts";
 
+/** Boolean compare / connectives used by stock Logic blocks and DL predicates. */
+export const LOGIC_COMPARE_NAMES = ["eq", "ne", "lt", "le", "gt", "ge"] as const;
+export const LOGIC_BOOL_NAMES = ["and", "or", "not"] as const;
+/** Manchester-style restrictions over a list (∀/∃/cardinality). */
+export const LOGIC_QUANTIFY_NAMES = ["all_of", "any_of", "none_of"] as const;
+export const LOGIC_CARDINALITY_NAMES = ["at_least", "at_most", "exactly"] as const;
+/** Class/set operators: ∩ ∪ complement (relative to a universe). */
+export const LOGIC_SET_NAMES = ["intersection", "union", "difference"] as const;
+
+export type LogicCompareName = typeof LOGIC_COMPARE_NAMES[number];
+export type LogicBoolName = typeof LOGIC_BOOL_NAMES[number];
+export type LogicQuantifyName = typeof LOGIC_QUANTIFY_NAMES[number];
+export type LogicCardinalityName = typeof LOGIC_CARDINALITY_NAMES[number];
+export type LogicSetName = typeof LOGIC_SET_NAMES[number];
+
 export type ExprAst =
   | { kind: "literal"; value: string | number | boolean }
   | {
@@ -18,6 +33,12 @@ export type ExprAst =
       | "xpathNode"
       | "handlebars"
       | "map"
+      | "list"
+      | LogicCompareName
+      | LogicBoolName
+      | LogicQuantifyName
+      | LogicCardinalityName
+      | LogicSetName
       | SheetAccessorName;
     args: ExprAst[];
   }
@@ -37,8 +58,21 @@ const BUILTIN_NAMES = new Set([
   "maps_get",
   "handlebars",
   "map",
+  "list",
+  ...LOGIC_COMPARE_NAMES,
+  ...LOGIC_BOOL_NAMES,
+  ...LOGIC_QUANTIFY_NAMES,
+  ...LOGIC_CARDINALITY_NAMES,
+  ...LOGIC_SET_NAMES,
   ...SHEET_ACCESSOR_NAMES,
 ]);
+
+export function isQuantifyCall(
+  name: string,
+): name is LogicQuantifyName | LogicCardinalityName {
+  return (LOGIC_QUANTIFY_NAMES as readonly string[]).includes(name) ||
+    (LOGIC_CARDINALITY_NAMES as readonly string[]).includes(name);
+}
 
 export function parseExpression(source: string): ExprAst {
   const tokens = tokenize(source.trim());

--- a/src/core/source/query_runtime.ts
+++ b/src/core/source/query_runtime.ts
@@ -1,7 +1,10 @@
 import fontoxpath from "fontoxpath";
 import type { SourceFormatId } from "../../types/mod.ts";
 import type { ExprAst } from "../expression/mod.ts";
-import { parseExpression } from "../expression/mod.ts";
+import {
+  isQuantifyCall,
+  parseExpression,
+} from "../expression/mod.ts";
 import { renderHandlebars } from "../output/handlebars_dialect.ts";
 import { DEFAULTS_MAP_NAME } from "../defaults/factory.ts";
 import { evalSheetCall, isSheetAccessor } from "../sheets/evaluate.ts";
@@ -21,6 +24,11 @@ export interface SourceContext {
   xmlDocument?: Document;
   /** Loop variables (`for_each_source` VAR → current source node). */
   vars?: Record<string, unknown>;
+  /**
+   * When set, relative source paths walk this node instead of `json`.
+   * Used while evaluating a DL restriction predicate against a list item.
+   */
+  relativeRoot?: unknown;
   /** Named Maps (Defaults Map and others) for `maps_get`. */
   namedMaps?: Record<string, Record<string, unknown>>;
   /** Named Sheets for `sheet_*` accessors (ADR 0005). */
@@ -75,6 +83,16 @@ function evalAst(ast: ExprAst, ctx: SourceContext): unknown {
       break;
     }
     case "call": {
+      if (isQuantifyCall(ast.name)) return evalQuantifier(ast, ctx);
+      if (ast.name === "and") {
+        return ast.args.every((arg) => !!evalAst(arg, ctx));
+      }
+      if (ast.name === "or") {
+        return ast.args.some((arg) => !!evalAst(arg, ctx));
+      }
+      if (ast.name === "not") {
+        return !evalAst(ast.args[0]!, ctx);
+      }
       const args = ast.args.map((a) => evalAst(a, ctx));
       switch (ast.name) {
         case "trim":
@@ -83,6 +101,26 @@ function evalAst(ast: ExprAst, ctx: SourceContext): unknown {
           return args.map(String).join("");
         case "if":
           return args[0] ? args[1] : args[2];
+        case "eq":
+          return sameItem(args[0], args[1]);
+        case "ne":
+          return !sameItem(args[0], args[1]);
+        case "lt":
+          return Number(args[0]) < Number(args[1]);
+        case "le":
+          return Number(args[0]) <= Number(args[1]);
+        case "gt":
+          return Number(args[0]) > Number(args[1]);
+        case "ge":
+          return Number(args[0]) >= Number(args[1]);
+        case "list":
+          return args;
+        case "intersection":
+          return setIntersection(asList(args[0]), asList(args[1]));
+        case "union":
+          return setUnion(asList(args[0]), asList(args[1]));
+        case "difference":
+          return setDifference(asList(args[0]), asList(args[1]));
         case "xpath":
         case "xpathString":
           return xpathEval(String(args[0] ?? ""), ctx, "string");
@@ -144,11 +182,12 @@ function xpathEval(expr: string, ctx: SourceContext, type: string): unknown {
     const path = relative
       ? (trimmed === "." ? "$" : `$.${trimmed.replace(/^\./, "")}`)
       : trimmed;
+    const walkRoot = relative ? (ctx.relativeRoot ?? ctx.json) : ctx.json;
     if (/\[\*\]/.test(path)) {
-      return evalJsonWildcard(path, ctx.json);
+      return evalJsonWildcard(path, walkRoot);
     }
     if (relative) {
-      return walkJsonSegments(ctx.json, parseJsonAuthoringPath(path));
+      return walkJsonSegments(walkRoot, parseJsonAuthoringPath(path));
     }
     const query = toJsonXPath(expr);
     const variables = { source: ctx.json };
@@ -275,10 +314,12 @@ function coerceReturn(value: unknown, returnType: string): unknown {
 export function evalSourceNode(expr: string, ctx: SourceContext): unknown {
   const trimmed = expr.trim();
   if (ctx.kind === "json") {
+    const relative = isRelativeJsonPath(trimmed);
+    const root = relative ? (ctx.relativeRoot ?? ctx.json) : ctx.json;
     if (!trimmed || trimmed === "$" || trimmed === "." || trimmed === "/") {
-      return ctx.json;
+      return root;
     }
-    const nodes = collectJsonNodes(trimmed, ctx.json);
+    const nodes = collectJsonNodes(trimmed, root);
     return nodes.length <= 1 ? (nodes[0] ?? null) : nodes;
   }
   const documentNode = ctx.xmlDocument;
@@ -286,6 +327,81 @@ export function evalSourceNode(expr: string, ctx: SourceContext): unknown {
   const path = !trimmed || trimmed === "$" || trimmed === "." ? "/" : trimmed;
   const node = fontoxpath.evaluateXPathToFirstNode(path, documentNode);
   return xmlNodeToJson(node as Node | null);
+}
+
+export function asList(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value;
+  if (value == null) return [];
+  return [value];
+}
+
+export function sameItem(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a && b && typeof a === "object" && typeof b === "object") {
+    try {
+      return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+function evalQuantifier(
+  ast: Extract<ExprAst, { kind: "call" }>,
+  ctx: SourceContext,
+): boolean {
+  const card = ast.name === "at_least" || ast.name === "at_most" || ast.name === "exactly";
+  const list = asList(evalAst(ast.args[0]!, ctx));
+  const n = card ? Number(evalAst(ast.args[1]!, ctx)) : 0;
+  const varArg = card ? ast.args[2] : ast.args[1];
+  const pred = card ? ast.args[3] : ast.args[2];
+  const varName = String(evalAst(varArg ?? { kind: "literal", value: "item" }, ctx) ?? "item");
+  const matches = (item: unknown) => {
+    if (!pred) return true;
+    return !!evalAst(pred, itemContext(ctx, varName, item));
+  };
+  switch (ast.name) {
+    case "all_of":
+      return list.every(matches);
+    case "any_of":
+      return list.some(matches);
+    case "none_of":
+      return list.every((item) => !matches(item));
+    case "at_least":
+      return list.filter(matches).length >= n;
+    case "at_most":
+      return list.filter(matches).length <= n;
+    case "exactly":
+      return list.filter(matches).length === n;
+    default:
+      return false;
+  }
+}
+
+function itemContext(ctx: SourceContext, name: string, item: unknown): SourceContext {
+  return {
+    ...ctx,
+    vars: { ...(ctx.vars ?? {}), [name]: item },
+    relativeRoot: item,
+    data: item,
+  };
+}
+
+function setIntersection(a: unknown[], b: unknown[]): unknown[] {
+  return a.filter((item) => b.some((other) => sameItem(item, other)));
+}
+
+function setUnion(a: unknown[], b: unknown[]): unknown[] {
+  const out = [...a];
+  for (const item of b) {
+    if (!out.some((other) => sameItem(item, other))) out.push(item);
+  }
+  return out;
+}
+
+function setDifference(universe: unknown[], excluded: unknown[]): unknown[] {
+  return universe.filter((item) => !excluded.some((other) => sameItem(item, other)));
 }
 
 function xmlNodeToJson(node: Node | null): unknown {

--- a/test/blockly_i18n_test.ts
+++ b/test/blockly_i18n_test.ts
@@ -21,4 +21,7 @@ Deno.test("custom messages localize Source and for_each_source", () => {
   assertEquals(msg("en").UI_LANGUAGE_LABEL, "UI");
   assertEquals(msg("sv").MODEL_LANGUAGE_LABEL, "Modell");
   assertEquals(msg("fr").SOURCE_QUERY, "source");
+  assertEquals(msg("en").LOGIC_ONLY, "only");
+  assertEquals(msg("sv").LOGIC_AS, "som");
+  assertEquals(msg("de").LOGIC_SET_AND, "and");
 });

--- a/test/logic_blocks_test.ts
+++ b/test/logic_blocks_test.ts
@@ -1,0 +1,148 @@
+import { assert, assertEquals } from "@std/assert";
+import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
+import "blockly/blocks";
+import {
+  initBlocklyGenerators,
+  blockToExpression,
+} from "@intehrgrator/blockly/mod.ts";
+import { buildDemoToolbox, toolboxBlockTypes } from "@intehrgrator/blockly/toolbox_demo.ts";
+import { msg } from "@intehrgrator/blockly/i18n/custom_msg.ts";
+import {
+  LOGIC_CARDINALITY_BLOCK,
+  LOGIC_QUANTIFY_BLOCK,
+  LOGIC_SET_NOT_BLOCK,
+  LOGIC_SET_OPERATION_BLOCK,
+} from "@intehrgrator/blockly/blocks/logic_blocks.ts";
+
+let ready = false;
+function ensure(): void {
+  if (ready) return;
+  initBlocklyGenerators();
+  ready = true;
+}
+
+Deno.test("DL logic blocks are registered and in the Logic toolbox drawer", () => {
+  ensure();
+  for (const type of [
+    LOGIC_QUANTIFY_BLOCK,
+    LOGIC_CARDINALITY_BLOCK,
+    LOGIC_SET_OPERATION_BLOCK,
+    LOGIC_SET_NOT_BLOCK,
+  ]) {
+    assert(Blockly.Blocks[type], `missing block ${type}`);
+  }
+  const toolbox = buildDemoToolbox("en") as {
+    contents: Array<{ name?: string; contents?: Array<{ type?: string }> }>;
+  };
+  const logic = toolbox.contents.find((c) => c.name === msg("en").CAT_LOGIC);
+  const types = (logic?.contents ?? []).map((block) => block.type);
+  assert(types.includes(LOGIC_QUANTIFY_BLOCK));
+  assert(types.includes(LOGIC_CARDINALITY_BLOCK));
+  assert(types.includes(LOGIC_SET_OPERATION_BLOCK));
+  assert(types.includes(LOGIC_SET_NOT_BLOCK));
+  const indexed = toolboxBlockTypes(toolbox);
+  assert(indexed.includes(LOGIC_QUANTIFY_BLOCK), "toolbox search indexes quantify");
+});
+
+Deno.test("logic_quantify serializes to all_of / any_of / none_of", () => {
+  ensure();
+  const workspace = new Blockly.Workspace();
+  const block = workspace.newBlock(LOGIC_QUANTIFY_BLOCK);
+  block.setFieldValue("ONLY", "OP");
+  const list = workspace.newBlock("lists_create_with") as Blockly.Block & {
+    itemCount_?: number;
+    updateShape_?: () => void;
+  };
+  list.itemCount_ = 0;
+  list.updateShape_?.();
+  block.getInput("LIST")!.connection!.connect(list.outputConnection!);
+  const pred = workspace.newBlock("logic_boolean");
+  pred.setFieldValue("TRUE", "BOOL");
+  block.getInput("PRED")!.connection!.connect(pred.outputConnection!);
+  const expr = blockToExpression(block);
+  assert(expr?.startsWith("all_of("), expr ?? "");
+  assert(expr?.includes("list()"), expr ?? "");
+  assert(expr?.includes("true"), expr ?? "");
+
+  block.setFieldValue("SOME", "OP");
+  assert(blockToExpression(block)?.startsWith("any_of("));
+  block.setFieldValue("NONE", "OP");
+  assert(blockToExpression(block)?.startsWith("none_of("));
+  workspace.dispose();
+});
+
+Deno.test("logic_cardinality serializes to at_least / at_most / exactly", () => {
+  ensure();
+  const workspace = new Blockly.Workspace();
+  const block = workspace.newBlock(LOGIC_CARDINALITY_BLOCK);
+  block.setFieldValue("MIN", "OP");
+  const n = workspace.newBlock("math_number");
+  n.setFieldValue("3", "NUM");
+  block.getInput("N")!.connection!.connect(n.outputConnection!);
+  const pred = workspace.newBlock("logic_boolean");
+  pred.setFieldValue("TRUE", "BOOL");
+  block.getInput("PRED")!.connection!.connect(pred.outputConnection!);
+  const expr = blockToExpression(block)!;
+  assert(expr.startsWith("at_least("), expr);
+  assert(expr.includes(", 3, "), expr);
+  block.setFieldValue("EXACTLY", "OP");
+  assert(blockToExpression(block)?.startsWith("exactly("));
+  workspace.dispose();
+});
+
+Deno.test("set operators serialize to intersection / union / difference", () => {
+  ensure();
+  const workspace = new Blockly.Workspace();
+  const op = workspace.newBlock(LOGIC_SET_OPERATION_BLOCK);
+  op.setFieldValue("AND", "OP");
+  const a = workspace.newBlock("lists_create_with") as Blockly.Block & {
+    itemCount_?: number;
+    updateShape_?: () => void;
+  };
+  a.itemCount_ = 0;
+  a.updateShape_?.();
+  const b = workspace.newBlock("lists_create_with") as Blockly.Block & {
+    itemCount_?: number;
+    updateShape_?: () => void;
+  };
+  b.itemCount_ = 0;
+  b.updateShape_?.();
+  op.getInput("A")!.connection!.connect(a.outputConnection!);
+  op.getInput("B")!.connection!.connect(b.outputConnection!);
+  assertEquals(blockToExpression(op), "intersection(list(), list())");
+  op.setFieldValue("OR", "OP");
+  assertEquals(blockToExpression(op), "union(list(), list())");
+
+  const notBlock = workspace.newBlock(LOGIC_SET_NOT_BLOCK);
+  const set = workspace.newBlock("lists_create_with") as Blockly.Block & {
+    itemCount_?: number;
+    updateShape_?: () => void;
+  };
+  set.itemCount_ = 0;
+  set.updateShape_?.();
+  const universe = workspace.newBlock("lists_create_with") as Blockly.Block & {
+    itemCount_?: number;
+    updateShape_?: () => void;
+  };
+  universe.itemCount_ = 0;
+  universe.updateShape_?.();
+  notBlock.getInput("SET")!.connection!.connect(set.outputConnection!);
+  notBlock.getInput("UNIVERSE")!.connection!.connect(universe.outputConnection!);
+  assertEquals(blockToExpression(notBlock), "difference(list(), list())");
+  workspace.dispose();
+});
+
+Deno.test("logic_compare serializes so restriction predicates can use it", () => {
+  ensure();
+  const workspace = new Blockly.Workspace();
+  const cmp = workspace.newBlock("logic_compare");
+  cmp.setFieldValue("EQ", "OP");
+  const left = workspace.newBlock("text");
+  left.setFieldValue("Cat", "TEXT");
+  const right = workspace.newBlock("text");
+  right.setFieldValue("Cat", "TEXT");
+  cmp.getInput("A")!.connection!.connect(left.outputConnection!);
+  cmp.getInput("B")!.connection!.connect(right.outputConnection!);
+  assertEquals(blockToExpression(cmp), 'eq("Cat", "Cat")');
+  workspace.dispose();
+});

--- a/test/logic_dl_expression_test.ts
+++ b/test/logic_dl_expression_test.ts
@@ -1,0 +1,115 @@
+import { assertEquals } from "@std/assert";
+import { parseExpression, serialize } from "@intehrgrator/core/expression/mod.ts";
+import { createSourceContext, evaluate } from "@intehrgrator/core/source/query_runtime.ts";
+import { emitTsExpression, createTsEmitContext } from "@intehrgrator/core/codegen/typescript.ts";
+import { emitXQueryExpr } from "@intehrgrator/core/codegen/xquery.ts";
+
+const empty = () => createSourceContext("{}", "json");
+
+Deno.test("all_of is vacuously true on an empty list; any_of is false", () => {
+  const ctx = empty();
+  assertEquals(evaluate('all_of(list(), "x", true)', ctx, "boolean"), true);
+  assertEquals(evaluate('any_of(list(), "x", true)', ctx, "boolean"), false);
+  assertEquals(evaluate('none_of(list(), "x", true)', ctx, "boolean"), true);
+});
+
+Deno.test("all_of / any_of / none_of evaluate the predicate per item", () => {
+  const ctx = empty();
+  assertEquals(
+    evaluate('all_of(list(1, 2, 3), "x", gt(var("x"), 0))', ctx, "boolean"),
+    true,
+  );
+  assertEquals(
+    evaluate('all_of(list(1, 0, 3), "x", gt(var("x"), 0))', ctx, "boolean"),
+    false,
+  );
+  assertEquals(
+    evaluate('any_of(list(0, 0, 4), "x", gt(var("x"), 3))', ctx, "boolean"),
+    true,
+  );
+  assertEquals(
+    evaluate('none_of(list(1, 2), "x", eq(var("x"), 9))', ctx, "boolean"),
+    true,
+  );
+});
+
+Deno.test("cardinality restrictions count matching items", () => {
+  const ctx = empty();
+  assertEquals(
+    evaluate('at_least(list(1, 2, 3, 4), 3, "x", gt(var("x"), 1))', ctx, "boolean"),
+    true,
+  );
+  assertEquals(
+    evaluate('at_most(list(1, 2, 3), 1, "x", gt(var("x"), 2))', ctx, "boolean"),
+    true,
+  );
+  assertEquals(
+    evaluate('exactly(list(1, 2, 3), 2, "x", gt(var("x"), 1))', ctx, "boolean"),
+    true,
+  );
+  assertEquals(
+    evaluate('exactly(list(), 0, "x", true)', ctx, "boolean"),
+    true,
+  );
+});
+
+Deno.test("relative source paths in a restriction predicate walk each item", () => {
+  const ctx = createSourceContext(
+    JSON.stringify({ pets: [{ type: "Cat" }, { type: "Cat" }, { type: "Dog" }] }),
+    "json",
+  );
+  assertEquals(
+    evaluate('all_of(xpathNode("$.pets"), "pet", eq(xpathString("type"), "Cat"))', ctx, "boolean"),
+    false,
+  );
+  assertEquals(
+    evaluate('any_of(xpathNode("$.pets"), "pet", eq(xpathString("type"), "Dog"))', ctx, "boolean"),
+    true,
+  );
+  assertEquals(
+    evaluate('exactly(xpathNode("$.pets"), 2, "pet", eq(xpathString("type"), "Cat"))', ctx, "boolean"),
+    true,
+  );
+  assertEquals(
+    evaluate('none_of(xpathNode("$.pets"), "pet", eq(xpathString("type"), "Snake"))', ctx, "boolean"),
+    true,
+  );
+});
+
+Deno.test("set and/or/not are intersection, union, and complement", () => {
+  const ctx = empty();
+  assertEquals(evaluate('intersection(list(1, 2, 3), list(2, 3, 4))', ctx, "node"), [2, 3]);
+  assertEquals(evaluate('union(list(1, 2), list(2, 3))', ctx, "node"), [1, 2, 3]);
+  assertEquals(evaluate('difference(list(1, 2, 3), list(2))', ctx, "node"), [1, 3]);
+});
+
+Deno.test("boolean connectives and compare parse and evaluate", () => {
+  const ctx = empty();
+  assertEquals(evaluate("and(true, false)", ctx, "boolean"), false);
+  assertEquals(evaluate("or(false, true)", ctx, "boolean"), true);
+  assertEquals(evaluate("not(false)", ctx, "boolean"), true);
+  assertEquals(evaluate('eq("a", "a")', ctx, "boolean"), true);
+  assertEquals(evaluate("lt(1, 2)", ctx, "boolean"), true);
+});
+
+Deno.test("DL expressions round-trip through parse/serialize", () => {
+  const src = 'all_of(xpathNode("$.pets"), "pet", eq(xpathString("type"), "Cat"))';
+  assertEquals(serialize(parseExpression(src)), src);
+});
+
+Deno.test("TypeScript emit uses every/some and asList for restrictions", () => {
+  const ctx = createTsEmitContext();
+  const ast = parseExpression('all_of(list(1, 2), "x", gt(var("x"), 0))');
+  const code = emitTsExpression(ast, ctx);
+  assertEquals(ctx.helpers.has("logic"), true);
+  assertEquals(code.includes("asList"), true);
+  assertEquals(code.includes(".every("), true);
+  assertEquals(code.includes('__vars["x"]'), true);
+});
+
+Deno.test("XQuery emit uses every/some for restrictions", () => {
+  const ast = parseExpression('any_of(list(1, 2), "x", gt(var("x"), 0))');
+  const xq = emitXQueryExpr(ast);
+  assertEquals(xq.includes("some $x in"), true);
+  assertEquals(xq.includes("$x"), true);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Description Logic–style blocks to the Blockly **Logic** drawer so mappings can evaluate list/set content without hand-written loops.

## Restrictions (Boolean)

Manchester keywords over a list (the fillers of a role) and a predicate (class *C*):

- `logic_quantify`: `only` / `some` / `none` → `all_of` / `any_of` / `none_of` (∀/∃/∀¬)
- `logic_cardinality`: `min` / `max` / `exactly` n → `at_least` / `at_most` / `exactly`

Relative source paths in the predicate run against each item. Empty list: `only` and `none` are true, `some` is false.

## Set class operators (Array)

- `logic_set_operation`: `and` = intersection, `or` = union
- `logic_set_not`: `not [set] in [universe]` = complement

Stock `logic_compare` / `logic_operation` / `logic_negate` now serialize into Mapping Expressions so predicates work in Test Run, TypeScript, and XQuery.

## Tests

- `test/logic_dl_expression_test.ts` — evaluate + codegen
- `test/logic_blocks_test.ts` — toolbox + serialization

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-122feca0-c43c-4989-b785-7dca0e8b7002?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-122feca0-c43c-4989-b785-7dca0e8b7002&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

