### PR TITLE
docs: robustness, metamorphic correctness, VMS toolbox cut

### DIFF
--- a/docs/future/formal-verification-export.md
+++ b/docs/future/formal-verification-export.md
@@ -32,19 +32,90 @@ and [ADR 0003](../adr/0003-mapping-preview-vs-generated-script.md).
 
 ## What “correctness” could mean
 
-Layers worth supporting (not all need day-one proof):
+Layers worth supporting (not all need day-one proof). In an **integration**
+setting, “the mapping is correct” is rarely a single clinical theorem; it is a
+stack of **machine-checkable relations** between source schema, convert-time
+environment (Defaults Map, Sheets), mapping, and target schema/template.
 
-1. **Syntactic / schema correctness** — output conforms to target schema/template.
-2. **Structural correspondence** — source path *P* maps to target slot *S* under relation *R* (units, codes, cardinality).
-3. **Completeness / totality** — required target slots populated for all sources matching the source schema.
-4. **Semantic preservation** — no invented clinical meaning; terminologies and units respected.
-5. **Pipeline / grain properties** — loops do not duplicate or drop rows; repeated-container grain is consistent.
-6. **Round-trip** — forward ∘ inverse ≈ identity when an inverse mapping exists (interop scenarios).
+1. **Syntactic / schema correctness** — output conforms to target schema/template
+   (`TemplateValidator`, JSON Schema, XSD).
+2. **Structural correspondence** — source path *P* maps to target slot *S* under
+   relation *R* (units, codes, cardinality).
+3. **Completeness** — required target slots populated whenever the source
+   actually has the corresponding data (and the mapping claims that path).
+4. **Semantic preservation** — no invented clinical meaning; terminologies and
+   units respected.
+5. **Pipeline / grain properties** — loops do not duplicate or drop rows;
+   repeated-container grain is consistent.
+6. **Round-trip** — forward ∘ inverse ≈ identity when an inverse mapping exists
+   (interop scenarios).
+7. **Robustness / definedness (crash-freedom)** — see below.
+8. **Metamorphic / sensitivity** — see below.
 
 Full machine-checked proofs of (4)–(6) are hard in healthcare because source
 schemas are often partial and semantics under-specified. A practical goal is
 **strong falsification** (counterexamples) plus **contract documentation**, with
