### PR TITLE
fix(ui): align logic glyphs; add ☰ array and ⊞ sheet symbols (#52)

### DIFF
--- a/src/blockly/block_type_glyph.ts
+++ b/src/blockly/block_type_glyph.ts
@@ -1,8 +1,13 @@
 /**
  * Blockly-check → type-fit glyphs for non-openEHR blocks.
  * ZipEHR emoji table is preferred for primitives; abstract unions use ⁇.
+ *
+ * Blockly uses the connection check name `Array` for lists (1-D arrays, possibly
+ * of objects). UI copy may say “list”; there is no separate `List` check type.
+ * Sheet blocks pass the display-only `Sheet` label for table-shaped values (⊞)
+ * while keeping `Array` on the socket for compatibility.
  */
-import type { Input } from "blockly/core";
+import type { Block, Input } from "blockly/core";
 import { Blockly } from "./blockly_core.ts";
 import { zipehrEmojiForRmType } from "../core/rm_emoji.ts";
 import {
@@ -18,10 +23,22 @@ const BLOCKLY_TYPE_GLYPH: Record<string, string> = {
   String: "🔤",
   Number: "🔢",
   Boolean: "✓",
-  Array: "📋",
+  Array: "☰",
+  /** Display-only: sheet row/column/data (socket check stays `Array`). */
+  Sheet: "⊞",
   Map: "↦",
   Source: "📂",
 };
+
+/** Blockly Align.RIGHT — slot captions and glyphs hug mouths. */
+export function inputAlignRight(): number {
+  return (Blockly.inputs?.Align?.RIGHT ?? Blockly.ALIGN_RIGHT ?? 1) as number;
+}
+
+/** Blockly Align.LEFT — block chrome / header row. */
+export function inputAlignLeft(): number {
+  return (Blockly.inputs?.Align?.LEFT ?? Blockly.ALIGN_LEFT ?? -1) as number;
+}
 
 export function glyphForBlocklyCheck(
   check: string | string[] | null | undefined,
@@ -98,4 +115,62 @@ export function appendInputTypeGlyph(
   const field = new Blockly.FieldLabel(glyph, glyph === ABSTRACT_SLOT_GLYPH ? "blockly-rm-emoji blockly-rm-emoji-abstract" : "blockly-rm-emoji");
   field.setTooltip(blocklyCheckTooltip(check));
   input.appendField(field, name);
+}
+
+/** Prepends a HEADER row with the block output glyph (openEHR-style). */
+export function ensureBlockOutputHeaderGlyph(block: Block): void {
+  if (!block.outputConnection) return;
+  if (block.getInput("HEADER")) return;
+  const header = block.appendDummyInput("HEADER").setAlign(inputAlignLeft());
+  const first = block.inputList[0];
+  if (first && first.name !== "HEADER") {
+    block.moveInputBefore("HEADER", first.name);
+  }
+  appendBlockOutputGlyph(header, block.outputConnection.getCheck());
+}
+
+/** Appends socket glyphs as the last field on each value input. */
+export function decorateValueInputGlyphs(block: Block): void {
+  for (const input of block.inputList) {
+    if (input.type !== Blockly.INPUT_VALUE) continue;
+    if (input.name === "HEADER") continue;
+    input.setAlign(inputAlignRight());
+    appendInputTypeGlyph(input, input.connection?.getCheck() ?? null);
+  }
+}
+
+const STOCK_GLYPH_BLOCK_TYPES = [
+  "logic_compare",
+  "logic_operation",
+  "logic_negate",
+  "logic_boolean",
+  "logic_ternary",
+  "lists_create_with",
+  "lists_length",
+  "lists_isEmpty",
+  "lists_indexOf",
+  "lists_getIndex",
+  "lists_getSublist",
+  "lists_split",
+  "lists_sort",
+  "lists_reverse",
+  "for_each_list",
+] as const;
+
+const stockGlyphPatches = new Set<string>();
+
+/** Stock Blockly blocks from `blockly/blocks` — glyphs after labels, sockets right-aligned. */
+export function registerStockBlocklyGlyphs(): void {
+  for (const type of STOCK_GLYPH_BLOCK_TYPES) {
+    if (stockGlyphPatches.has(type)) continue;
+    const def = Blockly.Blocks[type];
+    if (!def?.init) continue;
+    const originalInit = def.init as (this: Block) => void;
+    def.init = function (this: Block) {
+      originalInit.call(this);
+      ensureBlockOutputHeaderGlyph(this);
+      decorateValueInputGlyphs(this);
+    };
+    stockGlyphPatches.add(type);
+  }
 }

--- a/src/blockly/blocks/logic_blocks.ts
+++ b/src/blockly/blocks/logic_blocks.ts
@@ -1,7 +1,13 @@
 import { Blockly } from "../blockly_core.ts";
 import { FieldDropdownHug } from "../field_dropdown_hug.ts";
 import { detectLocale, msg } from "../i18n/locale.ts";
-import { appendBlockOutputGlyph, appendInputTypeGlyph } from "../block_type_glyph.ts";
+import {
+  appendBlockOutputGlyph,
+  appendInputTypeGlyph,
+  inputAlignLeft,
+  inputAlignRight,
+  registerStockBlocklyGlyphs,
+} from "../block_type_glyph.ts";
 
 const LOGIC_COLOUR = "#D1C4E9";
 const LIST_COLOUR = "#4DB6AC";
@@ -144,12 +150,11 @@ export function registerLogicBlocks(): void {
       this.itemName_ = DEFAULT_ITEM_NAME;
       this.countValue_ = 1;
       this.guardValue_ = false;
-      const header = this.appendDummyInput("HEADER");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
       appendBlockOutputGlyph(header, "Boolean");
       const listInput = this.appendValueInput("LIST")
-        .setCheck(LIST_CHECK);
-      appendInputTypeGlyph(listInput, LIST_CHECK);
-      listInput
+        .setAlign(inputAlignRight())
+        .setCheck(LIST_CHECK)
         .appendField(
           new FieldDropdownHug(
             [
@@ -170,10 +175,12 @@ export function registerLogicBlocks(): void {
           "OP",
         )
         .appendField(m.LOGIC_OF, "OF_LABEL");
+      appendInputTypeGlyph(listInput, LIST_CHECK);
       const predInput = this.appendValueInput("PRED")
-        .setCheck("Boolean");
+        .setAlign(inputAlignRight())
+        .setCheck("Boolean")
+        .appendField(m.LOGIC_MATCH, "MATCH_LABEL");
       appendInputTypeGlyph(predInput, "Boolean");
-      predInput.appendField(m.LOGIC_MATCH, "MATCH_LABEL");
       this.setInputsInline(false);
       this.setOutput(true, "Boolean");
       this.setColour(LOGIC_COLOUR);
@@ -281,7 +288,7 @@ export function registerLogicBlocks(): void {
 
   Blockly.Blocks[LOGIC_CURRENT_ITEM_BLOCK] = {
     init: function (this: Blockly.Block) {
-      const header = this.appendDummyInput("HEADER");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
       appendBlockOutputGlyph(header, "Boolean");
       header.appendField(new FieldItemDropdown(currentItemOptions), "VAR");
       this.setOutput(true, "Boolean");
@@ -293,12 +300,11 @@ export function registerLogicBlocks(): void {
 
   Blockly.Blocks[LISTS_SET_OPERATION_BLOCK] = {
     init: function (this: Blockly.Block) {
-      const header = this.appendDummyInput("HEADER");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
       appendBlockOutputGlyph(header, "Array");
       const inputA = this.appendValueInput("A")
-        .setCheck(LIST_CHECK);
-      appendInputTypeGlyph(inputA, LIST_CHECK);
-      inputA
+        .setAlign(inputAlignRight())
+        .setCheck(LIST_CHECK)
         .appendField(
           new FieldDropdownHug(
             [
@@ -315,10 +321,12 @@ export function registerLogicBlocks(): void {
           ),
           "OP",
         );
+      appendInputTypeGlyph(inputA, LIST_CHECK);
       const inputB = this.appendValueInput("B")
-        .setCheck(LIST_CHECK);
+        .setAlign(inputAlignRight())
+        .setCheck(LIST_CHECK)
+        .appendField(new Blockly.FieldLabel(m.LOGIC_SET_CONN_AND), "CONN");
       appendInputTypeGlyph(inputB, LIST_CHECK);
-      inputB.appendField(new Blockly.FieldLabel(m.LOGIC_SET_CONN_AND), "CONN");
       this.setInputsInline(false);
       this.setOutput(true, "Array");
       this.setColour(LIST_COLOUR);
@@ -326,6 +334,8 @@ export function registerLogicBlocks(): void {
       this.setStyle?.("list_blocks");
     },
   };
+
+  registerStockBlocklyGlyphs();
 }
 
 /** "and" / "or" / "but not in" — the connector follows the chosen set operator. */

--- a/src/blockly/blocks/sheet_blocks.ts
+++ b/src/blockly/blocks/sheet_blocks.ts
@@ -1,5 +1,13 @@
 import { Blockly } from "../blockly_core.ts";
-import { appendBlockOutputGlyph, appendInputTypeGlyph } from "../block_type_glyph.ts";
+import {
+  appendBlockOutputGlyph,
+  appendInputTypeGlyph,
+  inputAlignLeft,
+  inputAlignRight,
+} from "../block_type_glyph.ts";
+
+/** Sheet table / row / column values (Blockly check stays `Array`). */
+const SHEET_TABLE_GLYPH = "Sheet";
 
 const SHEET_COLOUR = "#00897B";
 const SHEET_DECL_COLOUR = "#00695C";
@@ -85,10 +93,10 @@ export function registerSheetBlocks(): void {
 
   Blockly.Blocks[SHEET_GET_CELL] = {
     init: function (this: Blockly.Block) {
-      const header = this.appendDummyInput("HEADER");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
       appendBlockOutputGlyph(header, ["String", "Number", "Boolean"]);
       header.appendField("get").appendField(nameField(), "NAME").appendField("cell");
-      const a1 = this.appendValueInput("A1").setCheck("String");
+      const a1 = this.appendValueInput("A1").setAlign(inputAlignRight()).setCheck("String");
       appendInputTypeGlyph(a1, "String");
       this.setColour(SHEET_COLOUR);
       this.setInputsInline(true);
@@ -98,15 +106,13 @@ export function registerSheetBlocks(): void {
 
   Blockly.Blocks[SHEET_GET_XY] = {
     init: function (this: Blockly.Block) {
-      const header = this.appendDummyInput("HEADER");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
       appendBlockOutputGlyph(header, ["String", "Number", "Boolean"]);
       header.appendField("get").appendField(nameField(), "NAME");
-      const xIn = this.appendValueInput("X").setCheck("Number");
+      const xIn = this.appendValueInput("X").setAlign(inputAlignRight()).setCheck("Number").appendField("x");
       appendInputTypeGlyph(xIn, "Number");
-      xIn.appendField("x");
-      const yIn = this.appendValueInput("Y").setCheck("Number");
+      const yIn = this.appendValueInput("Y").setAlign(inputAlignRight()).setCheck("Number").appendField("y");
       appendInputTypeGlyph(yIn, "Number");
-      yIn.appendField("y");
       this.setOutput(true, ["String", "Number", "Boolean"]);
       this.setColour(SHEET_COLOUR);
       this.setInputsInline(true);
@@ -116,8 +122,11 @@ export function registerSheetBlocks(): void {
 
   Blockly.Blocks[SHEET_GET_ROW] = {
     init: function (this: Blockly.Block) {
-      this.appendDummyInput().appendField("get row of").appendField(nameField(), "NAME");
-      this.appendValueInput("Y").setCheck("Number").appendField("y");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
+      appendBlockOutputGlyph(header, SHEET_TABLE_GLYPH);
+      header.appendField("get row of").appendField(nameField(), "NAME");
+      const yIn = this.appendValueInput("Y").setAlign(inputAlignRight()).setCheck("Number").appendField("y");
+      appendInputTypeGlyph(yIn, "Number");
       this.setOutput(true, "Array");
       this.setColour(SHEET_COLOUR);
       this.setInputsInline(true);
@@ -126,8 +135,11 @@ export function registerSheetBlocks(): void {
 
   Blockly.Blocks[SHEET_GET_COLUMN] = {
     init: function (this: Blockly.Block) {
-      this.appendDummyInput().appendField("get column of").appendField(nameField(), "NAME");
-      this.appendValueInput("X").setCheck("Number").appendField("x");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
+      appendBlockOutputGlyph(header, SHEET_TABLE_GLYPH);
+      header.appendField("get column of").appendField(nameField(), "NAME");
+      const xIn = this.appendValueInput("X").setAlign(inputAlignRight()).setCheck("Number").appendField("x");
+      appendInputTypeGlyph(xIn, "Number");
       this.setOutput(true, "Array");
       this.setColour(SHEET_COLOUR);
       this.setInputsInline(true);
@@ -136,8 +148,11 @@ export function registerSheetBlocks(): void {
 
   Blockly.Blocks[SHEET_GET_HEADER] = {
     init: function (this: Blockly.Block) {
-      this.appendDummyInput().appendField("header of").appendField(nameField(), "NAME");
-      this.appendValueInput("X").setCheck("Number").appendField("x");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
+      appendBlockOutputGlyph(header, "String");
+      header.appendField("header of").appendField(nameField(), "NAME");
+      const xIn = this.appendValueInput("X").setAlign(inputAlignRight()).setCheck("Number").appendField("x");
+      appendInputTypeGlyph(xIn, "Number");
       this.setOutput(true, "String");
       this.setColour(SHEET_COLOUR);
       this.setInputsInline(true);
@@ -146,7 +161,9 @@ export function registerSheetBlocks(): void {
 
   Blockly.Blocks[SHEET_GET_DATA] = {
     init: function (this: Blockly.Block) {
-      this.appendDummyInput().appendField("data of").appendField(nameField(), "NAME");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
+      appendBlockOutputGlyph(header, SHEET_TABLE_GLYPH);
+      header.appendField("data of").appendField(nameField(), "NAME");
       this.setOutput(true, "Array");
       this.setColour(SHEET_COLOUR);
       this.setInputsInline(true);
@@ -155,10 +172,15 @@ export function registerSheetBlocks(): void {
 
   Blockly.Blocks[SHEET_LOOKUP] = {
     init: function (this: Blockly.Block) {
-      this.appendDummyInput().appendField("lookup").appendField(nameField(), "NAME");
-      this.appendValueInput("MATCH_COL").setCheck(["String", "Number"]).appendField("where");
-      this.appendValueInput("MATCH_VAL").appendField("=");
-      this.appendValueInput("RETURN_COL").setCheck(["String", "Number"]).appendField("return");
+      const header = this.appendDummyInput("HEADER").setAlign(inputAlignLeft());
+      appendBlockOutputGlyph(header, ["String", "Number", "Boolean"]);
+      header.appendField("lookup").appendField(nameField(), "NAME");
+      const matchCol = this.appendValueInput("MATCH_COL").setAlign(inputAlignRight()).setCheck(["String", "Number"]).appendField("where");
+      appendInputTypeGlyph(matchCol, ["String", "Number"]);
+      const matchVal = this.appendValueInput("MATCH_VAL").setAlign(inputAlignRight()).appendField("=");
+      appendInputTypeGlyph(matchVal, null);
+      const returnCol = this.appendValueInput("RETURN_COL").setAlign(inputAlignRight()).setCheck(["String", "Number"]).appendField("return");
+      appendInputTypeGlyph(returnCol, ["String", "Number"]);
       this.setOutput(true, ["String", "Number", "Boolean"]);
       this.setColour(SHEET_COLOUR);
       this.setInputsInline(true);
@@ -194,8 +216,10 @@ export function registerSheetBlocks(): void {
   Blockly.Blocks[SHEET_SET_ROW] = {
     init: function (this: Blockly.Block) {
       this.appendDummyInput().appendField("set row of").appendField(nameField(), "NAME");
-      this.appendValueInput("Y").setCheck("Number").appendField("y");
-      this.appendValueInput("VALUE").setCheck("Array").appendField("to");
+      const yIn = this.appendValueInput("Y").setAlign(inputAlignRight()).setCheck("Number").appendField("y");
+      appendInputTypeGlyph(yIn, "Number");
+      const valueIn = this.appendValueInput("VALUE").setAlign(inputAlignRight()).setCheck("Array").appendField("to");
+      appendInputTypeGlyph(valueIn, SHEET_TABLE_GLYPH);
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.setColour(SHEET_COLOUR);
@@ -206,8 +230,10 @@ export function registerSheetBlocks(): void {
   Blockly.Blocks[SHEET_SET_COLUMN] = {
     init: function (this: Blockly.Block) {
       this.appendDummyInput().appendField("set column of").appendField(nameField(), "NAME");
-      this.appendValueInput("X").setCheck("Number").appendField("x");
-      this.appendValueInput("VALUE").setCheck("Array").appendField("to");
+      const xIn = this.appendValueInput("X").setAlign(inputAlignRight()).setCheck("Number").appendField("x");
+      appendInputTypeGlyph(xIn, "Number");
+      const valueIn = this.appendValueInput("VALUE").setAlign(inputAlignRight()).setCheck("Array").appendField("to");
+      appendInputTypeGlyph(valueIn, SHEET_TABLE_GLYPH);
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.setColour(SHEET_COLOUR);

--- a/test/block_type_glyph_test.ts
+++ b/test/block_type_glyph_test.ts
@@ -6,7 +6,8 @@ Deno.test("glyphForBlocklyCheck maps Blockly primitives", () => {
   assertEquals(typeof glyphForBlocklyCheck("String"), "string");
   assertEquals(typeof glyphForBlocklyCheck("Number"), "string");
   assertEquals(glyphForBlocklyCheck("Boolean"), "✓");
-  assertEquals(glyphForBlocklyCheck("Array"), "📋");
+  assertEquals(glyphForBlocklyCheck("Array"), "☰");
+  assertEquals(glyphForBlocklyCheck("Sheet"), "⊞");
   assertEquals(glyphForBlocklyCheck("Map"), "↦");
 });
 


### PR DESCRIPTION
Use ☰ for Blockly Array checks (lists are Arrays, not a separate type). Add display-only Sheet glyph (⊞) on sheet table row/column/data blocks. Patch stock logic and list blocks for output/header and right-aligned socket glyphs; fix custom logic restriction blocks so labels precede mouth glyphs.