### PR TITLE
feat(ui): issues #51, #52, #54, #56 — mapping spec chrome, glyphs, rename, conversion start

### DIFF
--- a/src/blockly/block_type_glyph.ts
+++ b/src/blockly/block_type_glyph.ts
@@ -1,0 +1,101 @@
+/**
+ * Blockly-check → type-fit glyphs for non-openEHR blocks.
+ * ZipEHR emoji table is preferred for primitives; abstract unions use ⁇.
+ */
+import type { Input } from "blockly/core";
+import { Blockly } from "./blockly_core.ts";
+import { zipehrEmojiForRmType } from "../core/rm_emoji.ts";
+import {
+  ABSTRACT_SLOT_GLYPH,
+  BLOCK_OUT_EMOJI_FIELD,
+  createRmTypeEmojiField,
+  rmTypeConnectionTooltip,
+  slotEmojiFieldName,
+} from "./rm_type_emoji.ts";
+
+/** Blockly output / socket check → display glyph. */
+const BLOCKLY_TYPE_GLYPH: Record<string, string> = {
+  String: "🔤",
+  Number: "🔢",
+  Boolean: "☑️",
+  Array: "📋",
+  Map: "🗺️",
+  Source: "📂",
+};
+
+export function glyphForBlocklyCheck(
+  check: string | string[] | null | undefined,
+  forSlot = false,
+): string | undefined {
+  if (!check) return undefined;
+  if (Array.isArray(check)) {
+    if (check.length === 1) return glyphForBlocklyCheck(check[0], forSlot);
+    const concrete = check.map((t) => glyphForSingleCheck(t)).filter(Boolean);
+    const unique = [...new Set(concrete)];
+    if (unique.length === 1) return unique[0];
+    return ABSTRACT_SLOT_GLYPH;
+  }
+  return glyphForSingleCheck(check, forSlot);
+}
+
+function glyphForSingleCheck(check: string, forSlot = false): string | undefined {
+  const zipehr = zipehrEmojiForRmType(check);
+  if (zipehr) return zipehr;
+  if (BLOCKLY_TYPE_GLYPH[check]) return BLOCKLY_TYPE_GLYPH[check];
+  if (check === "DATA_VALUE") return ABSTRACT_SLOT_GLYPH;
+  return undefined;
+}
+
+export function blocklyCheckTooltip(
+  check: string | string[] | null | undefined,
+): string {
+  if (!check) return "any type";
+  if (Array.isArray(check)) {
+    if (check.length === 1) return blocklyCheckTooltip(check[0]);
+    return ["Allowed:", ...check.map((t) => `${glyphForSingleCheck(t) ?? ABSTRACT_SLOT_GLYPH} ${t}`)].join("\n");
+  }
+  const rmTip = rmTypeConnectionTooltip(check);
+  if (rmTip !== check) return rmTip;
+  const glyph = glyphForSingleCheck(check);
+  return glyph ? `${glyph} ${check}` : check;
+}
+
+/** Output-tab glyph from a Blockly check string. */
+export function appendBlockOutputGlyph(
+  header: Input,
+  check: string | string[] | null,
+): void {
+  const glyph = glyphForBlocklyCheck(check, false);
+  if (!glyph) return;
+  const rmField = createRmTypeEmojiField(
+    Array.isArray(check) ? (check[0] ?? "") : (check ?? ""),
+    false,
+  );
+  if (rmField && glyph !== ABSTRACT_SLOT_GLYPH) {
+    header.appendField(rmField, BLOCK_OUT_EMOJI_FIELD);
+    return;
+  }
+  header.appendField(
+    new Blockly.FieldLabel(glyph, "blockly-rm-emoji"),
+    BLOCK_OUT_EMOJI_FIELD,
+  );
+}
+
+/** Socket glyph appended to an input row. */
+export function appendInputTypeGlyph(
+  input: Input,
+  check: string | string[] | null,
+): void {
+  const glyph = glyphForBlocklyCheck(check, true);
+  if (!glyph) return;
+  const name = slotEmojiFieldName(input.name);
+  const existing = input.fieldRow.find((f) => f.name === name);
+  if (existing) {
+    existing.setValue(glyph);
+    existing.setTooltip(blocklyCheckTooltip(check));
+    return;
+  }
+  const field = new Blockly.FieldLabel(glyph, glyph === ABSTRACT_SLOT_GLYPH ? "blockly-rm-emoji blockly-rm-emoji-abstract" : "blockly-rm-emoji");
+  field.setTooltip(blocklyCheckTooltip(check));
+  input.appendField(field, name);
+}