-optional proof slices for safety-critical mappings.
+optional proof slices for safety-critical mappings. Layers **(7)** and **(8)**
+are especially fitting for integration pipelines: they do not require a full
+clinical gold standard, yet they catch mappings that “work on the three demo
+files” and then explode or silently lie in production.
+
+### Robustness: no valid source should break the mapping
+
+Informally: *if the input is a legal source record, conversion must finish and
+must not emit garbage that looks like a target instance.*
+
+More formally, fix a source schema \(S\), convert-time environment \(E\)
+(Defaults Map + static Sheets), mapping \(m\), and target schema/template \(T\).
+For every source \(s \in S\):
+
+| Outcome | Meaning | Verdict |
+|---------|---------|---------|
+| **Defined + valid** | \(m(s, E)\) terminates and \(m(s, E) \in T\) | Success |
+| **Defined + incomplete** | Terminates; optional slots omitted; still in \(T\) (optionals allowed) | Success if those slots were optional |
+| **Rejected** | \(s \notin S\) or \(E\) fails its precondition | Not a mapping bug — document the precondition |
+| **Erroneous** | \(s \in S\) but convert **throws**, **hangs**, or returns a value **not in** \(T\) (half-built RM, wrong types, failed deserialize) | Mapping bug |
+
+“Erroneous” includes: uncaught XPath errors, `undefined` leaking from unhandled
+Blockly types, division by zero, template engines throwing on missing helpers,
+and producing JSON that the OPT validator then rejects when the source was
+schema-valid.
+
+This is **totality of convert on \(S\)** plus **soundness of output wrt \(T\)**.
+It is *not* “every optional clinical field is filled.” Empty optional slots are
+fine; **crash** and **invalid structure** are not.
+
+Testable today (PBT / generators from Source Schema):
+
+- generate many \(s \in S\); assert convert does not throw;
+- assert output passes `TemplateValidator` / JSON Schema / XSD;
+- treat timeouts and `undefined` slots on **mandatory** paths as failures.
+
+### Metamorphic / sensitivity: variation in input vs variation in output
+
+Informally: *changing the source in a way the mapping cares about should change
+the corresponding output; changing things the mapping ignores should not; adding
+another repeating item should add another target child.*
+
+This is **metamorphic testing**: relations between *pairs* of runs, without a
+full expected COMPOSITION for every input. Useful relations for mappings:
+
+| Relation | Typical check |
+|----------|----------------|
+| **Independence of unread fields** | Mutate JSON/XML nodes that no `source_query` reads → output unchanged (up to allowed metadata). Catches accidental whole-document Handlebars/`text_code` coupling. |
+| **Sensitivity of mapped fields** | Change a source value that a slot’s expression reads → that slot’s value changes, *unless* the mapping’s `if`/`switch` puts both values in the same equivalence class (then document the class). Catches dead mappings and always-constant slots. |
+| **Normalization invariance** | Extra whitespace, JSON key order, equivalent XML prefixes, Unicode NFC vs NFD on strings the mapping `trim`s → clinical values unchanged. |
+| **Loop grain / monotonicity** | Add one node to a `for_each_source` collection → target repeating container grows by one (no fan-trap / chasm-trap). Delete the last node → count decreases. |
+| **Determinism** | Same \((s, E)\) twice → identical output. Forbids `math_random_*` and hidden convert-time mutation (sheet mutators). |
+
+“Reasonable variation” is **not** mathematical continuity (coded values are
+discrete). It is: *the mapping’s declared dataflow explains the output delta.*
+If systolic goes 120 → 130, `DV_QUANTITY.magnitude` should follow; territory
+should not flip; an unread `comment` field should not rewrite `COMPOSITION.uid`.
+
+Function-level decision tables ([function-test-harnesses.md](function-test-harnesses.md))
+are the **specified points** on this surface; PBT plus metamorphic relations
+fill the gaps between those points.
 
 ## Candidate formalisms (ranked)
 
@@ -319,32 +390,44 @@ rules; JSON-LD / SHACL / description-logic approaches want a fixed target schema
 
 ### Proposed direction: Verifiable Mapping Subset (VMS)
 
-A practical near-term gate before mapping-contract export:
+**Do not implement codegen / Mapping Model coverage for hostile stock Blockly.**
+Prefer **removing those blocks from the toolbox** (see GitHub issue on
+verification-hostile blocks) so agents do not spend effort on
+`controls_whileUntil`, random numbers, sheet mutators, etc.
+
+After that cut, treat remaining constructs as:
 
 ```text
-VMS allowed:
-  source_query_* (literal paths), maps_get, sheet_get_* / sheet_lookup (static sheets),
-  trim, concat, if, switch, math on numbers, logic_ternary, term_pick,
-  for_each_source (one level, documented grain), target_structure / RM scaffold slots
+VMS allowed (implement fully, including Mapping Model + all exporters):
+  source_query_* (prefer literal paths), maps_get, sheet_get_* / sheet_lookup
+  (static sheets), trim, concat, if, switch, math_arithmetic / round / modulo /
+  constrain, logic_compare / operation / negate / boolean / ternary, term_pick,
+  for_each_source (documented grain), lists_create_with / getIndex (read-only),
+  target_structure / RM scaffold slots, variables_get (loop vars only)
 
-VMS escape hatch (marked unverified):
-  text_code, text_handlebars, json_object/xml_element ad-hoc trees,
-  sheet mutators, stock Blockly loops/variables, dynamic source paths
+VMS escape hatch (keep in toolbox for Kintegrate / Go snippets; mark unverified):
+  text_code, text_handlebars, ad-hoc json_object / xml_element trees,
+  dynamic (non-literal) source paths, procedures_defreturn (until function
+  harness lands)
 
-VMS forbidden for proof (warn or block):
-  controls_whileUntil, controls_repeat_ext, variables_set (if used for mapping)
+VMS remove from toolbox (do not implement):
+  controls_whileUntil, controls_repeat_ext, controls_for, controls_forEach,
+  controls_flow_statements, controls_if (statement; keep logic_ternary),
+  math_random_int / math_random_float, text_print, text_append,
+  lists_setIndex, lists_repeat, sheet mutators, variables_set
 ```
 
