### PR TITLE
Constraint Overlay Phase 1 on RM Blocks

### DIFF
--- a/src/blockly/blocks/rm_blocks.ts
+++ b/src/blockly/blocks/rm_blocks.ts
@@ -1229,25 +1229,53 @@ type ProhibitedRmRow = {
   effective: SlotCardinality;
 };
 
-function parseMutatorExtraState(
-  state: {
-    extras?: string[];
-    attrs?: string[];
-    prohibited?: ProhibitedRmRow[];
-  } | string | null,
-): { extras: string[]; attrs: string[]; prohibited: ProhibitedRmRow[] } {
-  if (state == null || state === "") return { extras: [], attrs: [], prohibited: [] };
-  const obj = typeof state === "string"
-    ? JSON.parse(state) as {
-      extras?: string[];
-      attrs?: string[];
-      prohibited?: ProhibitedRmRow[];
+type OptionalRmMutatorState = {
+  extras?: string[];
+  attrs?: string[];
+  prohibited?: ProhibitedRmRow[];
+  slotCards?: Record<string, SlotCardinality>;
+  rmCards?: Record<string, SlotCardinality>;
+};
+
+function parseSlotCardMap(raw: unknown): Record<string, SlotCardinality> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, SlotCardinality> = {};
+  for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!value || typeof value !== "object") continue;
+    const rec = value as { min?: unknown; max?: unknown };
+    const min = Number(rec.min ?? 0);
+    if (!Number.isFinite(min)) continue;
+    if (rec.max == null) {
+      out[name] = { min, max: null };
+      continue;
     }
+    const max = Number(rec.max);
+    out[name] = { min, max: Number.isFinite(max) ? max : null };
+  }
+  return out;
+}
+
+function parseMutatorExtraState(
+  state: OptionalRmMutatorState | string | null,
+): {
+  extras: string[];
+  attrs: string[];
+  prohibited: ProhibitedRmRow[];
+  slotCards: Record<string, SlotCardinality>;
+  rmCards: Record<string, SlotCardinality>;
+} {
+  if (state == null || state === "") {
+    return { extras: [], attrs: [], prohibited: [], slotCards: {}, rmCards: {} };
+  }
+  const obj = typeof state === "string"
+    ? JSON.parse(state) as OptionalRmMutatorState
     : state;
   return {
     extras: Array.isArray(obj.extras) ? obj.extras : [],
     attrs: Array.isArray(obj.attrs) ? obj.attrs : [],
     prohibited: Array.isArray(obj.prohibited) ? obj.prohibited : [],
+    slotCards: parseSlotCardMap(obj.slotCards),
+    rmCards: parseSlotCardMap(obj.rmCards),
   };
 }
 
@@ -1468,12 +1496,27 @@ function registerOptionalRmMutator(): void {
       const extras = this.extraInputs_ ?? [];
       xml.setAttribute("extras", JSON.stringify(extras));
       xml.setAttribute("attrs", JSON.stringify(presentAttributeNames(this)));
+      xml.setAttribute("slotCards", JSON.stringify(this.slotCardinalities_ ?? {}));
+      xml.setAttribute("rmCards", JSON.stringify(this.rmCardinalities_ ?? {}));
+      xml.setAttribute("prohibited", JSON.stringify(this.prohibitedAttributes_ ?? []));
       return xml;
     },
     domToMutation: function (this: Blockly.Block, xmlElement: Element) {
       const extras = JSON.parse(xmlElement.getAttribute("extras") || "[]") as string[];
       this.extraInputs_ = extras;
       const attrs = JSON.parse(xmlElement.getAttribute("attrs") || "[]") as string[];
+      this.slotCardinalities_ = parseSlotCardMap(
+        JSON.parse(xmlElement.getAttribute("slotCards") || "{}"),
+      );
+      this.rmCardinalities_ = parseSlotCardMap(
+        JSON.parse(xmlElement.getAttribute("rmCards") || "{}"),
+      );
+      const prohibited = JSON.parse(
+        xmlElement.getAttribute("prohibited") || "[]",
+      ) as ProhibitedRmRow[];
+      if (Array.isArray(prohibited) && prohibited.length) {
+        this.prohibitedAttributes_ = prohibited;
+      }
       restoreMutatorAttributes(this, extras, attrs);
     },
     saveExtraState: function (this: Blockly.Block) {
@@ -1481,18 +1524,22 @@ function registerOptionalRmMutator(): void {
         extras: this.extraInputs_ ?? [],
         attrs: presentAttributeNames(this),
         prohibited: this.prohibitedAttributes_ ?? [],
+        slotCards: this.slotCardinalities_ ?? {},
+        rmCards: this.rmCardinalities_ ?? {},
       };
     },
     loadExtraState: function (
       this: Blockly.Block,
-      state: {
-        extras?: string[];
-        attrs?: string[];
-        prohibited?: ProhibitedRmRow[];
-      } | string | null,
+      state: OptionalRmMutatorState | string | null,
     ) {
       const parsed = parseMutatorExtraState(state);
       this.extraInputs_ = parsed.extras;
+      if (Object.keys(parsed.slotCards).length) {
+        this.slotCardinalities_ = parsed.slotCards;
+      }
+      if (Object.keys(parsed.rmCards).length) {
+        this.rmCardinalities_ = parsed.rmCards;
+      }
       if (parsed.prohibited.length) this.prohibitedAttributes_ = parsed.prohibited;
       restoreMutatorAttributes(this, parsed.extras, parsed.attrs);
     },