--- a/src/blockly/block_type_glyph.ts
+++ b/src/blockly/block_type_glyph.ts
@@ -17,9 +17,9 @@ import {
 const BLOCKLY_TYPE_GLYPH: Record<string, string> = {
   String: "🔤",
   Number: "🔢",
-  Boolean: "☑️",
+  Boolean: "✓",
   Array: "📋",
-  Map: "🗺️",
+  Map: "↦",
   Source: "📂",
 };
 

--- a/src/blockly/blocks/logic_blocks.ts
+++ b/src/blockly/blocks/logic_blocks.ts
@@ -1,6 +1,7 @@
 import { Blockly } from "../blockly_core.ts";
 import { FieldDropdownHug } from "../field_dropdown_hug.ts";
 import { detectLocale, msg } from "../i18n/locale.ts";
+import { appendBlockOutputGlyph, appendInputTypeGlyph } from "../block_type_glyph.ts";
 
 const LOGIC_COLOUR = "#D1C4E9";
 const LIST_COLOUR = "#4DB6AC";
@@ -143,8 +144,12 @@ export function registerLogicBlocks(): void {
       this.itemName_ = DEFAULT_ITEM_NAME;
       this.countValue_ = 1;
       this.guardValue_ = false;
-      this.appendValueInput("LIST")
-        .setCheck(LIST_CHECK)
+      const header = this.appendDummyInput("HEADER");
+      appendBlockOutputGlyph(header, "Boolean");
+      const listInput = this.appendValueInput("LIST")
+        .setCheck(LIST_CHECK);
+      appendInputTypeGlyph(listInput, LIST_CHECK);
+      listInput
         .appendField(
           new FieldDropdownHug(
             [
@@ -165,9 +170,10 @@ export function registerLogicBlocks(): void {
           "OP",
         )
         .appendField(m.LOGIC_OF, "OF_LABEL");
-      this.appendValueInput("PRED")
-        .setCheck("Boolean")
-        .appendField(m.LOGIC_MATCH, "MATCH_LABEL");
+      const predInput = this.appendValueInput("PRED")
+        .setCheck("Boolean");
+      appendInputTypeGlyph(predInput, "Boolean");
+      predInput.appendField(m.LOGIC_MATCH, "MATCH_LABEL");
       this.setInputsInline(false);
       this.setOutput(true, "Boolean");
       this.setColour(LOGIC_COLOUR);
@@ -275,9 +281,10 @@ export function registerLogicBlocks(): void {
 
   Blockly.Blocks[LOGIC_CURRENT_ITEM_BLOCK] = {
     init: function (this: Blockly.Block) {
-      this.appendDummyInput()
-        .appendField(new FieldItemDropdown(currentItemOptions), "VAR");
-      this.setOutput(true, null);
+      const header = this.appendDummyInput("HEADER");
+      appendBlockOutputGlyph(header, "Boolean");
+      header.appendField(new FieldItemDropdown(currentItemOptions), "VAR");
+      this.setOutput(true, "Boolean");
       this.setColour(LOGIC_COLOUR);
       this.setTooltip(m.LOGIC_CURRENT_ITEM_TOOLTIP);
       this.setStyle?.("logic_blocks");
@@ -286,8 +293,12 @@ export function registerLogicBlocks(): void {
 
   Blockly.Blocks[LISTS_SET_OPERATION_BLOCK] = {
     init: function (this: Blockly.Block) {
-      this.appendValueInput("A")
-        .setCheck(LIST_CHECK)
+      const header = this.appendDummyInput("HEADER");
+      appendBlockOutputGlyph(header, "Array");
+      const inputA = this.appendValueInput("A")
+        .setCheck(LIST_CHECK);
+      appendInputTypeGlyph(inputA, LIST_CHECK);
+      inputA
         .appendField(
           new FieldDropdownHug(
             [
@@ -304,9 +315,10 @@ export function registerLogicBlocks(): void {
           ),
           "OP",
         );
-      this.appendValueInput("B")
-        .setCheck(LIST_CHECK)
-        .appendField(new Blockly.FieldLabel(m.LOGIC_SET_CONN_AND), "CONN");
+      const inputB = this.appendValueInput("B")
+        .setCheck(LIST_CHECK);
+      appendInputTypeGlyph(inputB, LIST_CHECK);
+      inputB.appendField(new Blockly.FieldLabel(m.LOGIC_SET_CONN_AND), "CONN");
       this.setInputsInline(false);
       this.setOutput(true, "Array");
       this.setColour(LIST_COLOUR);

--- a/src/blockly/blocks/map_blocks.ts
+++ b/src/blockly/blocks/map_blocks.ts
@@ -11,6 +11,7 @@ import {
   hideDefaultMutatorIcon,
   openBlockMutator,
 } from "../dynamic_mutator.ts";
+import { appendBlockOutputGlyph, appendInputTypeGlyph } from "../block_type_glyph.ts";
 
 const MAP_COLOUR = "#7E57C2";
 const DEFAULTS_COLOUR = "#5C6BC0";
@@ -256,6 +257,7 @@ export function registerMapBlocks(): void {
       const header = this.appendDummyInput("HEADER").setAlign(
         (Blockly.inputs?.Align?.LEFT ?? Blockly.ALIGN_LEFT ?? 0) as number,
       );
+      appendBlockOutputGlyph(header, "Map");
       header.appendField("map");
       appendMutatorCogwheel(header);
       this.setOutput(true, "Map");
@@ -294,12 +296,12 @@ export function registerMapBlocks(): void {
 
   Blockly.Blocks[MAPS_GET] = {
     init: function (this: Blockly.Block) {
-      this.appendDummyInput("HEADER")
-        .appendField("get")
-        .appendField(new Blockly.FieldTextInput(DEFAULTS_MAP_NAME), "NAME");
-      this.appendValueInput("KEY")
-        .setCheck("String")
-        .appendField("key");
+      const header = this.appendDummyInput("HEADER");
+      appendBlockOutputGlyph(header, null);
+      header.appendField("get").appendField(new Blockly.FieldTextInput(DEFAULTS_MAP_NAME), "NAME");
+      const keyIn = this.appendValueInput("KEY").setCheck("String");
+      appendInputTypeGlyph(keyIn, "String");
+      keyIn.appendField("key");
       appendHiddenSerializable(this, "SLOT_ID", "");
       appendHiddenSerializable(this, "RM_TYPE", "");
       this.setOutput(true, null);
@@ -349,13 +351,13 @@ export function registerMapBlocks(): void {
         INFO_SVG,
         18,
         18,
-        "Defaults Map: convert-time language, territory, encoding, facility, and similar values. Folder: load, save, or download the map as JSON.",
+        "Default context mapping: design-time table of execution-context values (language, territory, time, composer, facility, …). Folder: load, save, or download.",
         () => {
           defaultsMapInfoHandler?.(fieldClickAnchor(infoField as ClickableField));
         },
       );
       this.appendDummyInput("HEADER")
-        .appendField("Defaults Map")
+        .appendField("Default context mapping")
         .appendField(
           new Blockly.FieldImage(FOLDER_SVG, 18, 18, "Load/save", () => {
             defaultsMapPickHandler?.();

--- a/src/blockly/blocks/rm_blocks.ts
+++ b/src/blockly/blocks/rm_blocks.ts
@@ -28,6 +28,7 @@ import {
   slotRmTypeForAttr,
 } from "../rm_type_emoji.ts";
 import { FieldSkeletonTitle, humanizeRmType, isSkeletonTitleField } from "../field_skeleton_title.ts";
+import { INSTANCE_ROOT_CONNECTION } from "../instance_root.ts";
 import {
   parseSlotCardinality,
   rmAttributeCardinality,
@@ -1016,6 +1017,9 @@ function defineContainerBlock(
       }
       if (options.expandable) {
         Blockly.Extensions.apply("optional_rm_mutator", this, true);
+      }
+      if (options.rmType === "COMPOSITION") {
+        this.setPreviousStatement(true, INSTANCE_ROOT_CONNECTION);
       }
       enforceOpenEhrBlockLayout(this);
     },

--- a/src/blockly/blocks/schema_mutator.ts
+++ b/src/blockly/blocks/schema_mutator.ts
@@ -22,6 +22,7 @@ import {
 } from "./target_blocks.ts";
 import { specForChild, type SchemaInputSpec } from "../../core/target/schema_block_ids.ts";
 import { createHiddenSerializableField } from "../hidden_serializable_field.ts";
+import { applyInstanceRootCap } from "../instance_root.ts";
 
 const TARGET_CHILD_PREFIX = "TARGET_";
 
@@ -92,6 +93,7 @@ function restoreTargetStructureState(
     connection?: "statement" | "value";
     typeCheck?: string;
     xmlAttributes?: string[];
+    instanceRoot?: boolean;
   } | null,
 ): void {
   if (state?.typeCheck) {
@@ -116,6 +118,7 @@ function restoreTargetStructureState(
   block.schemaExtraFields_ = Array.isArray(state?.extras) ? state!.extras! : [];
   block.schemaOptionalSpecs_ = Array.isArray(state?.optionalFields) ? state!.optionalFields! : [];
   block.updateSchemaFields_?.();
+  if (state?.instanceRoot) applyInstanceRootCap(block);
 }
 
 function defineSchemaMutatorQuarks(): void {
@@ -239,7 +242,11 @@ export function registerSchemaFieldsMutator(): void {
         if (typeCheck) payload.typeCheck = typeCheck;
         const xmlAttributes = (this as Block & { schemaXmlAttributes_?: string[] }).schemaXmlAttributes_;
         if (xmlAttributes?.length) payload.xmlAttributes = xmlAttributes;
-        return extras.length || fields?.length || payload.childGroups || typeCheck
+        if ((this as Block & { isInstanceRoot_?: boolean }).isInstanceRoot_) {
+          payload.instanceRoot = true;
+        }
+        return extras.length || fields?.length || payload.childGroups || typeCheck ||
+          payload.instanceRoot
           ? payload
           : null;
       },
@@ -254,6 +261,7 @@ export function registerSchemaFieldsMutator(): void {
           connection?: "statement" | "value";
           typeCheck?: string;
           xmlAttributes?: string[];
+          instanceRoot?: boolean;
         } | string | null,
       ) {
         if (state == null || state === "") {

--- a/src/blockly/blocks/sheet_blocks.ts
+++ b/src/blockly/blocks/sheet_blocks.ts
@@ -1,4 +1,5 @@
 import { Blockly } from "../blockly_core.ts";
+import { appendBlockOutputGlyph, appendInputTypeGlyph } from "../block_type_glyph.ts";
 
 const SHEET_COLOUR = "#00897B";
 const SHEET_DECL_COLOUR = "#00695C";
@@ -84,12 +85,11 @@ export function registerSheetBlocks(): void {
 
   Blockly.Blocks[SHEET_GET_CELL] = {
     init: function (this: Blockly.Block) {
-      this.appendDummyInput()
-        .appendField("get")
-        .appendField(nameField(), "NAME")
-        .appendField("cell");
-      this.appendValueInput("A1").setCheck("String");
-      this.setOutput(true, ["String", "Number", "Boolean"]);
+      const header = this.appendDummyInput("HEADER");
+      appendBlockOutputGlyph(header, ["String", "Number", "Boolean"]);
+      header.appendField("get").appendField(nameField(), "NAME").appendField("cell");
+      const a1 = this.appendValueInput("A1").setCheck("String");
+      appendInputTypeGlyph(a1, "String");
       this.setColour(SHEET_COLOUR);
       this.setInputsInline(true);
       this.setTooltip("Get a Sheet cell by A1 reference (e.g. B2).");
@@ -98,9 +98,15 @@ export function registerSheetBlocks(): void {
 
   Blockly.Blocks[SHEET_GET_XY] = {
     init: function (this: Blockly.Block) {
-      this.appendDummyInput().appendField("get").appendField(nameField(), "NAME");
-      this.appendValueInput("X").setCheck("Number").appendField("x");
-      this.appendValueInput("Y").setCheck("Number").appendField("y");
+      const header = this.appendDummyInput("HEADER");
+      appendBlockOutputGlyph(header, ["String", "Number", "Boolean"]);
+      header.appendField("get").appendField(nameField(), "NAME");
+      const xIn = this.appendValueInput("X").setCheck("Number");
+      appendInputTypeGlyph(xIn, "Number");
+      xIn.appendField("x");
+      const yIn = this.appendValueInput("Y").setCheck("Number");
+      appendInputTypeGlyph(yIn, "Number");
+      yIn.appendField("y");
       this.setOutput(true, ["String", "Number", "Boolean"]);
       this.setColour(SHEET_COLOUR);
       this.setInputsInline(true);

--- a/src/blockly/blocks/target_blocks.ts
+++ b/src/blockly/blocks/target_blocks.ts
@@ -6,6 +6,7 @@ import { findSkeletonNode } from "../schema_catalog.ts";
 import { appendSlotLabel } from "../slot_label.ts";
 import { registerSchemaFieldsMutator, SCHEMA_FIELDS_MUTATOR } from "./schema_mutator.ts";
 import type { SchemaInputSpec } from "../../core/target/schema_block_ids.ts";
+import { applyInstanceRootCap } from "../instance_root.ts";
 
 const TARGET_STRUCTURE_COLOUR = "#4B5563";
 const TARGET_VALUE_COLOUR = "#6B7280";
@@ -130,14 +131,19 @@ function defineStructureBlock(
       const childGroups = this.inputList
         .filter((input) => input.name.startsWith(TARGET_CHILD_PREFIX))
         .map((input) => input.name.slice(TARGET_CHILD_PREFIX.length));
-      return childGroups.length ? { childGroups } : null;
+      const instanceRoot = Boolean((this as Block & { isInstanceRoot_?: boolean }).isInstanceRoot_);
+      const payload: { childGroups?: string[]; instanceRoot?: boolean } = {};
+      if (childGroups.length) payload.childGroups = childGroups;
+      if (instanceRoot) payload.instanceRoot = true;
+      return Object.keys(payload).length ? payload : null;
     };
     blockDef.loadExtraState = function (this: Block, state: unknown) {
       const raw = state && typeof state === "object"
-        ? (state as { childGroups?: unknown }).childGroups
+        ? state as { childGroups?: unknown; instanceRoot?: unknown }
         : undefined;
-      const childGroups = Array.isArray(raw)
-        ? raw.filter((group): group is string => typeof group === "string" && group.length > 0)
+      if (raw?.instanceRoot) applyInstanceRootCap(this);
+      const childGroups = Array.isArray(raw?.childGroups)
+        ? raw!.childGroups.filter((group): group is string => typeof group === "string" && group.length > 0)
         : [];
       const groups = defaultChildGroup && !childGroups.includes(defaultChildGroup)
         ? [defaultChildGroup, ...childGroups]

--- a/src/blockly/blocks/text_blocks.ts
+++ b/src/blockly/blocks/text_blocks.ts
@@ -7,8 +7,15 @@ import {
 import { EDITOR_LANGUAGE_OPTIONS } from "../../workbench/codemirror_setup.ts";
 import { msg, detectLocale } from "../i18n/locale.ts";
 
+import {
+  applyInstanceRootCap,
+  TEXT_DOCUMENT_BLOCK_TYPE,
+} from "../instance_root.ts";
+import { appendBlockOutputGlyph, appendInputTypeGlyph } from "../block_type_glyph.ts";
+
 export const TEXT_CODE_BLOCK_TYPE = "text_code";
 export const TEXT_HANDLEBARS_BLOCK_TYPE = "text_handlebars";
+export { TEXT_DOCUMENT_BLOCK_TYPE };
 
 const TEXT_COLOUR = "#FFCA28";
 
@@ -55,6 +62,23 @@ export function registerTextBlocks(): void {
       this.setTooltip(m.TEXT_HANDLEBARS_TOOLTIP);
       this.setStyle?.("text_blocks");
       this.setInputsInline(false);
+    },
+  };
+
+  Blockly.Blocks[TEXT_DOCUMENT_BLOCK_TYPE] = {
+    init: function (this: Blockly.Block) {
+      const header = this.appendDummyInput("HEADER");
+      appendBlockOutputGlyph(header, "String");
+      header.appendField("Text document");
+      const value = this.appendValueInput("VALUE").setCheck("String");
+      appendInputTypeGlyph(value, "String");
+      value.appendField("content");
+      applyInstanceRootCap(this);
+      this.setColour(TEXT_COLOUR);
+      this.setTooltip(
+        "Free-form text instance root. Plug in Code text, Handlebars text, or a string Source query.",
+      );
+      this.setStyle?.("text_blocks");
     },
   };
 }

--- a/src/blockly/conversion_start_canvas.ts
+++ b/src/blockly/conversion_start_canvas.ts
@@ -1,0 +1,121 @@
+import type { BlockSvg, WorkspaceSvg } from "blockly/core";
+import { Blockly } from "./blockly_core.ts";
+import {
+  applyInstanceRootCap,
+  CONVERSION_START_TYPE,
+  findConversionStartBlock,
+  findInstanceRootUnderStart,
+  INSTANCE_ROOT_CONNECTION,
+  isInstanceRootBlockType,
+  registerConversionStartBlock,
+} from "./instance_root.ts";
+import { DEFAULTS_BLOCK_TYPE } from "../core/defaults/extract.ts";
+
+const START_X = 20;
+const START_Y = 20;
+
+function finalize(block: Blockly.Block): Blockly.Block {
+  const svg = block as BlockSvg;
+  if (typeof document !== "undefined") {
+    svg.initSvg?.();
+    svg.render?.();
+  }
+  return block;
+}
+
+export function dropDuplicateConversionStart(
+  workspace: Blockly.Workspace,
+  keep: Blockly.Block,
+): void {
+  for (const block of workspace.getTopBlocks(false)) {
+    if (block.type === CONVERSION_START_TYPE && block.id !== keep.id) {
+      block.dispose(false);
+    }
+  }
+}
+
+export function ensureConversionStartBlock(workspace: Blockly.Workspace): Blockly.Block {
+  registerConversionStartBlock();
+  const existing = findConversionStartBlock(workspace);
+  if (existing) {
+    dropDuplicateConversionStart(workspace, existing);
+    return existing;
+  }
+  const block = workspace.newBlock(CONVERSION_START_TYPE);
+  if (typeof (block as BlockSvg).moveBy === "function") {
+    (block as BlockSvg).moveBy(START_X, START_Y);
+  }
+  finalize(block);
+  dropDuplicateConversionStart(workspace, block);
+  return block;
+}
+
+/** Attach Conversion start above an instance root if not already connected. */
+export function attachStartToInstanceRoot(
+  workspace: Blockly.Workspace,
+  root: Blockly.Block,
+): Blockly.Block {
+  applyInstanceRootCap(root);
+  const start = ensureConversionStartBlock(workspace);
+  if (!start.nextConnection?.isConnected() && root.previousConnection) {
+    start.nextConnection?.connect(root.previousConnection);
+  }
+  layoutStartAboveRoot(start, root);
+  return start;
+}
+
+function layoutStartAboveRoot(start: Blockly.Block, root: Blockly.Block): void {
+  const rootSvg = root as BlockSvg;
+  const startSvg = start as BlockSvg;
+  if (typeof rootSvg.getRelativeToSurfaceXY !== "function") return;
+  const pos = rootSvg.getRelativeToSurfaceXY();
+  const rootH = rootSvg.getHeightWidth?.().height ?? 80;
+  if (typeof startSvg.moveBy === "function") {
+    const startPos = startSvg.getRelativeToSurfaceXY?.() ?? { x: START_X, y: START_Y };
+    const dx = pos.x - startPos.x;
+    const dy = pos.y - rootH - 12 - startPos.y;
+    if (dx || dy) startSvg.moveBy(dx, dy);
+  }
+}
+
+/** Find the scaffold / product root among top blocks (excluding defaults and start). */
+export function findScaffoldInstanceRoot(workspace: Blockly.Workspace): Blockly.Block | null {
+  const underStart = findInstanceRootUnderStart(workspace);
+  if (underStart) return underStart;
+  for (const top of workspace.getTopBlocks(false)) {
+    if (top.type === DEFAULTS_BLOCK_TYPE || top.type === CONVERSION_START_TYPE) continue;
+    if (top.type === "maps_create_with") continue;
+    if (isInstanceRootBlockType(top.type) || top.type === "composition") return top;
+    if (top.type.startsWith("schema_")) return top;
+  }
+  return null;
+}
+
+/** Ensure Start caps the scaffold root; attach if a suitable root exists without Start. */
+export function ensureConversionStartOnScaffold(workspace: Blockly.Workspace): void {
+  const root = findScaffoldInstanceRoot(workspace);
+  if (!root) return;
+  if (root.type === CONVERSION_START_TYPE) return;
+  attachStartToInstanceRoot(workspace, root);
+}
+
+/** Reject a second Conversion start being placed (dispose the newcomer). */
+export function enforceConversionStartUniqueness(workspace: Blockly.Workspace): void {
+  const starts = workspace.getTopBlocks(false).filter((b) => b.type === CONVERSION_START_TYPE);
+  if (starts.length <= 1) return;
+  const keep = findConversionStartBlock(workspace) ?? starts[0]!;
+  for (const block of starts) {
+    if (block.id !== keep.id) block.dispose(false);
+  }
+}
+
+export function isValidStartConnection(
+  startNext: Blockly.Connection,
+  rootPrev: Blockly.Connection,
+): boolean {
+  return (
+    startNext.type === Blockly.NEXT_STATEMENT &&
+    rootPrev.type === Blockly.PREVIOUS_STATEMENT &&
+    startNext.check === INSTANCE_ROOT_CONNECTION
+  );
+}

--- a/src/blockly/instance_root.ts
+++ b/src/blockly/instance_root.ts
@@ -1,0 +1,83 @@
+/**
+ * Instance root connection contract for Conversion start (ADR 0008).
+ */
+import type { Block } from "blockly/core";
+import { Blockly } from "./blockly_core.ts";
+import type { TargetFormatId } from "../types/mod.ts";
+import { isSchemaStructureBlock } from "./blocks/target_blocks.ts";
+import { isRmContainerBlockType } from "./blocks/rm_blocks.ts";
+
+export const CONVERSION_START_TYPE = "conversion_start";
+export const TEXT_DOCUMENT_BLOCK_TYPE = "text_document";
+export const INSTANCE_ROOT_CONNECTION = "INSTANCE_ROOT";
+
+export const INSTANCE_ROOT_BLOCK_TYPES = new Set([
+  "composition",
+  "json_object",
+  "xml_element",
+  TEXT_DOCUMENT_BLOCK_TYPE,
+]);
+
+export function isInstanceRootBlockType(type: string): boolean {
+  if (INSTANCE_ROOT_BLOCK_TYPES.has(type)) return true;
+  return type.startsWith("schema_");
+}
+
+/** Cap an instance root: previous notch for Start, no next notch. */
+export function applyInstanceRootCap(block: Block): void {
+  if (block.outputConnection?.isConnected()) block.outputConnection.disconnect();
+  if (block.nextConnection?.isConnected()) block.nextConnection.disconnect();
+  block.setOutput(false);
+  block.setNextStatement(false);
+  block.setPreviousStatement(true, INSTANCE_ROOT_CONNECTION);
+  (block as Block & { isInstanceRoot_?: boolean }).isInstanceRoot_ = true;
+}
+
+export function inferTargetFormatFromRoot(block: Block): TargetFormatId | undefined {
+  const type = block.type;
+  if (type === "composition" || isRmContainerBlockType(type)) return "openehr-template";
+  if (isSchemaStructureBlock(block)) {
+    const targetType = String(block.getFieldValue("TARGET_TYPE") || "");
+    if (targetType.includes("xml") || type.includes("xml")) return "xml-schema";
+    return "json-schema";
+  }
+  if (type === "xml_element") return "xml-schema";
+  if (type === "json_object") return "json-schema";
+  if (type === TEXT_DOCUMENT_BLOCK_TYPE) return "free-form";
+  return undefined;
+}
+
+/** Walk from Conversion start to the designated instance root block. */
+export function findInstanceRootUnderStart(workspace: Blockly.Workspace): Block | null {
+  for (const top of workspace.getTopBlocks(false)) {
+    if (top.type !== CONVERSION_START_TYPE) continue;
+    const next = top.getNextBlock();
+    if (next) return next;
+  }
+  return null;
+}
+
+export function findConversionStartBlock(workspace: Blockly.Workspace): Block | null {
+  for (const top of workspace.getTopBlocks(false)) {
+    if (top.type === CONVERSION_START_TYPE) return top;
+  }
+  return null;
+}
+
+export function registerConversionStartBlock(): void {
+  if (Blockly.Blocks[CONVERSION_START_TYPE]) return;
+  Blockly.Blocks[CONVERSION_START_TYPE] = {
+    init: function (this: Block) {
+      this.appendDummyInput("HEADER")
+        .appendField("▶")
+        .appendField("Conversion start");
+      this.setNextStatement(true, INSTANCE_ROOT_CONNECTION);
+      this.setColour("#43A047");
+      this.setTooltip(
+        "Designates which tree is the conversion product. Not a script trigger — mapping preview and export walk this tree only.",
+      );
+      this.setDeletable(true);
+      this.setMovable(true);
+    },
+  };
+}

--- a/src/blockly/mod.ts
+++ b/src/blockly/mod.ts
@@ -106,6 +106,20 @@ export {
   restoreDefaultsBlockState,
   serializeDefaultsMapArgument,
 } from "./defaults_canvas.ts";
+export {
+  attachStartToInstanceRoot,
+  ensureConversionStartOnScaffold,
+  enforceConversionStartUniqueness,
+  findScaffoldInstanceRoot,
+} from "./conversion_start_canvas.ts";
+export {
+  CONVERSION_START_TYPE,
+  TEXT_DOCUMENT_BLOCK_TYPE,
+  registerConversionStartBlock,
+  findInstanceRootUnderStart,
+  inferTargetFormatFromRoot,
+  isInstanceRootBlockType,
+} from "./instance_root.ts";
 export { setDefaultsMapPickHandler, setDefaultsMapInfoHandler, setDefaultsMapHardcodeHandler } from "./blocks/map_blocks.ts";
 export {
   defaultsMapKeys,
@@ -128,6 +142,8 @@ export {
   registerTypeScriptExportAdapter,
 } from "./typescript_codegen.ts";
 
+import { registerConversionStartBlock } from "./instance_root.ts";
+
 export function initBlocklyGenerators(): void {
   registerRmBlocks();
   registerTargetBlocks();
@@ -135,6 +151,7 @@ export function initBlocklyGenerators(): void {
   registerMapBlocks();
   registerSheetBlocks();
   registerTextBlocks();
+  registerConversionStartBlock();
   registerLogicBlocks();
   registerExtractToFunctionMenu();
   registerGenerators();

--- a/src/blockly/schema_blocks.ts
+++ b/src/blockly/schema_blocks.ts
@@ -18,6 +18,7 @@ import {
   syncSchemaFieldInputs,
   TARGET_CHILD_PREFIX,
 } from "./blocks/target_blocks.ts";
+import { applyInstanceRootCap } from "./instance_root.ts";
 
 export type { SchemaInputSpec };
 export { specForChild, schemaInputSpecs } from "../core/target/schema_block_ids.ts";
@@ -30,6 +31,7 @@ export interface SchemaStructureExtraState {
   childGroups?: string[];
   extras?: string[];
   xmlAttributes?: string[];
+  instanceRoot?: boolean;
 }
 
 export function registerSchemaBlocksFromSkeleton(skeleton: SkeletonNode[]): void {
@@ -84,6 +86,9 @@ export function schemaExtraStateOf(block: Block): SchemaStructureExtraState | nu
     .filter((input) => input.name.startsWith(TARGET_CHILD_PREFIX))
     .map((input) => input.name.slice(TARGET_CHILD_PREFIX.length));
   if (!fields?.length && childGroups.length) payload.childGroups = childGroups;
+  if ((block as Block & { isInstanceRoot_?: boolean }).isInstanceRoot_) {
+    payload.instanceRoot = true;
+  }
   return Object.keys(payload).length ? payload : null;
 }
 
@@ -108,6 +113,7 @@ export function restoreSchemaExtraState(
   block.schemaExtraFields_ = Array.isArray(state?.extras) ? state!.extras! : [];
   block.schemaOptionalSpecs_ = Array.isArray(state?.optionalFields) ? state!.optionalFields! : [];
   block.updateSchemaFields_?.();
+  if (state?.instanceRoot) applyInstanceRootCap(block);
 }
 
 export function schemaSlotIdForInput(block: Block, inputName: string): string | null {

--- a/src/blockly/skeleton_loader.ts
+++ b/src/blockly/skeleton_loader.ts
@@ -33,6 +33,8 @@ import {
   placeDefaultsBesideSkeleton,
   restoreDefaultsBlockState,
 } from "./defaults_canvas.ts";
+import { attachStartToInstanceRoot } from "./conversion_start_canvas.ts";
+import { findInstanceRootUnderStart } from "./instance_root.ts";
 import { isGenericValueBlockType, isSchemaStructureBlock } from "./blocks/target_blocks.ts";
 import { targetChildInputName } from "./blocks/target_blocks.ts";
 import { schemaOptionalInputName, composeSchemaOptionalFields } from "./blocks/schema_mutator.ts";
@@ -87,6 +89,10 @@ export function loadSkeletonIntoWorkspace(
     applyModelExpressions(workspace, model);
     restoreDefaultsBlockState(workspace, savedDefaults, uiLanguage, targetFormat);
     placeDefaultsBesideSkeleton(workspace);
+    const scaffoldRoot = workspace.getTopBlocks(false).find((b) =>
+      b.type !== "defaults_block" && b.type !== "maps_create_with" && b.type !== "conversion_start"
+    );
+    if (scaffoldRoot) attachStartToInstanceRoot(workspace, scaffoldRoot);
     if (!schemaTarget) {
       attachDefaultPointLookups(workspace, skeleton, (parent, insertion) =>
         attachOptionalRmChild(workspace, parent, insertion)
@@ -118,6 +124,8 @@ export function lockWorkspaceRootsExpanded(workspace: Blockly.Workspace): void {
   for (const block of workspace.getTopBlocks(false)) {
     lockRootExpanded(block);
   }
+  const instanceRoot = findInstanceRootUnderStart(workspace);
+  if (instanceRoot) lockRootExpanded(instanceRoot);
 }
 
 /**
@@ -128,6 +136,8 @@ export function setAllBlocksCollapsed(
   collapsed: boolean,
 ): void {
   const roots = new Set(workspace.getTopBlocks(false));
+  const instanceRoot = findInstanceRootUnderStart(workspace);
+  if (instanceRoot) roots.add(instanceRoot);
   const grouped = typeof Blockly.Events.setGroup === "function";
   if (grouped) Blockly.Events.setGroup(true);
   try {

--- a/src/blockly/toolbox_demo.ts
+++ b/src/blockly/toolbox_demo.ts
@@ -57,6 +57,10 @@ function mapsCreateWithToolboxBlock(itemCount: number): Record<string, unknown> 
   };
 }
 
+function conversionStartToolboxBlock(): Record<string, unknown> {
+  return { kind: "block", type: "conversion_start", gap: 8 };
+}
+
 function compositionToolboxBlock(): Record<string, unknown> {
   return {
     kind: "block",
@@ -73,6 +77,7 @@ function compositionToolboxBlock(): Record<string, unknown> {
 
 function openEhrTypeToolboxContents(m: ReturnType<typeof msg>): Array<Record<string, unknown>> {
   return [
+    conversionStartToolboxBlock(),
     { kind: "label", text: m.CAT_OPENEHR_ENTRIES },
     compositionToolboxBlock(),
     { kind: "block", type: "section", gap: 8 },
@@ -171,6 +176,7 @@ export function buildDemoToolbox(locale: string, context: ToolboxContext = {}): 
       colour: 40,
       cssconfig: { row: "blocklyToolboxCategory blocklyToolboxCategoryJson" },
       contents: [
+        conversionStartToolboxBlock(),
         { kind: "block", type: "json_object", gap: 8 },
         { kind: "block", type: "json_array", gap: 8 },
         { kind: "block", type: "json_value", gap: 8 },
@@ -186,6 +192,7 @@ export function buildDemoToolbox(locale: string, context: ToolboxContext = {}): 
       colour: 200,
       cssconfig: { row: "blocklyToolboxCategory blocklyToolboxCategoryXml" },
       contents: [
+        conversionStartToolboxBlock(),
         {
           kind: "block",
           type: "xml_element",
@@ -354,6 +361,8 @@ export function buildDemoToolbox(locale: string, context: ToolboxContext = {}): 
         colour: 46,
         cssconfig: { row: "blocklyToolboxCategory blocklyToolboxCategoryText" },
         contents: [
+          conversionStartToolboxBlock(),
+          { kind: "block", type: "text_document" },
           { kind: "block", type: "text" },
           {
             kind: "block",

--- a/src/blockly/typescript_codegen.ts
+++ b/src/blockly/typescript_codegen.ts
@@ -23,6 +23,12 @@ import { registerSchemaBlocksFromSkeleton } from "./schema_blocks.ts";
 import { TERM_PICK_BLOCK_TYPE } from "./blocks/term_pick.ts";
 import { TERM_PICK_NONE, termSetById } from "../core/openehr_term_catalog.ts";
 import { DEFAULTS_BLOCK_TYPE } from "../core/defaults/extract.ts";
+import {
+  CONVERSION_START_TYPE,
+  findInstanceRootUnderStart,
+  inferTargetFormatFromRoot,
+  TEXT_DOCUMENT_BLOCK_TYPE,
+} from "./instance_root.ts";
 import { attributesFor, isPrimitiveRmType } from "../core/rm_meta.ts";
 import { LOCATABLE_TYPES } from "../core/rm_mandatory.ts";
 import type { MappingModel } from "../types/mod.ts";
@@ -96,16 +102,25 @@ export function generateTypeScriptFromWorkspace(
   model: MappingModel,
 ): string | null {
   const ctx = createTsEmitContext();
+  const instanceRoot = findInstanceRootUnderStart(workspace);
   const roots = workspace.getTopBlocks(true).filter((block) =>
     block.type !== DEFAULTS_BLOCK_TYPE &&
-    block.type !== "maps_create_with"
+    block.type !== "maps_create_with" &&
+    block.type !== CONVERSION_START_TYPE
   );
-  const composition = roots.find((block) => block.type === "composition") ??
-    roots.find((block) => isRmContainerBlockType(block.type));
+  const composition = instanceRoot?.type === "composition" ? instanceRoot
+    : roots.find((block) => block.type === "composition") ??
+      roots.find((block) => isRmContainerBlockType(block.type));
+
+  const targetFormat = model.targetFormat ??
+    (instanceRoot ? inferTargetFormatFromRoot(instanceRoot) : undefined);
 
   let body: string;
   let rootType: string | undefined;
-  if (composition) {
+  if (instanceRoot?.type === TEXT_DOCUMENT_BLOCK_TYPE) {
+    const value = instanceRoot.getInputTargetBlock("VALUE");
+    body = value ? `return ${emitBlock(value, ctx, 0)};` : 'return "";';
+  } else if (composition) {
     const code = emitBlock(composition, ctx, 0);
     rootType = rmTypeOf(composition);
     if (rootType === "COMPOSITION") {
@@ -113,8 +128,14 @@ export function generateTypeScriptFromWorkspace(
     } else {
       body = `return ${code};`;
     }
-  } else if (model.targetFormat && model.targetFormat !== "openehr-template") {
-    const generic = roots.find((block) =>
+  } else if (instanceRoot && (
+    isSchemaStructureBlock(instanceRoot) ||
+    instanceRoot.type === "json_object" ||
+    instanceRoot.type === "xml_element"
+  )) {
+    body = `return ${emitGeneric(instanceRoot, ctx, 0)};`;
+  } else if (targetFormat && targetFormat !== "openehr-template") {
+    const generic = instanceRoot ?? roots.find((block) =>
       isSchemaStructureBlock(block) || block.type === "json_object" || block.type === "xml_element"
     );
     if (generic) {

--- a/src/ui/mapping_spec_chrome.ts
+++ b/src/ui/mapping_spec_chrome.ts
@@ -1,0 +1,94 @@
+/**
+ * Mapping Spec root layout chrome: list vs tabbed view, root tab bar.
+ */
+import { projectBlocklyState } from "../workbench/mapping_spec/project.ts";
+
+export type SpecRootLayout = "list" | "tabs";
+
+const STORAGE_KEY = "intehrgrator-spec-root-layout";
+
+export interface SpecRootTab {
+  id: string;
+  label: string;
+}
+
+export function loadSpecRootLayout(): SpecRootLayout {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === "tabs" ? "tabs" : "list";
+}
+
+export function saveSpecRootLayout(layout: SpecRootLayout): void {
+  localStorage.setItem(STORAGE_KEY, layout);
+}
+
+export function specRootTabsFromBlockly(blocklyState: unknown): SpecRootTab[] {
+  const projection = projectBlocklyState(blocklyState);
+  const tabs: SpecRootTab[] = [];
+  const seen = new Set<string>();
+  for (const line of projection.lines) {
+    if (line.kind !== "header" || !line.rootId || seen.has(line.rootId)) continue;
+    if (line.type === "conversion_start") continue;
+    seen.add(line.rootId);
+    tabs.push({ id: line.rootId, label: line.label || line.type });
+  }
+  return tabs;
+}
+
+export function mountMappingSpecChrome(
+  specEditorHost: HTMLElement,
+  options: {
+    getBlocklyState: () => unknown;
+    onLayoutChange: (layout: SpecRootLayout, activeRootId: string | null) => void;
+  },
+): {
+  refresh: () => void;
+  getLayout: () => SpecRootLayout;
+  getActiveRootId: () => string | null;
+  setLayout: (layout: SpecRootLayout) => void;
+} {
+  let layout = loadSpecRootLayout();
+  let activeRootId: string | null = null;
+
+  const rootTabsEl = document.createElement("div");
+  rootTabsEl.className = "spec-root-tabs";
+  rootTabsEl.hidden = layout !== "tabs";
+  specEditorHost.parentElement?.insertBefore(rootTabsEl, specEditorHost);
+
+  const refresh = (): void => {
+    const tabs = specRootTabsFromBlockly(options.getBlocklyState());
+    rootTabsEl.hidden = layout !== "tabs" || tabs.length <= 1;
+    rootTabsEl.replaceChildren();
+    if (layout !== "tabs" || tabs.length <= 1) {
+      activeRootId = null;
+      options.onLayoutChange(layout, null);
+      return;
+    }
+    if (!activeRootId || !tabs.some((t) => t.id === activeRootId)) {
+      activeRootId = tabs[0]?.id ?? null;
+    }
+    for (const tab of tabs) {
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "spec-root-tab" + (tab.id === activeRootId ? " active" : "");
+      btn.textContent = tab.label;
+      btn.title = tab.label;
+      btn.addEventListener("click", () => {
+        activeRootId = tab.id;
+        refresh();
+      });
+      rootTabsEl.append(btn);
+    }
+    options.onLayoutChange(layout, activeRootId);
+  };
+
+  return {
+    refresh,
+    getLayout: () => layout,
+    getActiveRootId: () => activeRootId,
+    setLayout: (next) => {
+      layout = next;
+      saveSpecRootLayout(next);
+      refresh();
+    },
+  };
+}

--- a/src/ui/sheets_panel.ts
+++ b/src/ui/sheets_panel.ts
@@ -55,6 +55,10 @@ export function mountSheetsPanel(
   root.innerHTML = "";
   const toolbar = document.createElement("div");
   toolbar.className = "sheets-toolbar";
+  const tabsEl = document.createElement("div");
+  tabsEl.className = "sheets-tabs";
+  tabsEl.setAttribute("role", "tablist");
+  tabsEl.setAttribute("aria-label", "Sheets");
   const select = document.createElement("select");
   select.className = "sheets-select";
   select.setAttribute("aria-label", "Sheet");
@@ -80,7 +84,7 @@ export function mountSheetsPanel(
   fileInput.type = "file";
   fileInput.accept = ".csv,.tsv,.txt";
   fileInput.hidden = true;
-  toolbar.append(select, addBtn, renameBtn, deleteBtn, importBtn, exportBtn, fullBtn, fileInput);
+  toolbar.append(tabsEl, select, addBtn, renameBtn, deleteBtn, importBtn, exportBtn, fullBtn, fileInput);
 
   const emptyEl = document.createElement("p");
   emptyEl.className = "sheets-empty";
@@ -222,6 +226,29 @@ export function mountSheetsPanel(
     }
     if (sheets.some((s) => s.name === current)) select.value = current;
     else if (sheets[0]) select.value = sheets[0].name;
+    const multi = sheets.length > 1;
+    tabsEl.hidden = !multi;
+    select.hidden = multi;
+    tabsEl.replaceChildren();
+    if (multi) {
+      const selected = select.value || activeName;
+      for (const sheet of sheets) {
+        const tab = document.createElement("button");
+        tab.type = "button";
+        tab.className = "sheets-tab" + (sheet.name === selected ? " active" : "");
+        tab.textContent = sheet.name;
+        tab.setAttribute("role", "tab");
+        tab.setAttribute("aria-selected", sheet.name === selected ? "true" : "false");
+        tab.addEventListener("click", () => {
+          select.value = sheet.name;
+          activeName = sheet.name;
+          const doc = findSheet(host.getSheets(), sheet.name);
+          if (doc) bindSheet(doc);
+          fillSelect(host.getSheets());
+        });
+        tabsEl.append(tab);
+      }
+    }
   };
 
   const refresh = (): void => {

--- a/src/workbench/mapping_spec/editor.ts
+++ b/src/workbench/mapping_spec/editor.ts
@@ -10,6 +10,7 @@ import {
 import { foldGutter, foldKeymap, foldService } from "@codemirror/language";
 import {
   blocklyJsonDocument,
+  blocklyJsonDocumentForRoot,
   type BlocklyJsonDocument,
   type SpecLine,
 } from "./project.ts";
@@ -514,12 +515,20 @@ export function createMappingSpecEditor(
 }
 
 /** Replace the Spec view from canonical Blockly workspace JSON. */
+export interface MappingSpecViewOptions {
+  /** When set, show only rows for this canvas root (tabbed view). */
+  rootId?: string | null;
+}
+
 export function setMappingSpecFromBlockly(
   view: EditorView,
   blocklyState: unknown,
   chrome: SpecChrome = emptyChrome,
+  viewOptions: MappingSpecViewOptions = {},
 ): void {
-  const next = blocklyJsonDocument(blocklyState);
+  const next = viewOptions.rootId
+    ? blocklyJsonDocumentForRoot(blocklyState, viewOptions.rootId)
+    : blocklyJsonDocument(blocklyState);
   const current = view.state.doc.toString();
   if (current === next.text) {
     setMappingSpecChrome(view, chrome);

--- a/src/workbench/mapping_spec/overview.ts
+++ b/src/workbench/mapping_spec/overview.ts
@@ -26,6 +26,7 @@ export function specWarningMarkers(
 ): SpecWarningMarker[] {
   const out: SpecWarningMarker[] = [];
   for (const widget of doc.widgets) {
+    if (widget.line.kind === "header") continue;
     const ids = [widget.line.blockId, ...(widget.line.aliasIds ?? [])].filter(
       (id): id is string => Boolean(id),
     );

--- a/src/workbench/mapping_spec/project.ts
+++ b/src/workbench/mapping_spec/project.ts
@@ -66,6 +66,8 @@ export interface SpecEditableField {
 export interface SpecLine {
   kind: SpecLineKind;
   indent: number;
+  /** Top-level canvas root this row belongs to (for tabbed Spec view). */
+  rootId?: string;
   /** Stable Blockly block id when this line maps to a block. */
   blockId?: string;
   /** Skipped wrapper / nested-logic ids that should scroll/highlight this row. */
@@ -118,6 +120,8 @@ interface BlocklyWorkspaceJson {
   variables?: unknown;
 }
 
+let projectingRootId: string | undefined;
+
 const DV_PREFIX = "dv_";
 const COMPARE_OP: Record<string, string> = {
   EQ: "=",
@@ -144,9 +148,75 @@ export function projectBlocklyState(state: unknown): SpecProjection {
   }
 
   for (const root of roots) {
+    if (root.type === "conversion_start") {
+      projectingRootId = idOf(root);
+      emit(lines, {
+        kind: "header",
+        indent: 0,
+        rootId: projectingRootId,
+        type: "conversion_start",
+        label: "Conversion start",
+        summary: "product marker",
+        editKind: "none",
+        info: collectInfo(root),
+      });
+      const instance = root.next?.block;
+      if (instance) {
+        projectingRootId = idOf(instance) ?? projectingRootId;
+        emit(lines, rootDividerLine(instance, projectingRootId!));
+        walkBlock(instance, 0, lines);
+      }
+      continue;
+    }
+    projectingRootId = idOf(root) ?? `root-${lines.length}`;
+    emit(lines, rootDividerLine(root, projectingRootId));
     walkBlock(root, 0, lines);
   }
   return toProjection(lines);
+}
+
+function rootDividerLine(block: BlocklyBlockJson, rootId: string): SpecLine {
+  return {
+    kind: "header",
+    indent: 0,
+    rootId,
+    blockId: idOf(block),
+    type: block.type ?? "root",
+    label: rootLabel(block),
+    summary: rootLabel(block),
+    editKind: "none",
+    info: collectInfo(block),
+  };
+}
+
+function rootLabel(block: BlocklyBlockJson): string {
+  const type = block.type ?? "block";
+  if (type === "defaults_block") return "Default context mapping";
+  if (type === "composition") return "COMPOSITION";
+  if (type.startsWith("procedures_def")) {
+    return stringField(block, "NAME") || "Function";
+  }
+  const name = stringField(block, "NAME") || stringField(block, "RM_TYPE");
+  return name ? `${type} · ${name}` : type;
+}
+
+/** Lines grouped by top-level canvas root (for tabbed Mapping Spec view). */
+export function projectBlocklyStateByRoot(state: unknown): Map<string, SpecLine[]> {
+  const projection = projectBlocklyState(state);
+  const groups = new Map<string, SpecLine[]>();
+  let currentRoot = "";
+  for (const line of projection.lines) {
+    if (line.kind === "header" && line.rootId) {
+      currentRoot = line.rootId;
+      if (!groups.has(currentRoot)) groups.set(currentRoot, []);
+      groups.get(currentRoot)!.push(line);
+      continue;
+    }
+    const rootId = line.rootId ?? currentRoot;
+    if (!groups.has(rootId)) groups.set(rootId, []);
+    groups.get(rootId)!.push(line);
+  }
+  return groups;
 }
 
 function emptyLine(label: string, info: Record<string, unknown>): SpecLine {
@@ -166,6 +236,7 @@ function emit(
   line: SpecLine,
   attributeEdit?: SpecEditableField,
 ): void {
+  if (projectingRootId && !line.rootId) line.rootId = projectingRootId;
   if (attributeEdit) line.attributeEdit = attributeEdit;
   lines.push(line);
 }
@@ -188,6 +259,11 @@ function walkBlock(
   attributeEdit?: SpecEditableField,
 ): void {
   const type = block.type ?? "unknown";
+
+  if (type === "conversion_start") {
+    if (block.next?.block) walkBlock(block.next.block, indent, lines, attribute, extraAliases, shell, attributeEdit);
+    return;
+  }
 
   if (type === "xml_text" || type === "json_value" || type === "target_value") {
     walkInputs(block, indent, lines, attribute, withAlias(extraAliases, idOf(block)), shell, attributeEdit);
@@ -950,10 +1026,27 @@ export interface BlocklyJsonDocument {
   widgets: Array<{ from: number; to: number; line: SpecLine }>;
 }
 
-/** Compact Spec text plus widget ranges, one range per projected line. */
-export function blocklyJsonDocument(state: unknown): BlocklyJsonDocument {
+/** Spec document filtered to one canvas root (tabbed view). */
+export function blocklyJsonDocumentForRoot(
+  state: unknown,
+  rootId: string,
+): BlocklyJsonDocument {
   const projection = projectBlocklyState(state);
-  const text = projection.text;
+  const lines = projection.lines.filter((line) => line.rootId === rootId);
+  return toBlocklyJsonDocument(lines);
+}
+
+function toBlocklyJsonDocument(lines: SpecLine[]): BlocklyJsonDocument {
+  const text = lines
+    .map((line) => {
+      const pad = "  ".repeat(line.indent);
+      const parts = [line.type];
+      if (line.summary) parts.push(line.summary);
+      else if (line.label && line.label !== line.type) parts.push(line.label);
+      const body = parts.join(" · ");
+      return line.attribute ? `${pad}${line.attribute}  ${body}` : `${pad}${body}`;
+    })
+    .join("\n");
   const widgets: BlocklyJsonDocument["widgets"] = [];
   let offset = 0;
   const rows = text.length ? text.split("\n") : [""];
@@ -962,10 +1055,16 @@ export function blocklyJsonDocument(state: unknown): BlocklyJsonDocument {
     const from = offset;
     const to = from + row.length;
     offset = to + (i < rows.length - 1 ? 1 : 0);
-    const line = projection.lines[i];
+    const line = lines[i];
     if (line) widgets.push({ from, to, line });
   }
   return { text, widgets };
+}
+
+/** Compact Spec text plus widget ranges, one range per projected line. */
+export function blocklyJsonDocument(state: unknown): BlocklyJsonDocument {
+  const projection = projectBlocklyState(state);
+  return toBlocklyJsonDocument(projection.lines);
 }
 
 function toProjection(lines: SpecLine[]): SpecProjection {

--- a/src/workbench/mapping_spec/widgets.ts
+++ b/src/workbench/mapping_spec/widgets.ts
@@ -34,6 +34,7 @@ export class MappingSpecWidget extends WidgetType {
   }
 
   override get estimatedHeight(): number {
+    if (this.line.kind === "header") return 22;
     if (this.line.editKind === "code") {
       const text = this.line.editable?.find((f) => f.field === "TEXT")?.value ?? "";
       const rows = Math.min(CODE_MAX_ROWS, Math.max(3, text.split("\n").length));
@@ -43,6 +44,11 @@ export class MappingSpecWidget extends WidgetType {
   }
 
   override eq(other: MappingSpecWidget): boolean {
+    if (this.line.kind === "header" || other.line.kind === "header") {
+      return this.line.kind === other.line.kind &&
+        this.line.label === other.line.label &&
+        this.line.blockId === other.line.blockId;
+    }
     return (
       this.line.blockId === other.line.blockId &&
       this.line.kind === other.line.kind &&
@@ -61,6 +67,21 @@ export class MappingSpecWidget extends WidgetType {
   }
 
   override toDOM(): HTMLElement {
+    if (this.line.kind === "header") {
+      const divider = document.createElement("div");
+      divider.className = "spec-root-divider";
+      const label = document.createElement("span");
+      label.className = "spec-root-divider-label";
+      label.textContent = this.line.label || this.line.summary || this.line.type;
+      divider.appendChild(label);
+      if (this.line.blockId) divider.dataset.blockId = this.line.blockId;
+      if (this.onSelect && this.line.blockId) {
+        divider.tabIndex = 0;
+        divider.classList.add("spec-root-divider--clickable");
+        divider.addEventListener("click", () => this.onSelect?.(this.line.blockId!));
+      }
+      return divider;
+    }
     const row = document.createElement("span");
     row.className = `spec-widget spec-widget--${this.line.kind}`;
     if (this.line.editKind === "code") row.classList.add("spec-widget--multiline");

--- a/test/block_type_glyph_test.ts
+++ b/test/block_type_glyph_test.ts
@@ -1,0 +1,15 @@
+import { assertEquals } from "@std/assert";
+import { glyphForBlocklyCheck } from "@intehrgrator/blockly/block_type_glyph.ts";
+import { ABSTRACT_SLOT_GLYPH } from "@intehrgrator/blockly/rm_type_emoji.ts";
+
+Deno.test("glyphForBlocklyCheck maps Blockly primitives", () => {
+  assertEquals(typeof glyphForBlocklyCheck("String"), "string");
+  assertEquals(typeof glyphForBlocklyCheck("Number"), "string");
+  assertEquals(typeof glyphForBlocklyCheck("Boolean"), "string");
+  assertEquals(glyphForBlocklyCheck("Array"), "📋");
+  assertEquals(glyphForBlocklyCheck("Map"), "🗺️");
+});
+
+Deno.test("glyphForBlocklyCheck uses abstract glyph for unions", () => {
+  assertEquals(glyphForBlocklyCheck(["String", "Number", "Boolean"]), ABSTRACT_SLOT_GLYPH);
+});

--- a/test/block_type_glyph_test.ts
+++ b/test/block_type_glyph_test.ts
@@ -5,9 +5,9 @@ import { ABSTRACT_SLOT_GLYPH } from "@intehrgrator/blockly/rm_type_emoji.ts";
 Deno.test("glyphForBlocklyCheck maps Blockly primitives", () => {
   assertEquals(typeof glyphForBlocklyCheck("String"), "string");
   assertEquals(typeof glyphForBlocklyCheck("Number"), "string");
-  assertEquals(typeof glyphForBlocklyCheck("Boolean"), "string");
+  assertEquals(glyphForBlocklyCheck("Boolean"), "✓");
   assertEquals(glyphForBlocklyCheck("Array"), "📋");
-  assertEquals(glyphForBlocklyCheck("Map"), "🗺️");
+  assertEquals(glyphForBlocklyCheck("Map"), "↦");
 });
 
 Deno.test("glyphForBlocklyCheck uses abstract glyph for unions", () => {

--- a/test/blockly_rm_blocks_test.ts
+++ b/test/blockly_rm_blocks_test.ts
@@ -29,6 +29,12 @@ import {
 } from "@intehrgrator/blockly/blocks/rm_blocks.ts";
 import { registerExpressionBlocks } from "@intehrgrator/blockly/blocks/expression_blocks.ts";
 import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
+import { findInstanceRootUnderStart } from "@intehrgrator/blockly/instance_root.ts";
+
+function compositionRoot(workspace: Blockly.Workspace): Blockly.Block | undefined {
+  return findInstanceRootUnderStart(workspace) ??
+    workspace.getTopBlocks(false).find((block) => block.type === "composition");
+}
 import { zipehrEmojiForRmType } from "@intehrgrator/core/rm_emoji.ts";
 import {
   ABSTRACT_SLOT_GLYPH,
@@ -244,7 +250,7 @@ Deno.test("loadSkeletonIntoWorkspace auto-attaches mandatory DV shells", () => {
   );
   assert(observation, "expected observation block");
   assertEquals(observation.type, "observation");
-  const root = workspace.getTopBlocks(false).find((block) => block.type === "composition");
+  const root = compositionRoot(workspace);
   assertEquals(root?.type, "composition");
   assertEquals(
     workspace.getAllBlocks(false).some((b) => b.type === "rm_structure"),
@@ -273,9 +279,8 @@ Deno.test("imported skeleton starts expanded; collapse-all skips the root", () =
   const workspace = new Blockly.Workspace();
   loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
 
-  const roots = workspace.getTopBlocks(false);
-  assert(roots.length >= 1, "expected a root block");
-  const root = roots[0];
+  const root = compositionRoot(workspace);
+  assert(root, "expected composition instance root");
   assertEquals(root.isCollapsed(), false);
 
   const nested = workspace.getAllBlocks(false).filter((block) => {
@@ -345,7 +350,12 @@ Deno.test("COMPOSITION toolbox block has mandatory RM slots", () => {
     "CONTENT_ITEM",
   ]);
   assert(block.getInput(rmAttributeInputName("context")), "expected context statement");
-  assertEquals(block.previousConnection, null);
+  assert(block.previousConnection, "COMPOSITION accepts Conversion start on previous notch");
+  const prevCheck = block.previousConnection?.getCheck();
+  assertEquals(
+    prevCheck === "INSTANCE_ROOT" || (Array.isArray(prevCheck) && prevCheck.includes("INSTANCE_ROOT")),
+    true,
+  );
   workspace.dispose();
 });
 
@@ -578,7 +588,7 @@ Deno.test("Optional RM Insertion attaches a typed child without clearing the can
   const { skeleton } = generateSkeleton(fixture);
   const workspace = new Blockly.Workspace();
   loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
-  const root = workspace.getTopBlocks(false).find((block) => block.type === "composition");
+  const root = compositionRoot(workspace);
   assert(root);
   const beforeIds = new Set(workspace.getAllBlocks(false).map((b) => b.id));
   const child = attachOptionalRmChild(workspace as unknown as Blockly.WorkspaceSvg, root, {
@@ -643,7 +653,7 @@ Deno.test("skeleton canvas plugs language and territory Defaults lookups into CO
   const workspace = new Blockly.Workspace();
   loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
 
-  const composition = workspace.getTopBlocks(false).find((block) => block.type === "composition");
+  const composition = compositionRoot(workspace);
   assertEquals(composition?.type, "composition");
   const languageInput = composition.getInput(rmAttributeInputName("language"));
   assertEquals(languageInput?.connection?.getCheck(), ["CODE_PHRASE"]);
@@ -686,7 +696,7 @@ Deno.test("skeleton canvas pre-fills COMPOSITION.category from the template", ()
   const { skeleton } = generateSkeleton(persistent);
   const workspace = new Blockly.Workspace();
   loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
-  const composition = workspace.getTopBlocks(false).find((block) => block.type === "composition");
+  const composition = compositionRoot(workspace);
   const category = composition.getInputTargetBlock(rmAttributeInputName("category"));
   assertEquals(category?.type, "term_pick");
   assertEquals(category?.getFieldValue("CODE"), "431");
@@ -715,7 +725,7 @@ Deno.test("optional content observations still scaffold on the canvas", () => {
   }];
   const workspace = new Blockly.Workspace();
   loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
-  const composition = workspace.getTopBlocks(false).find((block) => block.type === "composition");
+  const composition = compositionRoot(workspace);
   const content = composition?.getInputTargetBlock(rmAttributeInputName("content"));
   assertEquals(content?.type, "observation");
   assertEquals(content?.getFieldValue("NAME"), "Blood pressure");
@@ -932,7 +942,7 @@ Deno.test("mandatory containers do not get a warning triangle just for being man
   const { skeleton } = generateSkeleton(fixture);
   const workspace = new Blockly.Workspace();
   loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("t"), null);
-  const composition = workspace.getTopBlocks(false).find((block) => block.type === "composition");
+  const composition = compositionRoot(workspace);
   assert(composition);
   const warning = (warningTextOf(composition) ?? blockConstraintMessages(composition).join("\n"));
   assertEquals(warning.includes("Mandatory"), false);

--- a/test/constraint_overlay_test.ts
+++ b/test/constraint_overlay_test.ts
@@ -191,7 +191,7 @@ Deno.test("mandated mouth shows overlay; quiet sibling has no Δ; protocol is mu
   const workspace = new Blockly.Workspace();
   loadSkeletonIntoWorkspace(workspace, skeleton, createEmptyModel("overlay_fixture"), null);
 
-  const composition = workspace.getTopBlocks(false).find((b) => b.type === "composition");
+  const composition = workspace.getAllBlocks(false).find((b) => b.type === "composition");
   assert(composition);
   const contextLabel = slotLabelOn(composition, "context");
   assert(contextLabel);

--- a/test/conversion_start_test.ts
+++ b/test/conversion_start_test.ts
@@ -1,0 +1,84 @@
+import { assertEquals, assertExists } from "@std/assert";
+import { Blockly } from "@intehrgrator/blockly/blockly_core.ts";
+import { initBlocklyGenerators } from "@intehrgrator/blockly/mod.ts";
+import {
+  attachStartToInstanceRoot,
+  ensureConversionStartOnScaffold,
+  findScaffoldInstanceRoot,
+} from "@intehrgrator/blockly/conversion_start_canvas.ts";
+import {
+  CONVERSION_START_TYPE,
+  findConversionStartBlock,
+  findInstanceRootUnderStart,
+  inferTargetFormatFromRoot,
+  TEXT_DOCUMENT_BLOCK_TYPE,
+} from "@intehrgrator/blockly/instance_root.ts";
+import { registerTargetBlocks } from "@intehrgrator/blockly/blocks/target_blocks.ts";
+import { generateTypeScriptFromWorkspace } from "@intehrgrator/blockly/typescript_codegen.ts";
+import { createEmptyModel } from "@intehrgrator/core/mapping_model/mod.ts";
+import { projectBlocklyState } from "@intehrgrator/workbench/mapping_spec/mod.ts";
+import { ensureDefaultsBlock } from "@intehrgrator/blockly/defaults_canvas.ts";
+
+function freshWorkspace(): import("blockly/core").Workspace {
+  initBlocklyGenerators();
+  registerTargetBlocks();
+  return new Blockly.Workspace();
+}
+
+Deno.test("scaffold attach places Conversion start above json_object root", () => {
+  const ws = freshWorkspace();
+  const root = ws.newBlock("json_object");
+  attachStartToInstanceRoot(ws, root);
+  const start = findConversionStartBlock(ws);
+  assertExists(start);
+  assertEquals(findInstanceRootUnderStart(ws)?.type, "json_object");
+  assertEquals(root.nextConnection, null);
+  assertExists(root.previousConnection);
+});
+
+Deno.test("ensureConversionStartOnScaffold attaches when root exists without Start", () => {
+  const ws = freshWorkspace();
+  ensureDefaultsBlock(ws, "en");
+  const root = ws.newBlock("json_object");
+  ensureConversionStartOnScaffold(ws);
+  assertEquals(findConversionStartBlock(ws)?.type, CONVERSION_START_TYPE);
+  assertEquals(findScaffoldInstanceRoot(ws)?.type, "json_object");
+});
+
+Deno.test("schema-less json_object codegen returns object literal", () => {
+  const ws = freshWorkspace();
+  const root = ws.newBlock("json_object");
+  attachStartToInstanceRoot(ws, root);
+  const model = createEmptyModel("");
+  model.targetFormat = inferTargetFormatFromRoot(root);
+  const code = generateTypeScriptFromWorkspace(ws, model);
+  assertExists(code);
+  assertEquals(code.includes("return"), true);
+});
+
+Deno.test("text document instance root codegen returns string expression", () => {
+  const ws = freshWorkspace();
+  const doc = ws.newBlock(TEXT_DOCUMENT_BLOCK_TYPE);
+  const text = ws.newBlock("text");
+  text.setFieldValue("hello", "TEXT");
+  doc.getInput("VALUE")?.connection?.connect(text.outputConnection!);
+  attachStartToInstanceRoot(ws, doc);
+  const model = createEmptyModel("");
+  model.targetFormat = "free-form";
+  const code = generateTypeScriptFromWorkspace(ws, model);
+  assertExists(code);
+  assertEquals(code.includes("hello"), true);
+});
+
+Deno.test("mapping spec treats Conversion start as chrome header", () => {
+  const ws = freshWorkspace();
+  const root = ws.newBlock("json_object");
+  attachStartToInstanceRoot(ws, root);
+  const state = Blockly.serialization.workspaces.save(ws);
+  const projection = projectBlocklyState(state);
+  const startLine = projection.lines.find((l) => l.type === "conversion_start");
+  assertExists(startLine);
+  assertEquals(startLine.kind, "header");
+  const divider = projection.lines.find((l) => l.type === "json_object" && l.kind === "header");
+  assertExists(divider);
+});

--- a/test/handlebars_text_blocks_test.ts
+++ b/test/handlebars_text_blocks_test.ts
@@ -90,10 +90,12 @@ Deno.test("Text toolbox lists CodeMirror text and Handlebars blocks after stock 
   };
   const text = toolbox.contents.find((cat) => cat.name === msg("en").CAT_TEXT);
   const types = (text?.contents ?? []).map((block) => block.type);
-  assertEquals(types[0], "text");
-  assertEquals(types[1], "text_code");
-  assertEquals(types[2], "text_code");
-  assertEquals(types[3], "text_handlebars");
+  assertEquals(types[0], "conversion_start");
+  assertEquals(types[1], "text_document");
+  assertEquals(types[2], "text");
+  assertEquals(types[3], "text_code");
+  assertEquals(types[4], "text_code");
+  assertEquals(types[5], "text_handlebars");
 });
 
 Deno.test("source_query_node outputs Source and serializes to xpathNode", () => {

--- a/test/map_blocks_test.ts
+++ b/test/map_blocks_test.ts
@@ -43,7 +43,7 @@ Deno.test("map blocks register create/get/keys/length/isEmpty and Defaults", () 
     .map((field) => field.getText());
   assertEquals(imageAlts.includes("Load/save"), true);
   assert(
-    imageAlts.some((alt) => alt.includes("convert-time")),
+    imageAlts.some((alt) => alt.includes("execution-context") || alt.includes("design-time")),
     `expected info FieldImage, got ${JSON.stringify(imageAlts)}`,
   );
   workspace.dispose();

--- a/test/mapping_spec_overview_test.ts
+++ b/test/mapping_spec_overview_test.ts
@@ -34,6 +34,8 @@ Deno.test("spec warning markers sit at widget positions for constraint warnings"
   assertEquals(markers.length, 1);
   assertEquals(markers[0]?.blockId, "warn");
   assertEquals(markers[0]?.message, "Unmapped mandatory value");
-  const warnWidget = doc.widgets.find((item) => item.line.blockId === "warn");
+  const warnWidget = doc.widgets.find(
+    (item) => item.line.blockId === "warn" && item.line.kind !== "header",
+  );
   assertEquals(markers[0]?.from, warnWidget?.from);
 });

--- a/test/mapping_spec_project_test.ts
+++ b/test/mapping_spec_project_test.ts
@@ -3,7 +3,12 @@ import {
   blocklyJsonDocument,
   projectBlocklyState,
   slotAttributeFromInputName,
+  type SpecProjection,
 } from "@intehrgrator/workbench/mapping_spec/mod.ts";
+
+function contentSpecLines(projection: SpecProjection) {
+  return projection.lines.filter((line) => line.kind !== "header");
+}
 import {
   TERM_PICK_NONE,
   termPickDropdownOptions,
@@ -248,8 +253,8 @@ Deno.test("projectBlocklyState flattens xml_text + maps_get + text key into one 
       }],
     },
   });
-  assertEquals(projection.lines.map((l) => l.type), ["xml_element", "maps_get"]);
-  const lookup = projection.lines[1];
+  assertEquals(contentSpecLines(projection).map((l) => l.type), ["xml_element", "maps_get"]);
+  const lookup = contentSpecLines(projection)[1];
   assertEquals(lookup?.kind, "map_lookup");
   assertEquals(lookup?.summary, 'defaults["Time"]');
   assertEquals(lookup?.aliasIds?.includes("xt"), true);
@@ -375,11 +380,12 @@ Deno.test("projectBlocklyState flattens xml_attribute to @name on the value", ()
       }],
     },
   });
-  assertEquals(projection.lines.length, 1);
-  assertEquals(projection.lines[0]?.attribute, "@MsgType");
-  assertEquals(projection.lines[0]?.blockId, "t1");
-  assertEquals(projection.lines[0]?.editKind, "text");
-  assertEquals(projection.lines[0]?.attributeEdit, {
+  const lines = contentSpecLines(projection);
+  assertEquals(lines.length, 1);
+  assertEquals(lines[0]?.attribute, "@MsgType");
+  assertEquals(lines[0]?.blockId, "t1");
+  assertEquals(lines[0]?.editKind, "text");
+  assertEquals(lines[0]?.attributeEdit, {
     field: "NAME",
     value: "MsgType",
     targetBlockId: "a1",
@@ -429,11 +435,12 @@ Deno.test("projectBlocklyState flattens sheet_lookup into one editable row", () 
       }],
     },
   });
-  assertEquals(projection.lines.length, 1);
-  assertEquals(projection.lines[0]?.kind, "sheet_lookup");
-  assertEquals(projection.lines[0]?.editKind, "sheet_lookup");
-  assertEquals(projection.lines[0]?.summary, "ICD[code=$.icd → snomed]");
-  assertEquals(projection.lines[0]?.aliasIds?.includes("sv"), true);
+  const lines = contentSpecLines(projection);
+  assertEquals(lines.length, 1);
+  assertEquals(lines[0]?.kind, "sheet_lookup");
+  assertEquals(lines[0]?.editKind, "sheet_lookup");
+  assertEquals(lines[0]?.summary, "ICD[code=$.icd → snomed]");
+  assertEquals(lines[0]?.aliasIds?.includes("sv"), true);
 });
 
 Deno.test("compare rows keep left-to-right field order when the left operand is text", () => {
@@ -457,10 +464,11 @@ Deno.test("compare rows keep left-to-right field order when the left operand is 
       }],
     },
   });
-  const fields = projection.lines[0]?.editable?.map((f) => f.field);
+  const row = contentSpecLines(projection)[0];
+  const fields = row?.editable?.map((f) => f.field);
   assertEquals(fields, ["TEXT", "OP", "EXPRESSION"]);
-  assertEquals(projection.lines[0]?.editable?.[0]?.targetBlockId, "left");
-  assertEquals(projection.lines[0]?.editable?.[2]?.targetBlockId, "right");
+  assertEquals(row?.editable?.[0]?.targetBlockId, "left");
+  assertEquals(row?.editable?.[2]?.targetBlockId, "right");
 });
 
 Deno.test("projectBlocklyState exposes editable TERM_PICK set and code with catalog options", () => {
@@ -479,7 +487,7 @@ Deno.test("projectBlocklyState exposes editable TERM_PICK set and code with cata
       }],
     },
   });
-  const row = projection.lines.find((line) => line.type === "term_pick");
+  const row = contentSpecLines(projection).find((line) => line.type === "term_pick");
   assertEquals(row?.editKind, "term_pick");
   assertEquals(row?.editable?.map((field) => field.field), ["SET", "CODE"]);
   assertEquals(row?.editable?.find((field) => field.field === "SET")?.value, "ISO_639-1");

--- a/web/index.html
+++ b/web/index.html
@@ -188,9 +188,24 @@
         <div class="mapping-bottom">
           <div class="mapping-editor-tabs" role="tablist" aria-label="Mapping editor text views">
             <div class="mapping-editor-tab-group">
-              <button id="tab-mapping-json" class="mapping-editor-tab active" type="button">Mapping Spec</button>
-              <button id="tab-handlebars" class="mapping-editor-tab" type="button">Handlebars Template</button>
+              <div class="split-btn split-btn--compact">
+                <button id="tab-mapping-json" class="mapping-editor-tab active split-btn-main" type="button">Mapping Spec</button>
+                <button
+                  id="tab-mapping-json-menu"
+                  class="mapping-editor-tab split-btn-chevron"
+                  type="button"
+                  aria-haspopup="menu"
+                  aria-expanded="false"
+                  aria-controls="menu-mapping-spec-layout"
+                  aria-label="Mapping Spec view options"
+                >▾</button>
+                <div id="menu-mapping-spec-layout" class="split-btn-menu" hidden role="menu">
+                  <button type="button" role="menuitem" data-spec-layout="list">List view (all roots)</button>
+                  <button type="button" role="menuitem" data-spec-layout="tabs">Tabbed view (per root)</button>
+                </div>
+              </div>
               <button id="tab-sheets" class="mapping-editor-tab" type="button">Sheets</button>
+              <button id="tab-handlebars" class="mapping-editor-tab" type="button">Handlebars Template</button>
             </div>
             <button
               id="btn-download-spec"
@@ -403,8 +418,8 @@
   </dialog>
   <dialog id="dialog-defaults-map" class="app-dialog app-dialog--wide">
     <form method="dialog" class="dialog-form">
-      <h2>Defaults Map</h2>
-      <p>Load a saved map, browse a file or URL, download the current map, or save the map plugged into the Defaults block.</p>
+      <h2>Default context mapping</h2>
+      <p>Load a saved map, browse a file or URL, download the current map, or save the map plugged into the Default context mapping block.</p>
       <div id="defaults-map-list" class="load-project-list"></div>
       <label class="dialog-label">
         URL
@@ -422,8 +437,8 @@
   </dialog>
   <dialog id="dialog-defaults-save-as" class="app-dialog">
     <form method="dialog" class="dialog-form">
-      <h2>Save Defaults Map as</h2>
-      <p>Store the current Defaults Map under a name you can pick later.</p>
+      <h2>Save default context mapping as</h2>
+      <p>Store the current default context mapping under a name you can pick later.</p>
       <label class="dialog-label">
         Name
         <input id="defaults-save-as-name" type="text" required placeholder="Clinic defaults" />
@@ -436,13 +451,13 @@
   </dialog>
   <dialog id="dialog-hardcode-defaults" class="app-dialog">
     <form method="dialog" class="dialog-form">
-      <h2>Hardcode Defaults Map entry</h2>
+      <h2>Hardcode default context mapping entry</h2>
       <p>
         Choose a map key to <strong>inline</strong> on the canvas. Every
         <code>get defaults key …</code> lookup for that key is replaced with a copy of
-        the value from this Defaults Map. After that, those slots no longer read the
+        the value from this default context mapping. After that, those slots no longer read the
         convert-time <code>defaults</code> argument — they use the hardcoded block instead.
-        The Defaults Map itself is left unchanged so you can hardcode other keys later
+        The default context mapping itself is left unchanged so you can hardcode other keys later
         or keep the entry for remaining lookups.
       </p>
       <div id="hardcode-defaults-list" class="load-project-list"></div>
@@ -480,9 +495,10 @@
     </form>
   </dialog>
   <span id="defaults-map-block-info" class="info-tip info-tip--anchor-host">
-    <button type="button" class="info-tip-btn" aria-expanded="false" aria-describedby="tip-defaults-map-block" aria-label="About the Defaults Map">i</button>
+    <button type="button" class="info-tip-btn" aria-expanded="false" aria-describedby="tip-defaults-map-block" aria-label="About default context mapping">i</button>
     <span id="tip-defaults-map-block" class="info-tip-balloon" role="tooltip">
-      The Defaults Map is a convert-time table of site or message values (language, territory, time, composer, facility, …). Generated Conversion Scripts take it as a <code>defaults</code> argument, so canvas lookups stay reusable instead of baking those literals into the mapping.<br>
+      <strong>Default context mapping</strong> is the design-time table you author on the canvas (language, territory, time, composer, facility, nested objects, …). At <em>convert time</em>, generated Conversion Scripts receive it as a <code>defaults</code> argument. Runtime code can merge that bag with per-message values, other named maps, and Sheet grids — the canvas map is the reusable baseline, not literals baked into every slot.<br>
+      Why design-time? So you can change site language, facility, or encoding once and re-run the same mapping against many source instances without regenerating the script. Map lookups on the canvas read this binding by name; hardcoding inlines one key when you want a fixed literal instead.<br>
       The folder opens load/save: pick a map saved in this browser, browse a JSON file, load a URL, save a named copy, or download the current map as JSON you can upload again later.
     </span>
   </span>

--- a/web/main.ts
+++ b/web/main.ts
@@ -63,6 +63,9 @@ import {
   relabelWorkspaceFromSkeleton,
   ensureDefaultsBlock,
   findDefaultsBlock,
+  ensureConversionStartOnScaffold,
+  enforceConversionStartUniqueness,
+  CONVERSION_START_TYPE,
   hydrateDefaultsMapArgument,
   serializeDefaultsMapArgument,
   setDefaultsMapPickHandler,
@@ -75,6 +78,7 @@ import {
 } from "../src/blockly/mod.ts";
 import { APP_VERSION } from "../src/core/persistence/mod.ts";
 import { registerServiceWorker } from "./pwa.ts";
+import { mountMappingSpecChrome, type SpecRootLayout } from "../src/ui/mapping_spec_chrome.ts";
 import { attachWorkspaceMinimap } from "../src/blockly/minimap.ts";
 import { installBlocklyFloatingOverlays } from "../src/blockly/floating_overlays.ts";
 import { installToolboxSearchInputFix } from "../src/blockly/toolbox_search.ts";
@@ -205,6 +209,40 @@ const handlebarsEditor = createTextEditor(handlebarsHost, (text) => {
 }, "handlebars");
 let activeTextView: "mapping-json" | "handlebars" | "sheets" = "mapping-json";
 let sheetsPanel: ReturnType<typeof mountSheetsPanel> | null = null;
+let specChromeUi: ReturnType<typeof mountMappingSpecChrome> | null = null;
+
+function refreshMappingSpecView(blocklyState?: unknown): void {
+  const state = blocklyState ?? Blockly.serialization.workspaces.save(workspace);
+  const layout = specChromeUi?.getLayout() ?? "list";
+  const rootId = layout === "tabs" ? specChromeUi?.getActiveRootId() ?? null : null;
+  setMappingSpecFromBlockly(specEditor, state, specChrome(), { rootId });
+}
+
+function wireMappingSpecLayoutMenu(): void {
+  const chevron = document.getElementById("tab-mapping-json-menu");
+  const menu = document.getElementById("menu-mapping-spec-layout");
+  if (!chevron || !menu) return;
+  const close = () => {
+    menu.hidden = true;
+    chevron.setAttribute("aria-expanded", "false");
+  };
+  chevron.addEventListener("click", (event) => {
+    event.stopPropagation();
+    const open = menu.hidden;
+    menu.hidden = !open;
+    chevron.setAttribute("aria-expanded", open ? "true" : "false");
+  });
+  document.addEventListener("click", (event) => {
+    if (!menu.contains(event.target as Node) && event.target !== chevron) close();
+  });
+  for (const item of menu.querySelectorAll<HTMLButtonElement>("[data-spec-layout]")) {
+    item.addEventListener("click", () => {
+      const layout = item.dataset.specLayout as SpecRootLayout;
+      specChromeUi?.setLayout(layout);
+      close();
+    });
+  }
+}
 type HandlebarsInsertMode = "flat" | "tree";
 const handlebarsInsertToolbar = document.getElementById("handlebars-insert-toolbar");
 
@@ -382,7 +420,14 @@ async function bootBlockly(): Promise<void> {
   }
   runWithoutBlocklyEvents(() => {
     ensureDefaultsBlock(workspace, blocklyLocale);
+    ensureConversionStartOnScaffold(workspace);
   });
+
+  specChromeUi = mountMappingSpecChrome(mappingJsonHost, {
+    getBlocklyState: () => Blockly.serialization.workspaces.save(workspace),
+    onLayoutChange: () => refreshMappingSpecView(),
+  });
+  wireMappingSpecLayoutMenu();
 
   setDefaultsMapPickHandler(() => {
     void openDefaultsMapDialog();
@@ -485,6 +530,16 @@ async function bootBlockly(): Promise<void> {
 
   workspace.addChangeListener((event) => {
     refreshUndoButtons();
+    if (
+      event.type === Blockly.Events.BLOCK_CREATE &&
+      "blockId" in event &&
+      typeof event.blockId === "string"
+    ) {
+      const created = workspace.getBlockById(event.blockId);
+      if (created?.type === CONVERSION_START_TYPE) {
+        enforceConversionStartUniqueness(workspace);
+      }
+    }
     if (event.type === DOCUMENT_SWAP_EVENT_TYPE) return;
     if (event.type === SHEET_CHANGE_EVENT_TYPE) {
       refreshUndoButtons();
@@ -804,11 +859,7 @@ function applyBlockSelection(blockId: string | null, origin: "blockly" | "spec")
     if (origin === "blockly" && blockId) {
       scrollMappingSpecToBlock(specEditor, blockId);
     }
-    setMappingSpecFromBlockly(
-      specEditor,
-      Blockly.serialization.workspaces.save(workspace),
-      specChrome(),
-    );
+    refreshMappingSpecView();
     if (block) {
       const target = listeningTargetFromBlock(block);
       if (target?.kind === "slot") controller.armSlot(target.slotId);
@@ -878,6 +929,7 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
     blocklySlotSignature = "";
     runWithoutBlocklyEvents(() => {
       ensureDefaultsBlock(workspace, blocklyLocale, targetFormatOf(s));
+      ensureConversionStartOnScaffold(workspace);
     });
     applyPendingDefaultsMap();
     return;
@@ -889,6 +941,7 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
       blocklySlotSignature = "";
       runWithoutBlocklyEvents(() => {
         ensureDefaultsBlock(workspace, blocklyLocale, targetFormatOf(s));
+        ensureConversionStartOnScaffold(workspace);
       });
       applyPendingDefaultsMap();
       return;
@@ -909,6 +962,7 @@ function syncBlocklyWorkspace(s: ReturnType<WorkbenchController["getState"]>): v
         if (!findDefaultsBlock(workspace)) {
           ensureDefaultsBlock(workspace, blocklyLocale, targetFormatOf(s));
         }
+        ensureConversionStartOnScaffold(workspace);
         applyModelLoops(workspace, s.model);
         refreshWorkspaceConstraints(workspace);
         relabelWorkspaceFromSkeleton(workspace, s.skeleton);
@@ -1522,7 +1576,7 @@ async function openDefaultsMapDialog(): Promise<void> {
   if (!entries.length && defaultsMapList.childElementCount === 0) {
     const empty = document.createElement("p");
     empty.className = "load-project-empty";
-    empty.textContent = "No saved Defaults Maps yet. Use Save as, Download, Browse file, or a URL.";
+    empty.textContent = "No saved default context mappings yet. Use Save as, Download, Browse file, or a URL.";
     defaultsMapList.appendChild(empty);
   }
   for (const entry of entries) {
@@ -1558,7 +1612,7 @@ function openHardcodeDefaultsDialog(): void {
   if (!entries.length) {
     const empty = document.createElement("p");
     empty.className = "load-project-empty";
-    empty.textContent = "The Defaults Map has no entries to hardcode yet.";
+    empty.textContent = "The default context mapping has no entries to hardcode yet.";
     hardcodeDefaultsList.appendChild(empty);
   }
   for (const entry of entries) {
@@ -1627,7 +1681,7 @@ document.getElementById("defaults-map-url-load")?.addEventListener("click", () =
 document.getElementById("defaults-map-download")?.addEventListener("click", () => {
   try {
     const mapBlock = serializeDefaultsMapArgument(workspace);
-    if (!mapBlock) throw new Error("No Defaults Map to download");
+    if (!mapBlock) throw new Error("No default context mapping to download");
     void host.downloadText(
       "defaults.map.json",
       JSON.stringify(mapBlock, null, 2),
@@ -1652,7 +1706,7 @@ dialogDefaultsSaveAs.addEventListener("close", () => {
   void (async () => {
     try {
       const mapBlock = serializeDefaultsMapArgument(workspace);
-      if (!mapBlock) throw new Error("No Defaults Map to save");
+      if (!mapBlock) throw new Error("No default context mapping to save");
       await defaultsCatalog.save(defaultsSaveAsNameInput.value, mapBlock);
       dialogDefaultsMap.close();
     } catch (err) {
@@ -1815,11 +1869,7 @@ function render(): void {
   // Blockly apply may have refreshed generatedCode without a re-render.
   const afterCanvas = controller.getState();
 
-  setMappingSpecFromBlockly(
-    specEditor,
-    afterCanvas.blocklyState ?? (workspace ? Blockly.serialization.workspaces.save(workspace) : null),
-    specChrome(),
-  );
+  specChromeUi?.refresh();
   if (handlebarsEditor.state.doc.toString() !== afterCanvas.handlebarsTemplate) {
     updatingHandlebarsEditor = true;
     setEditorDoc(

--- a/web/styles.css
+++ b/web/styles.css
@@ -349,6 +349,70 @@ html, body { margin: 0; height: 100%; font-family: system-ui, sans-serif; color:
   color: var(--text-secondary); padding: 3px 7px; font-size: 11px; cursor: pointer;
 }
 .mapping-editor-tab.active { border-color: var(--primary); color: var(--primary); background: #e8f5f2; }
+.split-btn--compact .mapping-editor-tab.split-btn-main { border-top-right-radius: 0; border-bottom-right-radius: 0; }
+.split-btn--compact .mapping-editor-tab.split-btn-chevron { min-width: 1.6rem; padding: 0 4px; border-top-left-radius: 0; border-bottom-left-radius: 0; margin-left: -1px; }
+.spec-root-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid #c5d5d3;
+  margin-bottom: 4px;
+  overflow-x: auto;
+  flex-shrink: 0;
+}
+.spec-root-tab {
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: #444;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.spec-root-tab.active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+  font-weight: 600;
+}
+.spec-root-divider {
+  display: block;
+  border-top: 1px solid #b8ccc9;
+  margin: 4px 0 2px;
+  padding-top: 2px;
+  min-height: 18px;
+}
+.spec-root-divider-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #5f7a76;
+}
+.spec-root-divider--clickable { cursor: pointer; }
+.spec-root-divider--clickable:hover .spec-root-divider-label { color: var(--primary); }
+.sheets-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid #c5d5d3;
+  margin-right: 8px;
+  overflow-x: auto;
+  max-width: min(50vw, 420px);
+}
+.sheets-tab {
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  padding: 4px 10px;
+  font-size: 12px;
+  color: #444;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.sheets-tab.active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+  font-weight: 600;
+}
 .handlebars-insert-toolbar {
   display: flex; flex-wrap: wrap; align-items: center; gap: 8px 12px;
   margin: 0 0 6px; padding: 4px 6px; font-size: 11px; color: var(--text-secondary);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements four UI-related issues in one pass:

- **#54** — Rename “defaults map” → **Default context mapping** with expanded tooltip explaining design-time vs convert-time usage.
- **#51** — Mapping Spec root dividers, list/tabbed layout split button (persisted), per-root tabs, sheet tab buttons when multiple sheets exist, and Handlebars tab moved last.
- **#52** — Type-fit emoji glyphs on non-openEHR blocks (logic, sheet accessors, map blocks); unified mutator cogwheel placement.
- **#56** — Green **Conversion start** hat above instance roots (`composition`, `json_object`, `xml_element`, `text_document`); toolbox drawers for JSON/XML/Text; codegen walks the Start tree.

Also fixes a Mapping Spec chrome refresh loop (`refresh()` → `onLayoutChange` → `refresh()` again) that caused autosave stack overflow.

## Testing

- `deno test -A --no-check --parallel --ignore=test/ui test/` — **503 passed**
- `deno task build` — OK

### Screenshots

**#54 — Default context mapping rename + tooltip**

[Default context mapping block and expanded info tooltip](https://cursor.com/agents/bc-880a65c0-9288-4def-9ec4-b76495e185fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-54-default-context-mapping.png)

**#51 — Mapping Spec tabbed layout + root tabs**

[Mapping Spec list/tabbed layout menu and per-root tabs](https://cursor.com/agents/bc-880a65c0-9288-4def-9ec4-b76495e185fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-51-mapping-spec-root-tabs.png)

**#51 — Mapping Spec root dividers (includes Conversion start header)**

[Mapping Spec section headers including DEFAULT CONTEXT MAPPING and CONVERSION START](https://cursor.com/agents/bc-880a65c0-9288-4def-9ec4-b76495e185fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-51-mapping-spec-dividers.png)

**#51 — Sheet tabs (2+ sheets)**

[Sheet tab buttons when multiple sheets exist](https://cursor.com/agents/bc-880a65c0-9288-4def-9ec4-b76495e185fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-51-sheet-tabs.png)

**#52 — Type-fit glyphs on canvas blocks**

[Logic list restriction block showing type glyphs on canvas](https://cursor.com/agents/bc-880a65c0-9288-4def-9ec4-b76495e185fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-52-glyphs-on-canvas.png)

**#56 — Conversion start** (present in workspace after template load; Mapping Spec shows `CONVERSION START` divider; Playwright test API confirms `conversion_start` block in snapshot)

[Mapping Spec and workspace after blood-pressure template load](https://cursor.com/agents/bc-880a65c0-9288-4def-9ec4-b76495e185fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue-56-conversion-start.png)

## Commits

1. `feat(ui): conversion start hat and schema-less instance roots (#56)`
2. `feat(ui): mapping spec root dividers, tabbed layout, and sheet tabs (#51)`
3. `feat(ui): type-fit glyphs on non-openEHR Blockly blocks (#52)`
4. `feat(ui): rename defaults map to default context mapping (#54)`

Closes #51, #52, #54, #56

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-880a65c0-9288-4def-9ec4-b76495e185fd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-880a65c0-9288-4def-9ec4-b76495e185fd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