-Implement as a workspace linter (similar to constraint warnings) rather than
-removing blocks from the toolbox — informaticians retain full expressiveness;
-verification export documents what was checked.
+A workspace linter still warns on leftover escape hatches and on any removed
+types that survive in old Project Bundles (migrate or show a load warning).
 
 ## Open questions
 
 1. **Contract language surface** — YAML vs JSON vs a dedicated `.mapping-contract` extension; alignment with [AI_SUGGESTION_FORMAT.md](../AI_SUGGESTION_FORMAT.md).
 2. **Source schema as precondition** — how strongly to require a loaded Source Schema vs inferring from examples.
 3. **Loop grain** — whether to adopt grain-correctness style rules for `for_each_source` (see recent data-pipeline formalization literature).
-4. **Execution oracle** — verify against Mapping preview interpreter vs generated TypeScript/XQuery (ADR 0003 seam).
+5. **Execution oracle** — verify against Mapping preview interpreter vs generated TypeScript/XQuery (ADR 0003 seam).
+6. **Robustness generators** — how complete must Source Schema be before PBT can claim “no valid source crashes convert”?
+7. **Sensitivity vs equivalence classes** — when `switch` maps many codes to one target, how to declare that class so sensitivity checks do not false-fail.
 
 ## Related
 
@@ -363,6 +446,7 @@ verification export documents what was checked.
 - Healthcare mapping formal specs: FHIRconnect, OMOCL (archetype path → target field)
 - Verifiable declarative mappings (RML → OCaml + Gospel/Cameleer): [Towards Verifiable Declarative Mappings](https://edkamb.github.io/files/kgcw2026.pdf)
 - Grain correctness in data pipelines: [Grain Theory (arXiv:2601.00995)](https://arxiv.org/abs/2601.00995)
+- Metamorphic testing of transformations (relations between paired runs, no gold output per input): Chen et al., *Metamorphic Testing: A Review of Challenges and Opportunities*
 
 ## Question for parallel research
 

--- a/docs/future/formal-verification-export.md
+++ b/docs/future/formal-verification-export.md
@@ -214,7 +214,7 @@ extractor (`workspaceToModelJson`), and codegen adapters (`xquery.ts`,
 | **Canvas vs Mapping Model gap** | High — XQuery emits flat `slots[]` only; loops and skeleton nesting are open work | High — verifier must choose Blockly walk vs slot index vs preview interpreter |
 | **Template / string DSL blocks** | High — `handlebars()` / `text_code` collapse to opaque strings | High — unbounded string templates are not a decidable logic |
 | **Sheet mutators** | High — not in Mapping Model expressions | High — imperative convert-time state |
-| **Stock imperative Blockly** | Medium — in toolbox but mostly un-codegen'd | Medium — authors can build non-analysable control flow |
+| **Stock imperative Blockly** | High if left in toolbox — do **not** codegen; **remove** while/for/random/print/mutators | High — unbounded / non-deterministic / stateful |
 | **Dynamic source paths** | Medium — literal paths compile; dynamic paths need runtime helpers | Medium — symbolic XPath over JSON/XML is hard to bound |
 | **Optional RM / schema mutators** | Low–medium — structure is partly in `optionalRm[]` | Medium — attachment graph must be part of the contract |
 | **Finite enumerations (`term_pick`)** | Low — easy to emit | **Positive** — ideal for DL-style value constraints |

--- a/docs/future/formal-verification-export.md
+++ b/docs/future/formal-verification-export.md
@@ -391,9 +391,13 @@ rules; JSON-LD / SHACL / description-logic approaches want a fixed target schema
 ### Proposed direction: Verifiable Mapping Subset (VMS)
 
 **Do not implement codegen / Mapping Model coverage for hostile stock Blockly.**
-Prefer **removing those blocks from the toolbox** (see GitHub issue on
-verification-hostile blocks) so agents do not spend effort on
-`controls_whileUntil`, random numbers, sheet mutators, etc.
+Prefer **removing those blocks from the toolbox** ([issue #35](https://github.com/regionstockholm/intehrgrator/issues/35))
+so agents do not spend effort on `controls_whileUntil`, random numbers, sheet
+mutators, etc. Follow-ups: Mapping Model IR [#37](https://github.com/regionstockholm/intehrgrator/issues/37),
+preview/codegen equivalence [#38](https://github.com/regionstockholm/intehrgrator/issues/38),
+XQuery loops [#39](https://github.com/regionstockholm/intehrgrator/issues/39),
+VMS linter [#40](https://github.com/regionstockholm/intehrgrator/issues/40),
+robustness/metamorphic PBT [#41](https://github.com/regionstockholm/intehrgrator/issues/41).
 
 After that cut, treat remaining constructs as:
 

--- a/src/blockly/expression_serialize.ts
+++ b/src/blockly/expression_serialize.ts
@@ -187,10 +187,21 @@ export function blockToExpression(block: Block | null): string | null {
       return `not(${inner})`;
     }
     case "lists_create_with": {
+      // Expression-path lists (DL quantifiers) need every item serializable.
+      // Scaffolded coded-text / ordinal value-set lists hold DV_* shells that
+      // are not Mapping Expressions — return null so TypeScript canvas codegen
+      // falls through to emitListsCreate (new DV_CODED_TEXT / …).
       const count = Number((block as Block & { itemCount_?: number }).itemCount_ ?? 0);
       const parts: string[] = [];
       for (let i = 0; i < count; i++) {
-        parts.push(blockToExpression(block.getInputTargetBlock(`ADD${i}`)) ?? "false");
+        const child = block.getInputTargetBlock(`ADD${i}`);
+        if (!child) {
+          parts.push("null");
+          continue;
+        }
+        const part = blockToExpression(child);
+        if (part === null) return null;
+        parts.push(part);
       }
       return `list(${parts.join(", ")})`;
     }

--- a/test/logic_blocks_test.ts
+++ b/test/logic_blocks_test.ts
@@ -146,3 +146,26 @@ Deno.test("logic_compare serializes so restriction predicates can use it", () =>
   assertEquals(blockToExpression(cmp), 'eq("Cat", "Cat")');
   workspace.dispose();
 });
+
+Deno.test("lists_create_with of non-expression children does not fake list(false,…)", () => {
+  // Regression: DL list() serialization must not swallow scaffolded DV_* shells
+  // (coded-text / ordinal value sets) as false — TypeScript canvas codegen needs
+  // null so it can emitListsCreate with new DV_CODED_TEXT.
+  ensure();
+  const workspace = new Blockly.Workspace();
+  const list = workspace.newBlock("lists_create_with") as Blockly.Block & {
+    itemCount_?: number;
+    updateShape_?: () => void;
+  };
+  list.itemCount_ = 2;
+  list.updateShape_?.();
+  const a = workspace.newBlock("text");
+  a.setFieldValue("ok", "TEXT");
+  list.getInput("ADD0")!.connection!.connect(a.outputConnection!);
+  // Data-value shells are Mapping Spec structure, not Mapping Expressions.
+  const shell = workspace.newBlock("dv_coded_text");
+  shell.setFieldValue("DV_CODED_TEXT", "RM_TYPE");
+  list.getInput("ADD1")!.connection!.connect(shell.outputConnection!);
+  assertEquals(blockToExpression(list), null);
+  workspace.dispose();
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the merged formal-verification-export note (#34).

- Adds robustness (no valid source should crash convert or emit invalid target) and metamorphic/sensitivity properties
- Prefers **removing** verification-hostile Blockly from the toolbox before implementing Mapping Model/codegen for them
- Links GitHub issues: [#35](https://github.com/regionstockholm/intehrgrator/issues/35) (decide/remove blocks first), then [#37](https://github.com/regionstockholm/intehrgrator/issues/37)–[#41](https://github.com/regionstockholm/intehrgrator/issues/41)
- **Fixes CI:** Description Logic `lists_create_with` serialization no longer turns scaffolded `DV_*` shells into `list(false,…)` (regression from #36), restoring TypeScript canvas emit of `new DV_CODED_TEXT` for OPT value sets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1015f24e-4d8d-4cb6-a7ea-e12dd223dd30?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1015f24e-4d8d-4cb6-a7ea-e12dd223dd30&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