--- a/src/blockly/blocks/rm_blocks.ts
+++ b/src/blockly/blocks/rm_blocks.ts
@@ -625,13 +625,15 @@ function appendRmAttributeInput(
     ? baseRmTypeName(typeName)
     : null;
   const card = cardinality ?? slotCardinalityFor(block, rmType, attr);
+  const rmCard = block.rmCardinalities_?.[attr] ?? rmAttributeCardinality(rmType, attr);
+  const labelOpts = { card, rmCard, rmType: slotType as string | undefined };
 
   if (slotType === "PARTY_REF" || typeName === "PARTY_REF") {
     const input = block.appendValueInput(rmAttributeInputName(attr))
       .setAlign(inputAlignRight());
     // Match party_ref block output check ("PARTY_REF"), not the block type id.
     input.setCheck(checkOverride ?? "PARTY_REF");
-    appendSlotLabel(input, attr, { card, rmType: "PARTY_REF" });
+    appendSlotLabel(input, attr, { ...labelOpts, rmType: "PARTY_REF" });
     return;
   }
 
@@ -641,7 +643,7 @@ function appendRmAttributeInput(
     const dvCheck = blocklyCheckForDv(listElement);
     // lists_create_with outputs "Array", not its block type name.
     input.setCheck(checkOverride ?? (dvCheck ? [dvCheck, "Array"] : "Array"));
-    appendSlotLabel(input, attr, { card, rmType: listElement });
+    appendSlotLabel(input, attr, { ...labelOpts, rmType: listElement });
     return;
   }
 
@@ -650,14 +652,14 @@ function appendRmAttributeInput(
       .setAlign(inputAlignRight());
     const check = checkOverride ?? puzzleCheckForAttr(rmType, attr, slotType);
     if (check) input.setCheck(check);
-    appendSlotLabel(input, attr, { card, rmType: slotType });
+    appendSlotLabel(input, attr, labelOpts);
     return;
   }
   const stmt = block.appendStatementInput(rmAttributeInputName(attr))
     .setAlign(inputAlignRight());
   const check = checkOverride ?? statementCheckForAttr(rmType, attr);
   if (check) stmt.setCheck(check);
-  appendSlotLabel(stmt, attr, { card, rmType: slotType });
+  appendSlotLabel(stmt, attr, labelOpts);
 }
 
 function puzzleCheckForAttr(
@@ -1095,6 +1097,7 @@ export const OPTIONAL_RM_MUTATOR_CONTAINER = "optional_rm_mutator_container";
 export const OPTIONAL_RM_MUTATOR_ITEM = "optional_rm_mutator_item";
 export const DV_FIELDS_MUTATOR_CONTAINER = "dv_fields_mutator_container";
 export const DV_FIELDS_MUTATOR_ITEM = "dv_fields_mutator_item";
+export const PROHIBITED_RM_INPUT_PREFIX = "PROHIBITED_";
 
 export type OptionalRmMutatorChange = {
   parent: Blockly.Block;
@@ -1122,6 +1125,8 @@ export function setOptionalRmPickHandler(
 /** Apply a mutator stack of optional RM extras (used by tests and the workbench seam). */
 export function composeOptionalRmExtras(block: Blockly.Block, names: string[]): void {
   if (!block.decompose || !block.compose) return;
+  const banned = prohibitedNameSet(block);
+  const allowed = names.filter((name) => name && !banned.has(name));
   const bubble = new Blockly.Workspace();
   try {
     const container = block.decompose(bubble);
@@ -1132,7 +1137,7 @@ export function composeOptionalRmExtras(block: Blockly.Block, names: string[]): 
       item = next;
     }
     let connection = container.getInput("STACK")?.connection ?? null;
-    for (const name of names) {
+    for (const name of allowed) {
       const quark = bubble.newBlock(OPTIONAL_RM_MUTATOR_ITEM);
       initSvgIfPresent(quark);
       if (name) applyMutatorItemLabel(quark, name, name);
@@ -1218,16 +1223,31 @@ function ensureDvFieldVisible(block: Blockly.Block, attrName: string): void {
   }
 }
 
+type ProhibitedRmRow = {
+  name: string;
+  rm: SlotCardinality;
+  effective: SlotCardinality;
+};
+
 function parseMutatorExtraState(
-  state: { extras?: string[]; attrs?: string[] } | string | null,
-): { extras: string[]; attrs: string[] } {
-  if (state == null || state === "") return { extras: [], attrs: [] };
+  state: {
+    extras?: string[];
+    attrs?: string[];
+    prohibited?: ProhibitedRmRow[];
+  } | string | null,
+): { extras: string[]; attrs: string[]; prohibited: ProhibitedRmRow[] } {
+  if (state == null || state === "") return { extras: [], attrs: [], prohibited: [] };
   const obj = typeof state === "string"
-    ? JSON.parse(state) as { extras?: string[]; attrs?: string[] }
+    ? JSON.parse(state) as {
+      extras?: string[];
+      attrs?: string[];
+      prohibited?: ProhibitedRmRow[];
+    }
     : state;
   return {
     extras: Array.isArray(obj.extras) ? obj.extras : [],
     attrs: Array.isArray(obj.attrs) ? obj.attrs : [],
+    prohibited: Array.isArray(obj.prohibited) ? obj.prohibited : [],
   };
 }
 
@@ -1259,14 +1279,35 @@ function optionalRmMutatorChoices(block: Blockly.Block): Array<[string, string]>
   for (const opt of getValidAttachments(rmType, {
     presentAttributes: locked,
     templateConstrained: locked,
+    prohibitedAttributes: prohibitedNameSet(block),
   })) {
     labels.set(opt.attributeName, opt.label);
   }
   for (const name of block.extraInputs_ ?? []) {
-    if (!labels.has(name)) labels.set(name, name);
+    if (!labels.has(name) && !prohibitedNameSet(block).has(name)) {
+      labels.set(name, name);
+    }
   }
   const rows = [...labels.entries()].map(([name, label]) => [label, name] as [string, string]);
   return rows.length ? rows : [["(none)", ""]];
+}
+
+function prohibitedNameSet(block: Blockly.Block): Set<string> {
+  return new Set((block.prohibitedAttributes_ ?? []).map((row) => row.name));
+}
+
+export function prohibitedRmInputName(attr: string): string {
+  return `${PROHIBITED_RM_INPUT_PREFIX}${attr}`;
+}
+
+function appendProhibitedMutatorRows(container: Blockly.Block, parent: Blockly.Block): void {
+  for (const row of parent.prohibitedAttributes_ ?? []) {
+    const input = container.appendDummyInput(prohibitedRmInputName(row.name));
+    appendSlotLabel(input, row.name, {
+      card: row.effective,
+      rmCard: row.rm,
+    });
+  }
 }
 
 function humanizeAttrName(name: string): string {
@@ -1439,28 +1480,37 @@ function registerOptionalRmMutator(): void {
       return {
         extras: this.extraInputs_ ?? [],
         attrs: presentAttributeNames(this),
+        prohibited: this.prohibitedAttributes_ ?? [],
       };
     },
     loadExtraState: function (
       this: Blockly.Block,
-      state: { extras?: string[]; attrs?: string[] } | string | null,
+      state: {
+        extras?: string[];
+        attrs?: string[];
+        prohibited?: ProhibitedRmRow[];
+      } | string | null,
     ) {
       const parsed = parseMutatorExtraState(state);
       this.extraInputs_ = parsed.extras;
+      if (parsed.prohibited.length) this.prohibitedAttributes_ = parsed.prohibited;
       restoreMutatorAttributes(this, parsed.extras, parsed.attrs);
     },
     decompose: function (this: Blockly.Block, workspace: Blockly.Workspace) {
       const labels = new Map(optionalRmMutatorChoices(this));
-      return stackMutatorItems(
+      const container = stackMutatorItems(
         workspace,
         OPTIONAL_RM_MUTATOR_CONTAINER,
         OPTIONAL_RM_MUTATOR_ITEM,
         this.extraInputs_ ?? [],
         labels,
       );
+      appendProhibitedMutatorRows(container, this);
+      return container;
     },
     compose: function (this: Blockly.Block, container: Blockly.Block) {
-      const next = namesFromMutatorStack(container);
+      const banned = prohibitedNameSet(this);
+      const next = namesFromMutatorStack(container).filter((name) => !banned.has(name));
       const prev = [...(this.extraInputs_ ?? [])];
       const connections = new Map<string, Blockly.Connection | null>();
       let item: Blockly.Block | null = container.getInputTargetBlock("STACK");
@@ -1494,6 +1544,7 @@ function registerOptionalRmMutator(): void {
       }
     },
     addInput_: function (this: Blockly.Block, name: string) {
+      if (prohibitedNameSet(this).has(name)) return;
       this.extraInputs_ = this.extraInputs_ ?? [];
       if (!this.extraInputs_.includes(name)) {
         this.extraInputs_.push(name);
@@ -1513,6 +1564,8 @@ function registerOptionalRmMutator(): void {
         const slotType = slotRmTypeForAttr(parentRm, name);
         const card = this.slotCardinalities_?.[name] ??
           rmAttributeCardinality(parentRm, name);
+        const rmCard = this.rmCardinalities_?.[name] ??
+          rmAttributeCardinality(parentRm, name);
         if (isRmValueAttribute(parentRm, name) || isPartyProxyType(slotType)) {
           const input = this.appendValueInput(`${OPTIONAL_INPUT_PREFIX}${name}`)
             .setAlign(inputAlignRight());
@@ -1520,12 +1573,12 @@ function registerOptionalRmMutator(): void {
             ? slotType
             : (slotType ? blocklyCheckForDv(slotType) : null);
           if (check) input.setCheck(check);
-          appendSlotLabel(input, name, { card, rmType: slotType });
+          appendSlotLabel(input, name, { card, rmCard, rmType: slotType });
           continue;
         }
         const stmt = this.appendStatementInput(`${OPTIONAL_INPUT_PREFIX}${name}`)
           .setAlign(inputAlignRight());
-        appendSlotLabel(stmt, name, { card, rmType: slotType });
+        appendSlotLabel(stmt, name, { card, rmCard, rmType: slotType });
       }
       enforceOpenEhrBlockLayout(this);
     },
@@ -1630,6 +1683,12 @@ declare module "blockly/core" {
     extraInputs_?: string[];
     extraDvFields_?: string[];
     slotCardinalities_?: Record<string, SlotCardinality>;
+    rmCardinalities_?: Record<string, SlotCardinality>;
+    prohibitedAttributes_?: Array<{
+      name: string;
+      rm: SlotCardinality;
+      effective: SlotCardinality;
+    }>;
     savedConnection_?: Blockly.Connection | null;
     firePlusClick?: () => void;
     addInput_?: (name: string) => void;

--- a/src/blockly/skeleton_loader.ts
+++ b/src/blockly/skeleton_loader.ts
@@ -1,7 +1,7 @@
 import type { BlockSvg, WorkspaceSvg } from "blockly/core";
 import type { AllowedOrdinal, AllowedValue, MappingLoop, MappingModel, SkeletonNode } from "../types/mod.ts";
 import { AUTO_FIXED_LOCATABLE_ATTRS } from "../core/rm_mandatory.ts";
-import { blockTypeForRm, isDataValueType } from "../core/rm_meta.ts";
+import { attributesFor, blockTypeForRm, isDataValueType } from "../core/rm_meta.ts";
 import { parseExpression } from "../core/expression/mod.ts";
 import { skeletonNodeForOptionalRm } from "../core/skeleton/generate_skeleton.ts";
 import { termSetById, termSetForMandatedCode, termSetForRmAttribute } from "../core/openehr_term_catalog.ts";
@@ -584,6 +584,7 @@ function buildContainerBlock(
   }
   block.slotCardinalities_ = cards;
   block.rmCardinalities_ = rmCards;
+  const rmAttrOrder = attributesFor(node.rmType).map((attr) => attr.name);
   block.prohibitedAttributes_ = (node.attributeConstraints ?? [])
     .filter((row) => row.prohibited)
     .flatMap((row) => {
@@ -591,7 +592,8 @@ function buildContainerBlock(
       const effective = parseSlotCardinality(row.effectiveCardinality);
       if (!rm || !effective) return [];
       return [{ name: row.name, rm, effective }];
-    });
+    })
+    .sort((a, b) => rmAttrOrder.indexOf(a.name) - rmAttrOrder.indexOf(b.name));
   syncRmAttributeInputs(block, node.rmType, attributes, cards);
 
   if (!isRoot && !block.outputConnection) {

--- a/src/blockly/skeleton_loader.ts
+++ b/src/blockly/skeleton_loader.ts
@@ -550,6 +550,9 @@ function buildContainerBlock(
     },
   );
 
+  const constraintByName = new Map(
+    (node.attributeConstraints ?? []).map((row) => [row.name, row]),
+  );
   const attributes = [
     ...new Set(
       visibleChildren
@@ -557,15 +560,38 @@ function buildContainerBlock(
         .filter((attr): attr is string => Boolean(attr)),
     ),
   ];
+  for (const row of node.attributeConstraints ?? []) {
+    if (row.prohibited) continue;
+    const effective = parseSlotCardinality(row.effectiveCardinality);
+    if (effective && effective.min >= 1 && !attributes.includes(row.name)) {
+      attributes.push(row.name);
+    }
+  }
   const cards: Record<string, SlotCardinality> = {};
+  const rmCards: Record<string, SlotCardinality> = {};
   for (const attr of attributes) {
     const kids = visibleChildren.filter((child) => child.rmAttribute === attr);
-    const raw = kids[0]?.slotCardinality ?? kids[0]?.multiplicity;
-    const parsed = parseSlotCardinality(raw) ??
+    const constraint = constraintByName.get(attr);
+    const effective = parseSlotCardinality(constraint?.effectiveCardinality) ??
+      parseSlotCardinality(kids[0]?.effectiveCardinality) ??
+      parseSlotCardinality(kids[0]?.slotCardinality ?? kids[0]?.multiplicity) ??
       rmAttributeCardinality(node.rmType, attr);
-    if (parsed) cards[attr] = parsed;
+    const rm = parseSlotCardinality(constraint?.rmCardinality) ??
+      parseSlotCardinality(kids[0]?.rmCardinality) ??
+      rmAttributeCardinality(node.rmType, attr);
+    if (effective) cards[attr] = effective;
+    if (rm) rmCards[attr] = rm;
   }
   block.slotCardinalities_ = cards;
+  block.rmCardinalities_ = rmCards;
+  block.prohibitedAttributes_ = (node.attributeConstraints ?? [])
+    .filter((row) => row.prohibited)
+    .flatMap((row) => {
+      const rm = parseSlotCardinality(row.rmCardinality);
+      const effective = parseSlotCardinality(row.effectiveCardinality);
+      if (!rm || !effective) return [];
+      return [{ name: row.name, rm, effective }];
+    });
   syncRmAttributeInputs(block, node.rmType, attributes, cards);
 
   if (!isRoot && !block.outputConnection) {

--- a/src/blockly/slot_cardinality.ts
+++ b/src/blockly/slot_cardinality.ts
@@ -1,17 +1,31 @@
 /**
  * Compact `[min..max]` labels on Blockly slots, bold when the live count
- * is outside the allowed range.
+ * is outside the allowed range. Interval math lives in `core/cardinality.ts`.
  */
 import type { Field, Input } from "blockly/core";
 import { Blockly } from "./blockly_core.ts";
-import { attributesFor } from "../core/rm_meta.ts";
+import {
+  type CardinalityInterval,
+  formatCardinalityBrackets,
+  isCardinalityMet as intervalIsMet,
+  parseCardinality,
+  rmAttributeInterval,
+} from "../core/cardinality.ts";
 
 export const SLOT_CARD_FIELD_PREFIX = "SLOT_CARD_";
 
-export interface SlotCardinality {
-  min: number;
-  max: number | null;
-}
+export type SlotCardinality = CardinalityInterval;
+
+export {
+  OVERLAY_DELTA,
+  constraintOverlayHelp,
+  formatCardinalityCompact,
+  intervalsEqual,
+  isProhibitedInterval,
+  isStrictNarrowing,
+  intervalFromAmAttribute,
+  intervalFromAmBound,
+} from "../core/cardinality.ts";
 
 // deno-lint-ignore no-explicit-any
 const FieldLabelBase = Blockly.FieldLabel as any;
@@ -60,37 +74,22 @@ export function slotCardinalityFieldName(inputName: string): string {
 
 /** Always `[n..m]` / `[n..*]`, including `[1..1]` rather than a bare `1`. */
 export function formatSlotCardinality(card: SlotCardinality): string {
-  const upper = card.max == null ? "*" : String(card.max);
-  return `[${card.min}..${upper}]`;
+  return formatCardinalityBrackets(card);
 }
 
 export function parseSlotCardinality(raw?: string | null): SlotCardinality | undefined {
-  if (!raw) return undefined;
-  const text = raw.trim().replace(/^\[/, "").replace(/\]$/, "");
-  if (text === "1") return { min: 1, max: 1 };
-  const star = /^(\d+)\.\.\*$/.exec(text);
-  if (star) return { min: Number(star[1]), max: null };
-  const range = /^(\d+)\.\.(\d+)$/.exec(text);
-  if (range) return { min: Number(range[1]), max: Number(range[2]) };
-  return undefined;
+  return parseCardinality(raw);
 }
 
 export function rmAttributeCardinality(
   rmType: string,
   attrName: string,
 ): SlotCardinality | undefined {
-  const meta = attributesFor(rmType).find((a) => a.name === attrName);
-  if (!meta?.multiplicity) return undefined;
-  return {
-    min: Number(meta.multiplicity.min ?? 0),
-    max: meta.multiplicity.max == null ? null : Number(meta.multiplicity.max),
-  };
+  return rmAttributeInterval(rmType, attrName);
 }
 
 export function isCardinalityMet(count: number, card: SlotCardinality): boolean {
-  if (count < card.min) return false;
-  if (card.max != null && count > card.max) return false;
-  return true;
+  return intervalIsMet(count, card);
 }
 
 /**

--- a/src/blockly/slot_label.ts
+++ b/src/blockly/slot_label.ts
@@ -17,7 +17,10 @@ import {
 } from "./rm_type_emoji.ts";
 import {
   formatSlotCardinality,
+  isStrictNarrowing,
   type SlotCardinality,
+  OVERLAY_DELTA,
+  constraintOverlayHelp,
 } from "./slot_cardinality.ts";
 
 export const SLOT_LABEL_FIELD_PREFIX = "SLOT_LABEL_";
@@ -54,6 +57,10 @@ export class FieldSlotLabel extends FieldLabelBase {
   max: number | null = 1;
   hasCard = false;
   unmet = false;
+  hasOverlay = false;
+  rmMin = 0;
+  rmMax: number | null = 1;
+  private hasRmCard_ = false;
   private rmType_ = "";
   /** Schema property docs when not using openEHR RM attribute tables. */
   private documentation_ = "";
@@ -69,6 +76,7 @@ export class FieldSlotLabel extends FieldLabelBase {
     attrLabel: string,
     options: {
       card?: SlotCardinality;
+      rmCard?: SlotCardinality;
       rmType?: string;
       documentation?: string;
     } = {},
@@ -80,8 +88,14 @@ export class FieldSlotLabel extends FieldLabelBase {
       this.min = options.card.min;
       this.max = options.card.max;
     }
+    if (options.rmCard) {
+      this.hasRmCard_ = true;
+      this.rmMin = options.rmCard.min;
+      this.rmMax = options.rmCard.max;
+    }
     this.rmType_ = options.rmType ?? "";
     this.documentation_ = (options.documentation ?? "").trim();
+    this.refreshOverlay_();
     this.refreshText_();
   }
 
@@ -97,7 +111,28 @@ export class FieldSlotLabel extends FieldLabelBase {
       this.min = card.min;
       this.max = card.max;
     }
+    this.refreshOverlay_();
     this.refreshText_();
+  }
+
+  setRmCardinality(card: SlotCardinality | undefined): void {
+    if (!card) {
+      this.hasRmCard_ = false;
+    } else {
+      this.hasRmCard_ = true;
+      this.rmMin = card.min;
+      this.rmMax = card.max;
+    }
+    this.refreshOverlay_();
+    this.refreshText_();
+  }
+
+  overlayHelp(): string {
+    if (!this.hasOverlay) return "";
+    return constraintOverlayHelp(
+      { min: this.rmMin, max: this.rmMax },
+      { min: this.min, max: this.max },
+    );
   }
 
   setRmType(rmType: string | undefined): void {
@@ -146,7 +181,20 @@ export class FieldSlotLabel extends FieldLabelBase {
   }
 
   isClickableInFlyout(): boolean {
-    return this.hasAttrHelp_() || this.isAbstractSlot_();
+    return this.hasAttrHelp_() || this.isAbstractSlot_() || this.hasOverlay;
+  }
+
+  private refreshOverlay_(): void {
+    this.hasOverlay = Boolean(
+      this.hasCard &&
+        this.hasRmCard_ &&
+        isStrictNarrowing(
+          { min: this.rmMin, max: this.rmMax },
+          { min: this.min, max: this.max },
+        ),
+    );
+    const help = this.overlayHelp();
+    this.setTooltip?.(help || "");
   }
 
   private isAbstractSlot_(): boolean {
@@ -175,14 +223,22 @@ export class FieldSlotLabel extends FieldLabelBase {
 
   private refreshText_(): void {
     const parts = [this.attrLabel];
-    if (this.hasCard) {
+    if (this.hasOverlay) {
+      parts.push(
+        OVERLAY_DELTA,
+        formatSlotCardinality({ min: this.min, max: this.max }),
+        formatSlotCardinality({ min: this.rmMin, max: this.rmMax }),
+      );
+    } else if (this.hasCard) {
       parts.push(formatSlotCardinality({ min: this.min, max: this.max }));
     }
     const glyph = connectionPointGlyph(this.rmType_ || undefined, true);
     // Abstract ⁇ is drawn as an underlined tspan so only the glyph is linked-looking.
     if (glyph && !this.isAbstractSlot_()) parts.push(glyph);
     this.setValue(parts.join(" "));
-    this.CURSOR = this.hasAttrHelp_() || this.isAbstractSlot_() ? "pointer" : "default";
+    this.CURSOR = this.hasAttrHelp_() || this.isAbstractSlot_() || this.hasOverlay
+      ? "pointer"
+      : "default";
     this.syncClass_();
     this.syncTipAttr_();
     this.updateSize_?.();
@@ -213,11 +269,18 @@ export class FieldSlotLabel extends FieldLabelBase {
     const card = this.hasCard
       ? formatSlotCardinality({ min: this.min, max: this.max })
       : "";
+    const rmCard = this.hasOverlay
+      ? formatSlotCardinality({ min: this.rmMin, max: this.rmMax })
+      : "";
     const concreteGlyph = !abstract
       ? (connectionPointGlyph(this.rmType_ || undefined, true) ?? "")
       : "";
     const fullParts = [this.attrLabel];
-    if (card) fullParts.push(card);
+    if (this.hasOverlay) {
+      fullParts.push(OVERLAY_DELTA, card, rmCard);
+    } else if (card) {
+      fullParts.push(card);
+    }
     if (abstract && glyph) fullParts.push(glyph);
     else if (concreteGlyph) fullParts.push(concreteGlyph);
     const full = fullParts.join(" ");
@@ -243,12 +306,21 @@ export class FieldSlotLabel extends FieldLabelBase {
     el.setAttribute("text-anchor", "start");
     el.setAttribute("x", "0");
     el.style.setProperty("font-size", `${bodyPx}px`, "important");
-    this.rebuildCaption_(el, card, abstract ? glyph : concreteGlyph, abstract, bodyPx, glyphPx);
+    this.rebuildCaption_(
+      el,
+      card,
+      rmCard,
+      abstract ? glyph : concreteGlyph,
+      abstract,
+      bodyPx,
+      glyphPx,
+    );
   }
 
   private rebuildCaption_(
     el: SVGTextElement,
     card: string,
+    rmCard: string,
     glyph: string,
     abstractGlyph: boolean,
     bodyPx: number,
@@ -285,7 +357,9 @@ export class FieldSlotLabel extends FieldLabelBase {
       el.appendChild(tspan);
       this.attrTspan_ = tspan;
     }
-    if (card) {
+    if (this.hasOverlay && card) {
+      appendOverlayTspans(el, this, card, rmCard, bodyPx);
+    } else if (card) {
       const cardNode = document.createTextNode(` ${card}`);
       el.appendChild(cardNode);
     }
@@ -335,6 +409,7 @@ export function appendSlotLabel(
   attrLabel: string,
   options: {
     card?: SlotCardinality;
+    rmCard?: SlotCardinality;
     rmType?: string;
     documentation?: string;
   } = {},
@@ -344,6 +419,7 @@ export function appendSlotLabel(
   if (existing && isSlotLabelField(existing)) {
     existing.attrLabel = attrLabel;
     existing.setCardinality(options.card);
+    existing.setRmCardinality(options.rmCard);
     existing.setRmType(options.rmType);
     existing.setDocumentation(options.documentation);
     return;
@@ -371,6 +447,87 @@ function cssClass(unmet: boolean, abstractSlot: boolean): string {
   if (unmet) parts.push("blockly-slot-label--unmet");
   if (abstractSlot) parts.push("blockly-slot-label--abstract");
   return parts.join(" ");
+}
+
+function appendOverlayTspans(
+  el: SVGTextElement,
+  field: FieldSlotLabel,
+  effective: string,
+  rm: string,
+  bodyPx: number,
+): void {
+  const help = field.overlayHelp();
+  const add = (className: string, text: string, leadingSpace: boolean): void => {
+    if (leadingSpace) el.appendChild(document.createTextNode(" "));
+    const tspan = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+    tspan.setAttribute("class", className);
+    tspan.textContent = text;
+    tspan.style.setProperty("font-size", `${bodyPx}px`, "important");
+    if (help) {
+      tspan.style.cursor = "pointer";
+      tspan.setAttribute("title", help);
+      tspan.addEventListener("mousedown", (event) => event.stopPropagation());
+      tspan.addEventListener("click", (event) => {
+        event.stopPropagation();
+        dismissSpecHelpPopup();
+        pinOverlayHelpTip(field, tspan);
+      });
+    }
+    el.appendChild(tspan);
+  };
+  add("blockly-slot-overlay-delta", OVERLAY_DELTA, true);
+  add("blockly-slot-overlay-effective", effective, true);
+  add("blockly-slot-overlay-rm", rm, true);
+}
+
+const OVERLAY_TIP_ID = "blockly-slot-overlay-tip";
+
+function pinOverlayHelpTip(field: FieldSlotLabel, anchor: Element): void {
+  if (typeof document === "undefined") return;
+  Blockly.Tooltip?.hide?.();
+  const text = field.overlayHelp();
+  if (!text) return;
+  let tip = document.getElementById(OVERLAY_TIP_ID);
+  if (tip && tip.dataset.anchor === field.pinId) {
+    dismissOverlayHelpTip();
+    return;
+  }
+  dismissOverlayHelpTip();
+  dismissSlotLabelTip();
+  tip = document.createElement("div");
+  tip.id = OVERLAY_TIP_ID;
+  tip.className = "blockly-rm-emoji-tip";
+  tip.dataset.anchor = field.pinId;
+  tip.textContent = text;
+  document.body.appendChild(tip);
+  anchorFloating(anchor, tip, {
+    placement: "bottom-start",
+    offset: 6,
+    fitSize: true,
+  });
+  const dismiss = (event: Event) => {
+    if (event.target instanceof Node && tip?.contains(event.target)) return;
+    dismissOverlayHelpTip();
+  };
+  const onKey = (event: KeyboardEvent) => {
+    if (event.key === "Escape") dismiss(event);
+  };
+  document.addEventListener("pointerdown", dismiss, true);
+  document.addEventListener("keydown", onKey, true);
+  (tip as HTMLElement & { _dismiss?: () => void })._dismiss = () => {
+    document.removeEventListener("pointerdown", dismiss, true);
+    document.removeEventListener("keydown", onKey, true);
+  };
+}
+
+function dismissOverlayHelpTip(): void {
+  if (typeof document === "undefined") return;
+  const tip = document.getElementById(OVERLAY_TIP_ID);
+  if (!tip) return;
+  const cleanup = (tip as HTMLElement & { _dismiss?: () => void })._dismiss;
+  cleanup?.();
+  stopAnchoring(tip);
+  tip.remove();
 }
 
 let measureCanvas: HTMLCanvasElement | null = null;

--- a/src/core/cardinality.ts
+++ b/src/core/cardinality.ts
@@ -124,7 +124,9 @@ export function intervalFromAmAttribute(attr: unknown): CardinalityInterval | un
   const rec = attr as {
     cardinality?: { interval?: unknown } | unknown;
     existence?: unknown;
+    is_prohibited?: unknown;
   };
+  if (rec.is_prohibited === true) return { min: 0, max: 0 };
   if (rec.cardinality) {
     const card = rec.cardinality as { interval?: unknown };
     const interval = card.interval ?? rec.cardinality;

--- a/src/core/cardinality.ts
+++ b/src/core/cardinality.ts
@@ -1,0 +1,147 @@
+/**
+ * Attribute existence/cardinality intervals: RM BMM vs effective OPT.
+ * Blockly captions and Constraint Overlay are a view of this pair.
+ */
+
+import { attributesFor } from "./rm_meta.ts";
+
+export type CardinalityInterval = {
+  min: number;
+  max: number | null;
+};
+
+/** Better Archetype Designer-style delta glyph for Constraint Overlay. */
+export const OVERLAY_DELTA = "Δ";
+
+/** Always `[n..m]` / `[n..*]`, including `[1..1]` rather than a bare `1`. */
+export function formatCardinalityBrackets(card: CardinalityInterval): string {
+  const upper = card.max == null ? "*" : String(card.max);
+  return `[${card.min}..${upper}]`;
+}
+
+/** Compact `1` / `0..1` / `0..*` form used on SkeletonNode strings. */
+export function formatCardinalityCompact(card: CardinalityInterval): string {
+  const upper = card.max == null ? "*" : String(card.max);
+  if (card.min === 1 && card.max === 1) return "1";
+  return `${card.min}..${upper}`;
+}
+
+export function parseCardinality(raw?: string | null): CardinalityInterval | undefined {
+  if (!raw) return undefined;
+  const text = raw.trim().replace(/^\[/, "").replace(/\]$/, "");
+  if (text === "1") return { min: 1, max: 1 };
+  const star = /^(\d+)\.\.\*$/.exec(text);
+  if (star) return { min: Number(star[1]), max: null };
+  const range = /^(\d+)\.\.(\d+)$/.exec(text);
+  if (range) return { min: Number(range[1]), max: Number(range[2]) };
+  return undefined;
+}
+
+export function intervalsEqual(
+  a: CardinalityInterval,
+  b: CardinalityInterval,
+): boolean {
+  return a.min === b.min && a.max === b.max;
+}
+
+/**
+ * True when `effective` is a strict narrowing of `rm` (higher min and/or
+ * lower max; unbounded `*` is wider than any finite max).
+ */
+export function isStrictNarrowing(
+  rm: CardinalityInterval,
+  effective: CardinalityInterval,
+): boolean {
+  if (effective.min > rm.min) return true;
+  if (rm.max == null && effective.max != null) return true;
+  if (rm.max != null && effective.max != null && effective.max < rm.max) {
+    return true;
+  }
+  return false;
+}
+
+export function isProhibitedInterval(card: CardinalityInterval): boolean {
+  return card.max === 0;
+}
+
+export function isCardinalityMet(
+  count: number,
+  card: CardinalityInterval,
+): boolean {
+  if (count < card.min) return false;
+  if (card.max != null && count > card.max) return false;
+  return true;
+}
+
+export function rmAttributeInterval(
+  rmType: string,
+  attrName: string,
+): CardinalityInterval | undefined {
+  const meta = attributesFor(rmType).find((a) => a.name === attrName);
+  if (!meta?.multiplicity) return undefined;
+  return {
+    min: Number(meta.multiplicity.min ?? 0),
+    max: meta.multiplicity.max == null ? null : Number(meta.multiplicity.max),
+  };
+}
+
+/**
+ * Parse AOM `Multiplicity_interval` / occurrences / existence objects
+ * (`lower`, `upper`, `upper_unbounded`).
+ */
+export function intervalFromAmBound(occ: unknown): CardinalityInterval | undefined {
+  if (!occ || typeof occ !== "object") return undefined;
+  const rec = occ as {
+    lower?: unknown;
+    upper?: unknown;
+    _upper?: unknown;
+    upper_unbounded?: unknown;
+    _upper_unbounded?: unknown | { value?: unknown };
+  };
+  const lower = Number(rec.lower ?? 0);
+  const unbounded = rec.upper_unbounded === true ||
+    rec._upper_unbounded === true ||
+    (typeof rec._upper_unbounded === "object" &&
+      rec._upper_unbounded?.value === true);
+  const upperRaw = rec.upper ?? rec._upper;
+  if (unbounded || upperRaw == null) {
+    return { min: Number.isFinite(lower) ? lower : 0, max: null };
+  }
+  const upper = Number(upperRaw);
+  if (Number.isNaN(upper) || upper < 0) {
+    return { min: lower > 0 ? 1 : 0, max: null };
+  }
+  return { min: Number.isFinite(lower) ? lower : 0, max: upper };
+}
+
+/**
+ * Effective interval of a C_ATTRIBUTE: container `cardinality` first,
+ * otherwise `existence`. Object occurrences are not used (mouths show
+ * attribute constraints only).
+ */
+export function intervalFromAmAttribute(attr: unknown): CardinalityInterval | undefined {
+  if (!attr || typeof attr !== "object") return undefined;
+  const rec = attr as {
+    cardinality?: { interval?: unknown } | unknown;
+    existence?: unknown;
+  };
+  if (rec.cardinality) {
+    const card = rec.cardinality as { interval?: unknown };
+    const interval = card.interval ?? rec.cardinality;
+    return intervalFromAmBound(interval);
+  }
+  if (rec.existence) return intervalFromAmBound(rec.existence);
+  return undefined;
+}
+
+export function constraintOverlayHelp(
+  rm: CardinalityInterval,
+  effective: CardinalityInterval,
+): string {
+  const rmText = formatCardinalityBrackets(rm);
+  const effText = formatCardinalityBrackets(effective);
+  if (isProhibitedInterval(effective)) {
+    return `RM ${rmText} is prohibited (${effText}) by the operational template.`;
+  }
+  return `RM ${rmText} narrowed to ${effText} by the operational template.`;
+}

--- a/src/core/rm_meta.ts
+++ b/src/core/rm_meta.ts
@@ -132,6 +132,8 @@ export function blocklyCheckForPrimitiveType(typeName: string): string | null {
 export interface AttachmentContext {
   presentAttributes: Set<string>;
   templateConstrained: Set<string>;
+  /** OPT-prohibited attributes (`max=0`) — listed in the mutator, never addable. */
+  prohibitedAttributes?: Set<string>;
 }
 
 /**
@@ -148,6 +150,7 @@ export function getValidAttachments(
     if (attr.mandatory) continue;
     if (context.presentAttributes.has(attr.name)) continue;
     if (context.templateConstrained.has(attr.name)) continue;
+    if (context.prohibitedAttributes?.has(attr.name)) continue;
 
     const base = baseRmTypeName(attr.typeName);
     if (isPrimitiveRmType(base)) continue;

--- a/src/core/skeleton/generate_skeleton.ts
+++ b/src/core/skeleton/generate_skeleton.ts
@@ -7,7 +7,12 @@ import {
   applyOperationalTemplateTermScopes,
   type TermScopeMeta,
 } from "ehrtslib/generation/term_scope.ts";
-import type { AllowedOrdinal, AllowedValue, SkeletonNode } from "../../types/mod.ts";
+import type {
+  AllowedOrdinal,
+  AllowedValue,
+  AttributeConstraint,
+  SkeletonNode,
+} from "../../types/mod.ts";
 import {
   blockTypeForRm,
   isAutoFixedValueSlot,
@@ -18,6 +23,14 @@ import {
 } from "../rm_mandatory.ts";
 import { withRmConstrainedFields } from "../rm_terminology.ts";
 import { isSubtypeOf } from "../rm_meta.ts";
+import {
+  formatCardinalityCompact,
+  intervalFromAmAttribute,
+  intervalFromAmBound,
+  isProhibitedInterval,
+  rmAttributeInterval,
+  type CardinalityInterval,
+} from "../cardinality.ts";
 import {
   archetypeShortName,
   availableOptLanguages,
@@ -203,12 +216,20 @@ function walkComplex(
 
   const children: SkeletonNode[] = [];
   const presentAttrs = new Set<string>();
+  const attributeConstraints: AttributeConstraint[] = [];
 
   for (const attr of (cObj.attributes ?? []) as AmObject[]) {
     const attrName = attr.rm_attribute_name as string | undefined;
     if (!attrName) continue;
     presentAttrs.add(attrName);
+    const rmInterval = rmAttributeInterval(rmType, attrName);
+    const effective = intervalFromAmAttribute(attr);
+    const constraint = attributeConstraintOf(attrName, rmInterval, effective);
+    if (constraint) attributeConstraints.push(constraint);
+    if (constraint?.prohibited) continue;
+
     const slotCard = multiplicityOfAttribute(attr);
+    const attrMandatory = (effective?.min ?? 0) >= 1;
     const childNodes = walkAttribute(
       attr,
       templateId,
@@ -220,6 +241,11 @@ function walkComplex(
     for (const child of childNodes) {
       child.rmAttribute = attrName;
       child.slotCardinality = slotCard ?? child.multiplicity;
+      if (constraint) {
+        child.rmCardinality = constraint.rmCardinality;
+        child.effectiveCardinality = constraint.effectiveCardinality;
+      }
+      if (attrMandatory) child.mandatory = true;
       applyRmConstrainedFields(child, rmType);
       children.push(child);
     }
@@ -238,6 +264,13 @@ function walkComplex(
     if (silent) {
       silent.rmAttribute = attrName;
       silent.slotCardinality = silent.slotCardinality ?? silent.multiplicity;
+      const silentRm = rmAttributeInterval(rmType, attrName);
+      if (silentRm) {
+        const compact = formatCardinalityCompact(silentRm);
+        silent.rmCardinality = silent.rmCardinality ?? compact;
+        silent.effectiveCardinality = silent.effectiveCardinality ??
+          silent.slotCardinality ?? compact;
+      }
       children.push(silent);
     }
   }
@@ -264,6 +297,7 @@ function walkComplex(
     multiplicity,
     children,
     attachmentPoint: slotPath,
+    ...(attributeConstraints.length ? { attributeConstraints } : {}),
   };
 }
 
@@ -499,10 +533,8 @@ function silentMandatoryRmType(parentType: string, attrName: string): string | n
 }
 
 function isMandatory(cObj: AmObject): boolean {
-  const occ = cObj.occurrences ?? cObj.existence;
-  if (!occ) return false;
-  const lower = Number(occ.lower ?? 0);
-  return lower > 0;
+  const occ = intervalFromAmBound(cObj.occurrences ?? cObj.existence);
+  return (occ?.min ?? 0) > 0;
 }
 
 const AQL_NAME_PRED = /^(.*),'([^']+)'$/;
@@ -545,32 +577,29 @@ function pathNodeSegment(nodeId: string | undefined, rmType: string): string {
 }
 
 export function multiplicityOfAm(cObj: AmObject): string | undefined {
-  const occ = cObj?.occurrences ?? cObj?.existence;
-  if (!occ) return undefined;
-  const lower = Number(occ.lower ?? 0);
-  const unbounded = occ.upper_unbounded === true ||
-    occ._upper_unbounded === true ||
-    occ._upper_unbounded?.value === true;
-  const upperRaw = occ.upper ?? occ._upper;
-  const upper = unbounded || upperRaw == null ? null : Number(upperRaw);
-  if (upper == null || Number.isNaN(upper) || upper < 0) {
-    return lower > 0 ? "1..*" : "0..*";
-  }
-  if (upper === 1) return lower > 0 ? "1" : "0..1";
-  return `${lower}..${upper}`;
+  const interval = intervalFromAmBound(cObj?.occurrences ?? cObj?.existence);
+  return interval ? formatCardinalityCompact(interval) : undefined;
 }
 
 function multiplicityOfAttribute(attr: AmObject): string | undefined {
-  if (!attr) return undefined;
-  const card = attr.cardinality;
-  if (card) {
-    const interval = card.interval ?? card;
-    return multiplicityOfAm({ occurrences: interval });
-  }
-  if (attr.existence) {
-    return multiplicityOfAm({ occurrences: attr.existence });
-  }
-  return undefined;
+  const interval = intervalFromAmAttribute(attr);
+  return interval ? formatCardinalityCompact(interval) : undefined;
+}
+
+function attributeConstraintOf(
+  name: string,
+  rm: CardinalityInterval | undefined,
+  effective: CardinalityInterval | undefined,
+): AttributeConstraint | undefined {
+  if (!rm && !effective) return undefined;
+  const rmCard = rm ?? effective!;
+  const effCard = effective ?? rm!;
+  return {
+    name,
+    rmCardinality: formatCardinalityCompact(rmCard),
+    effectiveCardinality: formatCardinalityCompact(effCard),
+    ...(isProhibitedInterval(effCard) ? { prohibited: true } : {}),
+  };
 }
 
 export function isRepeatingMultiplicity(multiplicity?: string): boolean {

--- a/src/types/mod.ts
+++ b/src/types/mod.ts
@@ -84,6 +84,20 @@ export interface MappingModel {
 
 export type SkeletonNodeKind = "container" | "value";
 
+/**
+ * RM BMM vs effective OPT interval for one Attribute mouth (or a prohibited
+ * Optional RM Insertion row). Blockly captions are a view of this pair.
+ */
+export interface AttributeConstraint {
+  name: string;
+  /** Compact RM BMM multiplicity, e.g. `0..1` / `0..*`. */
+  rmCardinality: string;
+  /** Compact effective OPT existence or cardinality. */
+  effectiveCardinality: string;
+  /** True when the OPT prohibits the attribute (`max=0`). */
+  prohibited?: boolean;
+}
+
 /** One member of a template-constrained coded/string value set. */
 export interface AllowedValue {
   code: string;
@@ -146,6 +160,15 @@ export interface SkeletonNode {
   multiplicity?: string;
   /** Cardinality of the parent attribute slot this node occupies. */
   slotCardinality?: string;
+  /** RM BMM multiplicity of the parent attribute this node occupies. */
+  rmCardinality?: string;
+  /** Effective OPT existence/cardinality of that parent attribute. */
+  effectiveCardinality?: string;
+  /**
+   * Per-attribute RM vs effective intervals on this RM class, including
+   * template-prohibited (`max=0`) attributes that never become mouths.
+   */
+  attributeConstraints?: AttributeConstraint[];
   /**
    * Free-text documentation for the help popup (JSON Schema `description`,
    * XSD `xs:documentation`). openEHR RM class/attr prose comes from ehrtslib

--- a/src/workbench/controller.ts
+++ b/src/workbench/controller.ts
@@ -1108,6 +1108,11 @@ export class WorkbenchController {
     return getValidAttachments(node.rmType, {
       presentAttributes: present,
       templateConstrained: present,
+      prohibitedAttributes: new Set(
+        (node.attributeConstraints ?? [])
+          .filter((row) => row.prohibited)
+          .map((row) => row.name),
+      ),
     });
   }
 

--- a/test/constraint_overlay_test.ts
+++ b/test/constraint_overlay_test.ts
@@ -99,6 +99,11 @@ function overlayFixtureOpt() {
                 existence: occ(0, 0),
                 children: [],
               },
+              {
+                rm_attribute_name: "state",
+                is_prohibited: true,
+                children: [],
+              },
             ],
           }],
         },
@@ -165,6 +170,11 @@ Deno.test("skeleton records RM vs effective intervals and prohibited attributes"
     observation.children.some((c) => c.rmAttribute === "protocol"),
     false,
   );
+
+  const state = observation.attributeConstraints?.find((c) => c.name === "state");
+  assert(state);
+  assertEquals(state.prohibited, true);
+  assertEquals(state.effectiveCardinality, "0..0");
 
   const dataChild = observation.children.find((c) => c.rmAttribute === "data");
   assertEquals(dataChild?.rmCardinality, "1");
@@ -238,6 +248,15 @@ Deno.test("mandated mouth shows overlay; quiet sibling has no Δ; protocol is mu
     prohibitedLabel.overlayHelp().includes("prohibited"),
     true,
   );
+  const stateRow = container.getInput(prohibitedRmInputName("state"));
+  assert(stateRow, "is_prohibited state appears as a non-addable overlay row");
+  const inputNames = container.inputList.map((input) => input.name);
+  assertEquals(
+    inputNames.indexOf(prohibitedRmInputName("protocol")) <
+      inputNames.indexOf(prohibitedRmInputName("state")),
+    true,
+    "prohibited mutator rows follow RM attribute order (protocol before state)",
+  );
 
   composeOptionalRmExtras(observation, ["protocol"]);
   assertEquals(
@@ -303,6 +322,28 @@ Deno.test("blood-pressure HISTORY.events is an overlay vs RM 0..*", () => {
 
   const workspace = new Blockly.Workspace();
   loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
+  const historyBlock = workspace.getAllBlocks(false).find(
+    (b) => b.getFieldValue("RM_TYPE") === "HISTORY",
+  );
+  assert(historyBlock);
+  const label = slotLabelOn(historyBlock, "events");
+  assert(label);
+  assertEquals(label.hasOverlay, true);
+  assertEquals(label.min, 1);
+  assertEquals(label.max, null);
+  assertEquals(label.rmMin, 0);
+  assertEquals(label.rmMax, null);
+  workspace.dispose();
+});
+
+Deno.test("HISTORY.events overlay survives Blockly workspace JSON round-trip", () => {
+  ensureBlocks();
+  const { skeleton } = generateSkeleton(bpOpt);
+  const workspace = new Blockly.Workspace();
+  loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
+  const saved = Blockly.serialization.workspaces.save(workspace);
+  workspace.clear();
+  Blockly.serialization.workspaces.load(saved as Record<string, unknown>, workspace);
   const historyBlock = workspace.getAllBlocks(false).find(
     (b) => b.getFieldValue("RM_TYPE") === "HISTORY",
   );

--- a/test/constraint_overlay_test.ts
+++ b/test/constraint_overlay_test.ts
@@ -1,0 +1,318 @@
+/**
+ * Constraint Overlay Phase 1: RM vs effective OPT on Attribute mouths and
+ * prohibited Optional RM Insertion rows.
+ *
+ * @see tasks/prd-constraint-overlay-on-rm-blocks.md
+ * @see docs/adr/0007-constraint-overlay-on-rm-block-mouths.md
+ */
+import { assert, assertEquals } from "@std/assert";
+import { join } from "@std/path";
+import type { SkeletonNode } from "@intehrgrator/types/mod.ts";
+import { generateSkeleton, generateSkeletonFromOperational } from "@intehrgrator/core/skeleton/generate_skeleton.ts";
+import { OVERLAY_DELTA } from "@intehrgrator/core/cardinality.ts";
+import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
+import { registerRmBlocks } from "@intehrgrator/blockly/blocks/rm_blocks.ts";
+import { registerExpressionBlocks } from "@intehrgrator/blockly/blocks/expression_blocks.ts";
+import {
+  buildOptionalRmFlyoutContents,
+  composeOptionalRmExtras,
+  optionalRmInputName,
+  prohibitedRmInputName,
+  rmAttributeInputName,
+} from "@intehrgrator/blockly/blocks/rm_blocks.ts";
+import { isSlotLabelField, FieldSlotLabel } from "@intehrgrator/blockly/slot_label.ts";
+import { loadSkeletonIntoWorkspace } from "@intehrgrator/blockly/skeleton_loader.ts";
+import {
+  blockConstraintMessages,
+  refreshWorkspaceConstraints,
+} from "@intehrgrator/blockly/block_constraints.ts";
+import { createEmptyModel } from "@intehrgrator/core/mapping_model/mod.ts";
+import { formatSlotCardinality } from "@intehrgrator/blockly/slot_cardinality.ts";
+
+const bpOpt = await Deno.readTextFile(
+  join(import.meta.dirname!, "fixtures", "blood_pressure.opt"),
+);
+
+let blocksReady = false;
+function ensureBlocks(): void {
+  if (blocksReady) return;
+  registerRmBlocks();
+  registerExpressionBlocks();
+  blocksReady = true;
+}
+
+function occ(lower: number, upper: number | null) {
+  return {
+    lower,
+    upper: upper ?? undefined,
+    upper_unbounded: upper == null,
+  };
+}
+
+/** Small OPT: mandation overlay, quiet RM-matching mouth, prohibited protocol. */
+function overlayFixtureOpt() {
+  return {
+    template_id: { value: "overlay_fixture" },
+    original_language: "en",
+    definition: {
+      rm_type_name: "COMPOSITION",
+      node_id: "at0000",
+      occurrences: occ(1, 1),
+      attributes: [
+        {
+          rm_attribute_name: "context",
+          existence: occ(1, 1),
+          children: [{
+            rm_type_name: "EVENT_CONTEXT",
+            node_id: "at0001",
+            attributes: [],
+          }],
+        },
+        {
+          rm_attribute_name: "content",
+          children: [{
+            rm_type_name: "OBSERVATION",
+            node_id: "at0002",
+            occurrences: occ(1, 1),
+            attributes: [
+              {
+                rm_attribute_name: "data",
+                existence: occ(1, 1),
+                children: [{
+                  rm_type_name: "HISTORY",
+                  node_id: "at0003",
+                  occurrences: occ(1, 1),
+                  attributes: [{
+                    rm_attribute_name: "events",
+                    cardinality: { interval: occ(1, 1) },
+                    children: [{
+                      rm_type_name: "POINT_EVENT",
+                      node_id: "at0004",
+                      occurrences: occ(1, 1),
+                      attributes: [],
+                    }],
+                  }],
+                }],
+              },
+              {
+                rm_attribute_name: "protocol",
+                existence: occ(0, 0),
+                children: [],
+              },
+            ],
+          }],
+        },
+      ],
+    },
+  };
+}
+
+function flatten(nodes: SkeletonNode[]): SkeletonNode[] {
+  return nodes.flatMap((n) => [n, ...flatten(n.children)]);
+}
+
+function slotLabelOn(block: Blockly.Block, attr: string) {
+  const input = block.getInput(rmAttributeInputName(attr));
+  const field = input?.fieldRow.find((item) => isSlotLabelField(item));
+  return field && isSlotLabelField(field) ? field : undefined;
+}
+
+Deno.test("FieldSlotLabel overlay caption model: Δ, effective, struck-through RM", () => {
+  const field = new FieldSlotLabel("context", {
+    card: { min: 1, max: 1 },
+    rmCard: { min: 0, max: 1 },
+  });
+  assertEquals(field.hasOverlay, true);
+  assertEquals(field.min, 1);
+  assertEquals(field.max, 1);
+  assertEquals(field.rmMin, 0);
+  assertEquals(field.rmMax, 1);
+  assertEquals(field.getText().includes(OVERLAY_DELTA), true);
+  assertEquals(field.getText().includes(formatSlotCardinality({ min: 1, max: 1 })), true);
+  assertEquals(field.getText().includes(formatSlotCardinality({ min: 0, max: 1 })), true);
+  assertEquals(
+    field.overlayHelp(),
+    "RM [0..1] narrowed to [1..1] by the operational template.",
+  );
+
+  const quiet = new FieldSlotLabel("data", {
+    card: { min: 1, max: 1 },
+    rmCard: { min: 1, max: 1 },
+  });
+  assertEquals(quiet.hasOverlay, false);
+  assertEquals(quiet.getText().includes(OVERLAY_DELTA), false);
+});
+
+Deno.test("skeleton records RM vs effective intervals and prohibited attributes", () => {
+  const { skeleton } = generateSkeletonFromOperational(overlayFixtureOpt());
+  const nodes = flatten(skeleton);
+  const composition = nodes.find((n) => n.rmType === "COMPOSITION");
+  const observation = nodes.find((n) => n.rmType === "OBSERVATION");
+  const history = nodes.find((n) => n.rmType === "HISTORY");
+  const context = composition?.children.find((c) => c.rmAttribute === "context");
+  assert(composition && observation && history && context);
+
+  assertEquals(context.mandatory, true);
+  assertEquals(context.rmCardinality, "0..1");
+  assertEquals(context.effectiveCardinality, "1");
+
+  const protocol = observation.attributeConstraints?.find((c) => c.name === "protocol");
+  assert(protocol);
+  assertEquals(protocol.prohibited, true);
+  assertEquals(protocol.rmCardinality, "0..1");
+  assertEquals(protocol.effectiveCardinality, "0..0");
+  assertEquals(
+    observation.children.some((c) => c.rmAttribute === "protocol"),
+    false,
+  );
+
+  const dataChild = observation.children.find((c) => c.rmAttribute === "data");
+  assertEquals(dataChild?.rmCardinality, "1");
+  assertEquals(dataChild?.effectiveCardinality, "1");
+
+  const events = history.children.find((c) => c.rmAttribute === "events");
+  assertEquals(events?.rmCardinality, "0..*");
+  assertEquals(events?.effectiveCardinality, "1");
+});
+
+Deno.test("mandated mouth shows overlay; quiet sibling has no Δ; protocol is mutator-only", () => {
+  ensureBlocks();
+  const { skeleton } = generateSkeletonFromOperational(overlayFixtureOpt());
+  const workspace = new Blockly.Workspace();
+  loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("overlay_fixture"), null);
+
+  const composition = workspace.getTopBlocks(false).find((b) => b.type === "composition");
+  assert(composition);
+  const contextLabel = slotLabelOn(composition, "context");
+  assert(contextLabel);
+  assertEquals(contextLabel.hasOverlay, true);
+  assertEquals(contextLabel.min, 1);
+  assertEquals(contextLabel.max, 1);
+  assertEquals(contextLabel.rmMin, 0);
+  assertEquals(contextLabel.rmMax, 1);
+  assertEquals(composition.getInput(rmAttributeInputName("context")) != null, true);
+
+  const flyout = buildOptionalRmFlyoutContents(composition, []);
+  assertEquals(
+    flyout.some((entry) => entry.extraState?.attr === "context"),
+    false,
+    "mandated context must not be an addable mutator option",
+  );
+  assertEquals(
+    flyout.some((entry) => entry.extraState?.attr === "feeder_audit"),
+    true,
+    "unconstrained RM-optional feeder_audit stays addable",
+  );
+
+  const observation = workspace.getAllBlocks(false).find(
+    (b) => b.getFieldValue("RM_TYPE") === "OBSERVATION",
+  );
+  assert(observation);
+  assertEquals(observation.getInput(rmAttributeInputName("protocol")), null);
+  assertEquals(
+    buildOptionalRmFlyoutContents(observation, []).some((e) =>
+      e.extraState?.attr === "protocol"
+    ),
+    false,
+    "prohibited protocol is not addable",
+  );
+  assertEquals(
+    buildOptionalRmFlyoutContents(observation, []).some((e) =>
+      e.extraState?.attr === "feeder_audit"
+    ),
+    true,
+  );
+
+  const bubble = new Blockly.Workspace();
+  const container = observation.decompose!(bubble);
+  const prohibited = container.getInput(prohibitedRmInputName("protocol"));
+  assert(prohibited, "protocol appears as a non-addable overlay row in the mutator");
+  const prohibitedLabel = prohibited.fieldRow.find((f) => isSlotLabelField(f));
+  assert(prohibitedLabel && isSlotLabelField(prohibitedLabel));
+  assertEquals(prohibitedLabel.hasOverlay, true);
+  assertEquals(prohibitedLabel.min, 0);
+  assertEquals(prohibitedLabel.max, 0);
+  assertEquals(prohibitedLabel.rmMin, 0);
+  assertEquals(prohibitedLabel.rmMax, 1);
+  assertEquals(
+    prohibitedLabel.overlayHelp().includes("prohibited"),
+    true,
+  );
+
+  composeOptionalRmExtras(observation, ["protocol"]);
+  assertEquals(
+    observation.getInput(optionalRmInputName("protocol")),
+    null,
+    "activating a prohibited row must not create a mouth",
+  );
+  assertEquals(observation.getInput(rmAttributeInputName("protocol")), null);
+
+  const dataLabel = slotLabelOn(observation, "data");
+  assert(dataLabel);
+  assertEquals(dataLabel.hasOverlay, false);
+
+  const history = workspace.getAllBlocks(false).find(
+    (b) => b.getFieldValue("RM_TYPE") === "HISTORY",
+  );
+  assert(history);
+  const eventsLabel = slotLabelOn(history, "events");
+  assert(eventsLabel);
+  assertEquals(eventsLabel.hasOverlay, true);
+  assertEquals(eventsLabel.min, 1);
+  assertEquals(eventsLabel.max, 1);
+  assertEquals(eventsLabel.rmMin, 0);
+  assertEquals(eventsLabel.rmMax, null);
+
+  workspace.dispose();
+  bubble.dispose();
+});
+
+Deno.test("unmet effective cardinality still warns on an overlay mouth", () => {
+  ensureBlocks();
+  const { skeleton } = generateSkeletonFromOperational(overlayFixtureOpt());
+  const workspace = new Blockly.Workspace();
+  loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("overlay_fixture"), null);
+  const history = workspace.getAllBlocks(false).find(
+    (b) => b.getFieldValue("RM_TYPE") === "HISTORY",
+  );
+  assert(history);
+  const eventsInput = history.getInput(rmAttributeInputName("events"));
+  const child = eventsInput?.connection?.targetBlock();
+  child?.dispose(true);
+  refreshWorkspaceConstraints(workspace);
+  const label = slotLabelOn(history, "events");
+  assert(label);
+  assertEquals(label.hasOverlay, true);
+  assertEquals(label.unmet, true);
+  const messages = blockConstraintMessages(history);
+  assert(
+    messages.some((m) => m.includes("events") && m.includes("[1..1]")),
+    `expected unmet effective [1..1], got ${messages.join(" | ")}`,
+  );
+  workspace.dispose();
+});
+
+Deno.test("blood-pressure HISTORY.events is an overlay vs RM 0..*", () => {
+  ensureBlocks();
+  const { skeleton } = generateSkeleton(bpOpt);
+  const history = flatten(skeleton).find((n) => n.rmType === "HISTORY");
+  assert(history);
+  const events = history.children.find((c) => c.rmAttribute === "events");
+  assertEquals(events?.rmCardinality, "0..*");
+  assertEquals(events?.effectiveCardinality, "1..*");
+
+  const workspace = new Blockly.Workspace();
+  loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
+  const historyBlock = workspace.getAllBlocks(false).find(
+    (b) => b.getFieldValue("RM_TYPE") === "HISTORY",
+  );
+  assert(historyBlock);
+  const label = slotLabelOn(historyBlock, "events");
+  assert(label);
+  assertEquals(label.hasOverlay, true);
+  assertEquals(label.min, 1);
+  assertEquals(label.max, null);
+  assertEquals(label.rmMin, 0);
+  assertEquals(label.rmMax, null);
+  workspace.dispose();
+});

--- a/test/ehrtslib_contract_test.ts
+++ b/test/ehrtslib_contract_test.ts
@@ -160,9 +160,25 @@ Deno.test("OPT XML parse keeps C_DV_ORDINAL.list value+symbol (upstream #79)", (
   );
 });
 
+/** Regression guard for ErikSundvall/ehrtslib#73 — no local vendor patch. */
+Deno.test("OPT XML parse keeps Position C_CODE_PHRASE code_list of 6 (upstream #73)", () => {
+  const parsed = parseTemplateInput(bpOpt);
+  const position = findAmNode(
+    parsed.operationalTemplate?.definition as AmWalkNode | undefined,
+    (n) =>
+      Array.isArray(n.code_list) &&
+      n.code_list.length === 6 &&
+      n.code_list.includes("at1000") &&
+      n.code_list.includes("at1014"),
+  );
+  assert(position, "expected Position C_CODE_PHRASE with six local codes");
+  assertEquals(position.code_list?.length, 6);
+});
+
 type AmWalkNode = {
   rm_type_name?: string;
   list?: unknown[];
+  code_list?: string[];
   attributes?: Array<{ children?: AmWalkNode | AmWalkNode[] }>;
   children?: AmWalkNode | AmWalkNode[];
 };

--- a/test/slot_cardinality_test.ts
+++ b/test/slot_cardinality_test.ts
@@ -2,6 +2,8 @@ import { assertEquals } from "@std/assert";
 import {
   formatSlotCardinality,
   isCardinalityMet,
+  isProhibitedInterval,
+  isStrictNarrowing,
   parseSlotCardinality,
 } from "@intehrgrator/blockly/slot_cardinality.ts";
 
@@ -25,4 +27,33 @@ Deno.test("isCardinalityMet enforces min and optional max", () => {
   assertEquals(isCardinalityMet(0, { min: 1, max: null }), false);
   assertEquals(isCardinalityMet(1, { min: 1, max: 1 }), true);
   assertEquals(isCardinalityMet(2, { min: 1, max: 1 }), false);
+});
+
+Deno.test("isStrictNarrowing is true only for a tighter interval", () => {
+  assertEquals(
+    isStrictNarrowing({ min: 0, max: 1 }, { min: 1, max: 1 }),
+    true,
+  );
+  assertEquals(
+    isStrictNarrowing({ min: 0, max: null }, { min: 1, max: 1 }),
+    true,
+  );
+  assertEquals(
+    isStrictNarrowing({ min: 0, max: null }, { min: 1, max: null }),
+    true,
+  );
+  assertEquals(
+    isStrictNarrowing({ min: 0, max: 1 }, { min: 0, max: 0 }),
+    true,
+  );
+  assertEquals(
+    isStrictNarrowing({ min: 1, max: 1 }, { min: 1, max: 1 }),
+    false,
+  );
+  assertEquals(
+    isStrictNarrowing({ min: 0, max: 1 }, { min: 0, max: 1 }),
+    false,
+  );
+  assertEquals(isProhibitedInterval({ min: 0, max: 0 }), true);
+  assertEquals(isProhibitedInterval({ min: 0, max: 1 }), false);
 });

--- a/web/styles.css
+++ b/web/styles.css
@@ -712,6 +712,15 @@ body.sheets-fullscreen::before {
 .blockly-mount .blocklyText.blockly-slot-label--unmet {
   font-weight: 700 !important;
 }
+.blockly-mount .blocklyText .blockly-slot-overlay-delta,
+.blockly-mount .blocklyText .blockly-slot-overlay-effective {
+  fill: #0f766e;
+  font-weight: 600;
+}
+.blockly-mount .blocklyText .blockly-slot-overlay-rm {
+  fill: #64748b;
+  text-decoration: line-through;
+}
 .blockly-mount .blocklyText.blockly-slot-label--abstract,
 .blockly-mount .blockly-rm-emoji-field.blockly-rm-emoji-abstract .blocklyText,
 .blockly-mount .blocklyText.blockly-rm-emoji-abstract {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements Constraint Overlay Phase 1 from issue #46, the PRD in `tasks/prd-constraint-overlay-on-rm-blocks.md`, and [ADR 0007](docs/adr/0007-constraint-overlay-on-rm-block-mouths.md).

## Issue #21

Already done on `main`: `scripts/vendor-ehrtslib.ts` no longer patches `parseCTerminologyCode` (upstream ErikSundvall/ehrtslib#73, commit `61167e5`). This PR only adds the optional contract test from that issue: Position’s `code_list` length is 6 after `parseTemplateInput` on the blood-pressure OPT. **#21 can be closed.** (`gh` is read-only here, so a human should close it.)

## Issue #46 — Constraint Overlay Phase 1

Keep one Blockly vocabulary (RM Blocks). When the operational template’s effective existence/cardinality is a strict narrowing of the RM BMM interval, the Attribute mouth shows:

- delta glyph `Δ`
- effective interval in overlay teal (not warning yellow)
- RM interval with strikethrough

Unchanged mouths stay a single `[min..max]`. Constraint warning triangles still mean “live mapping breaks the effective interval.”

Three-way canvas / mutator split:

- **Mandated** (RM-optional, OPT `min ≥ 1`, including `C_ATTRIBUTE.existence` when child occurrences are unstated): locked mouth on the block, with overlay vs RM.
- **Still optional**: addable in Optional RM Insertion (e.g. `feeder_audit`).
- **Prohibited** (`max=0` or `is_prohibited`): off the canvas; listed in the cogwheel mutator as a non-addable overlay row (`Δ [0..0]`, RM struck through), in RM attribute order. Activating it does not create a mouth.

Follows the PRD grill record (prohibited rows stay visible in the mutator). The original issue-body story that omitted them was superseded by the PRD.

## Blockly JSON round-trip

The Web Shell save/load path was dropping RM vs effective interval maps, so mouths such as blood-pressure `HISTORY.events` fell back to the RM `[0..*]` caption. Mutator extraState now persists `slotCards` / `rmCards` so the overlay survives workspace JSON reload (including the nested save after first scaffold).

## Browser check

Blood-pressure `HISTORY.events` on the Web Shell after this fix:

[HISTORY.events Constraint Overlay Δ \[1..*\] with RM \[0..*\] struck through](https://cursor.com/agents/bc-47b2069d-349f-4639-b0c2-db2fc9669fc0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_events_overlay_delta.webp)
[Zoomed HISTORY.events overlay on the blood-pressure canvas](https://cursor.com/agents/bc-47b2069d-349f-4639-b0c2-db2fc9669fc0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistory_events_overlay_zoomed.webp)

## Tests

- Interval narrowing helpers
- Synthetic OPT: mandation overlay, quiet RM-matching sibling, prohibited mutator rows (`existence` `0..0` and `is_prohibited`), unmet effective cardinality
- Blood-pressure `HISTORY.events` `[1..*]` vs RM `[0..*]`
- Overlay survives Blockly workspace JSON round-trip
- ehrtslib Position `code_list` length 6 (#21)

JSON Schema / XML Schema targets are unchanged. Value-domain overlay is out of scope (Phase 2). Flattened OPTs that already dropped `max=0` nodes (no remaining `C_ATTRIBUTE`) still cannot reconstruct a prohibition inventory from RM-optional names that were never mentioned — that stays a follow-up.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47b2069d-349f-4639-b0c2-db2fc9669fc0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47b2069d-349f-4639-b0c2-db2fc9669fc0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

