### PR TITLE
XQuery export: emit for_each_source iteration (#39)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,10 @@ If running in interactive mode (e.g. Gemini CLI) then stop after each parent tas
   `web/wasm/go_texttemplate.wasm` and `wasm_exec.js`). The Web Shell loads
   those files at runtime; ordinary lint/test/run does not need a Go toolchain.
   Rebuild only when `go/texttemplate` changes.
+- Optional XQuery engine golden tests (`deno task test:xquery-engine`) need
+  [BaseX](https://basex.org) on `PATH` (Java 21 is already present). See
+  `docs/agents/xquery-engine.md` for install/bind hints (`parse-json` for JSON
+  Example Instances; `BASEX_CMD` override).
 
 ## Agent skills
 

--- a/deno.json
+++ b/deno.json
@@ -52,6 +52,7 @@
     "setup:better-forms": "deno run -A scripts/setup-better-forms.ts",
     "convert:kintegrate-hbs": "deno run -A scripts/convert-kintegrate-hbs-to-blockly.ts",
     "test": "deno test -A --no-check --parallel --ignore=test/ui test/",
+    "test:xquery-engine": "deno test -A --no-check test/xquery_engine_test.ts",
     "test:ui": "deno run -A scripts/ui-test.ts",
     "wasm:go-template": "deno run -A scripts/build-go-template-wasm.ts",
     "lint": "deno lint src test scripts",

--- a/docs/agents/xquery-engine.md
+++ b/docs/agents/xquery-engine.md
@@ -1,0 +1,98 @@
+# XQuery engine golden tests (Cloud Agents)
+
+Generated `.xq` conversion scripts are **not** executed in-app Test Run (ADR 0003). To verify mappings against a real XQuery 3.1 engine in CI or Cloud Agent VMs, use **BaseX**.
+
+## Recommended engine: BaseX
+
+| Criterion | BaseX | Saxon-HE | eXist-db |
+|-----------|-------|----------|----------|
+| Install size | Small (~15 MB zip) | Java jar + license file | Server footprint |
+| XQuery 3.1 + maps | Yes (`json:parse`) | Yes | Yes (config varies) |
+| CLI one-shot | `basex -q '…'` | `java -jar saxon-he.jar -qs:…` | Needs running DB |
+| Cloud Agent fit | **Best** — download zip, add to `PATH` | Good (Java 21 already on image) | Heavier |
+
+**Choice:** BaseX 11.x for optional golden tests (`test/xquery_engine_test.ts`). Saxon-HE remains a valid alternative for teams already on Saxon; the generated `.xq` targets XQuery 3.1 without engine-specific extensions.
+
+## Cloud Agent / CI setup
+
+### BaseX (preferred)
+
+```bash
+# One-time in environment setup or snapshot
+BASEX_VERSION=11.0
+curl -fsSL "https://files.basex.org/releases/${BASEX_VERSION}/BaseX110.zip" \
+  -o /tmp/BaseX110.zip
+unzip -q /tmp/BaseX110.zip -d "$HOME"
+export PATH="$HOME/basex/bin:$PATH"
+```
+
+Verify:
+
+```bash
+basex -v
+deno test -A test/xquery_engine_test.ts
+```
+
+Override the binary with `BASEX_CMD=/opt/basex/basex/bin/basex` if `basex` is not on `PATH`.
+
+### Saxon-HE (alternative)
+
+Java 21 is on the Cloud Agent image. Download Saxon-HE 12.x, then:
+
+```bash
+java -jar saxon-he-12.5.jar -qs:"declare variable \$source external; …" -s:.
+```
+
+External JSON maps need a small wrapper (Saxon does not ship `json:parse` in all editions the same way BaseX does). Prefer BaseX for map-shaped Example Instance JSON unless you already standardise on Saxon.
+
+## Binding `$source` for golden runs
+
+Export emits:
+
+```xquery
+declare variable $source external;
+declare variable $defaults as map(*) external := map {};
+```
+
+**JSON Example Instance** (typical intEHRgrator Test Run input):
+
+1. Parse once in the query prolog (what `test/xquery_engine_test.ts` does):
+
+   ```xquery
+   declare variable $source as map(*) := parse-json('{"measurements":[{"pulse":72}]}');
+   ```
+
+   BaseX 11 implements XPath 3.1 `parse-json`; older `json:parse` returns a document node and is **not** compatible with map `?key` navigation in generated scripts.
+
+2. Or pass a file path from BaseX:
+
+   ```bash
+   basex -b 'source=parse-json(unparsed-text("source.json"))' convert.xq
+   ```
+
+**XML source:** bind `$source` to a document node (`doc('source.xml')/*`).
+
+**Defaults map:** bind `$defaults` when slots use `maps_get("defaults", …)`:
+
+```bash
+basex -b 'defaults=map{"language":"en"}' convert.xq
+```
+
+## Sheet accessors
+
+XQuery export **fails at generate time** when a slot uses `sheet_lookup` / `sheet_get_*` / `decision_table`. There is no silent `()` stub. Add Sheet support in a follow-up by declaring `external $sheets` and emitting lookup helpers.
+
+## What golden tests assert today
+
+`test/xquery_engine_test.ts` (skipped when `basex` is missing):
+
+- `for_each_source` over `$.measurements` produces one `<loop>` per source item
+- Relative paths (`pulse`, `timestamp`) resolve against the loop variable
+- `DV_QUANTITY` / `DV_DATE_TIME` magnitudes and values match the Example Instance JSON
+
+Full COMPOSITION XML emit and preview ≡ XQuery value parity remain follow-ups (issue #39 child / ROADMAP K).
+
+## Related
+
+- [xquery-export-investigation.md](../future/xquery-export-investigation.md) — emission model
+- [ADR 0003](../adr/0003-mapping-preview-vs-generated-script.md) — preview vs generated script oracles

--- a/docs/future/xquery-export-investigation.md
+++ b/docs/future/xquery-export-investigation.md
@@ -1,8 +1,11 @@
 # XQuery Conversion Script Language
 
-**Status:** Implemented (R1 / partial R2) — Conversion script language `xquery`
+**Status:** Implemented (R1 / R2 partial) — Conversion script language `xquery`
 emits a self-contained `.xq` from the Mapping Model (Blockly-derived slots).
-Full COMPOSITION tree emit and engine golden runs remain open.
+`for_each_source` / `for_each_list` compile to `for $var in … return` loop
+bodies ([#39](https://github.com/regionstockholm/intehrgrator/issues/39)).
+Full COMPOSITION tree emit remains open; optional BaseX golden runs are
+documented in [agents/xquery-engine.md](../agents/xquery-engine.md).
 
 Captured from design discussion 2026-07-02; productised 2026-08-02.
 
@@ -121,12 +124,16 @@ local:convert($source)
 
 1. **Full COMPOSITION emit (Model A/C)** — walk Template Skeleton / `targetPath`
    when exporting, not only flat `MappingModel.slots`.
-2. **Engine golden tests** — run generated `.xq` under Saxon-HE or BaseX in CI.
+2. **Engine golden tests** — optional BaseX run in `test/xquery_engine_test.ts`;
+   Saxon-HE alternative documented in [agents/xquery-engine.md](../agents/xquery-engine.md).
 3. **JSON source notes** — document engine-specific map lookup vs `fn:json-doc`.
 4. **Units / coded-text fields** — multi-field DV shells beyond the primary
    expression attribute.
-5. **`for_each_source` loops** — not in Mapping Model slots yet; emit when the
-   derived index gains iteration structure.
+5. **`for_each_source` loops** — **shipped** ([#39](https://github.com/regionstockholm/intehrgrator/issues/39)):
+   `loops[]` emit `for $var in … return` with loop-scoped slot manifests;
+   top-level slots stay in `<slots>`. Sheet accessors fail export (no silent `()`).
+6. **Engine golden tests** — optional `test/xquery_engine_test.ts` when BaseX is
+   installed; see [agents/xquery-engine.md](../agents/xquery-engine.md).
 
 ## Related
 

--- a/src/core/codegen/mod.ts
+++ b/src/core/codegen/mod.ts
@@ -10,9 +10,11 @@ import {
 
 export {
   compileLiteralPath,
+  compileLoopSequence,
   emitXQueryExpr,
   generateXQuery,
   jsonDollarPathToLookup,
+  XQueryExportError,
 } from "./xquery.ts";
 export { generateGoTemplate } from "./go_template.ts";
 export {

--- a/src/core/codegen/xquery.ts
+++ b/src/core/codegen/xquery.ts
@@ -2,20 +2,46 @@
  * XQuery conversion script language — Mapping Model → self-contained `.xq`.
  *
  * Emits a Model B slot-manifest program: each Blockly-mapped slot becomes an
- * XQuery binding with typed DV_* XML constructors. Full COMPOSITION nesting
- * remains a follow-up once skeleton metadata is available at export time.
+ * XQuery binding with typed DV_* XML constructors. `for_each_source` /
+ * `for_each_list` compile to `for $var in … return` iteration over loop-scoped
+ * slots. Full COMPOSITION nesting remains a follow-up once skeleton metadata is
+ * available at export time.
  *
  * See docs/future/xquery-export-investigation.md.
  */
-import type { MappingModel, MappingSlot } from "../../types/mod.ts";
+import type {
+  MappingLoop,
+  MappingModel,
+  MappingSlot,
+  TargetSignatureNode,
+} from "../../types/mod.ts";
+import { expressionUsesRelativeSourcePath } from "../mapping_model/loops.ts";
 import { parseExpression, type ExprAst, isQuantifyCall } from "../expression/mod.ts";
 
+export class XQueryExportError extends Error {
+  override name = "XQueryExportError";
+}
+
+export interface XQueryEmitEnv {
+  bind?: Record<string, string>;
+  /** Context node for xpath* — defaults to `$source`; loop bodies use the loop var. */
+  sourceVar?: string;
+}
+
+const SHEET_ACCESSOR_RE =
+  /\b(sheet_get_(?:cell|xy|row|column|header|data)|sheet_lookup|decision_table)\s*\(/;
+
 export function generateXQuery(model: MappingModel): string {
-  const slotBlocks = model.slots.map((slot) =>
-    emitSlot(slot).map((line) => `    ${line}`).join("\n")
+  validateExportModel(model);
+
+  const loops = model.loops ?? [];
+  const { loopSlots, topLevelSlots } = partitionSlots(model.slots, loops, model.targetSignature);
+
+  const loopBlocks = loops.map((loop) =>
+    emitLoop(loop, loopSlots.get(loop.attachSlotId) ?? []).map((line) => `    ${line}`).join("\n")
   );
-  const loopBlocks = (model.loops ?? []).map((loop) =>
-    emitLoop(loop).map((line) => `    ${line}`).join("\n")
+  const slotBlocks = topLevelSlots.map((slot) =>
+    emitSlot(slot).map((line) => `    ${line}`).join("\n")
   );
 
   const lines: string[] = [
@@ -57,11 +83,11 @@ export function generateXQuery(model: MappingModel): string {
     lines.push("    }" + (slotBlocks.length ? "," : ""));
   }
 
-  if (!slotBlocks.length) {
+  if (!slotBlocks.length && !loopBlocks.length) {
     lines.push(
       "    (: no mapped slots — map Target value slots in Blockly, then re-export :)",
     );
-  } else {
+  } else if (slotBlocks.length) {
     lines.push("    element slots {");
     for (let i = 0; i < slotBlocks.length; i++) {
       const block = slotBlocks[i]!;
@@ -81,7 +107,121 @@ export function generateXQuery(model: MappingModel): string {
   return lines.join("\n");
 }
 
-function emitLoop(loop: import("../../types/mod.ts").MappingLoop): string[] {
+function validateExportModel(model: MappingModel): void {
+  for (const block of model.unsupported ?? []) {
+    if (block.reason === "removed") {
+      throw new XQueryExportError(
+        `Cannot export XQuery: Blockly block type "${block.blockType}" was removed from the ` +
+          "verifiable mapping subset (#35). Remove it from the canvas before exporting.",
+      );
+    }
+  }
+
+  for (const slot of model.slots) {
+    if (SHEET_ACCESSOR_RE.test(slot.expression)) {
+      throw new XQueryExportError(
+        `Cannot export XQuery: slot "${slot.slotId}" uses Sheet accessors ` +
+          `(${slot.expression}). Bind a $sheets map at runtime or remove Sheet lookups before export.`,
+      );
+    }
+  }
+}
+
+function partitionSlots(
+  slots: MappingSlot[],
+  loops: MappingLoop[],
+  signature?: TargetSignatureNode[],
+): { loopSlots: Map<string, MappingSlot[]>; topLevelSlots: MappingSlot[] } {
+  const loopSlots = new Map<string, MappingSlot[]>();
+  for (const loop of loops) {
+    loopSlots.set(loop.attachSlotId, []);
+  }
+
+  const topLevelSlots: MappingSlot[] = [];
+  for (const slot of slots) {
+    if (!expressionUsesRelativeSourcePath(slot.expression)) {
+      topLevelSlots.push(slot);
+      continue;
+    }
+    const loop = resolveLoopForSlot(slot, loops, signature);
+    if (!loop) {
+      topLevelSlots.push(slot);
+      continue;
+    }
+    const bucket = loopSlots.get(loop.attachSlotId) ?? [];
+    bucket.push(slot);
+    loopSlots.set(loop.attachSlotId, bucket);
+  }
+
+  return { loopSlots, topLevelSlots };
+}
+
+function resolveLoopForSlot(
+  slot: MappingSlot,
+  loops: MappingLoop[],
+  signature?: TargetSignatureNode[],
+): MappingLoop | undefined {
+  const relativeLoops = loops.filter((loop) => slotMatchesLoop(slot.slotId, loop, signature));
+  if (relativeLoops.length === 1) return relativeLoops[0];
+  if (relativeLoops.length > 1) {
+    return relativeLoops.find((loop) => {
+      const ids = signatureSlotIds(loop.attachSlotId, signature);
+      return ids?.has(slot.slotId);
+    }) ?? relativeLoops[0];
+  }
+  return loops.length === 1 ? loops[0] : undefined;
+}
+
+function slotMatchesLoop(
+  slotId: string,
+  loop: MappingLoop,
+  signature?: TargetSignatureNode[],
+): boolean {
+  const ids = signatureSlotIds(loop.attachSlotId, signature);
+  if (ids) return ids.has(slotId);
+  return slotId === loop.attachSlotId ||
+    slotId.startsWith(`${loop.attachSlotId}/`) ||
+    slotId.startsWith(`${loop.attachSlotId}//`);
+}
+
+function signatureSlotIds(
+  attachSlotId: string,
+  signature?: TargetSignatureNode[],
+): Set<string> | undefined {
+  if (!signature?.length) return undefined;
+  const node = findSignatureNode(signature, attachSlotId);
+  if (!node) return undefined;
+  return new Set(collectSignatureSlotIds(node));
+}
+
+function findSignatureNode(
+  nodes: TargetSignatureNode[],
+  slotId: string,
+): TargetSignatureNode | undefined {
+  for (const node of nodes) {
+    if (node.slotId === slotId) return node;
+    const nested = findSignatureNode(node.children, slotId);
+    if (nested) return nested;
+  }
+  return undefined;
+}
+
+function collectSignatureSlotIds(node: TargetSignatureNode): string[] {
+  const ids = [node.slotId];
+  for (const child of node.children) {
+    ids.push(...collectSignatureSlotIds(child));
+  }
+  return ids;
+}
+
+function emitLoop(loop: MappingLoop, slots: MappingSlot[]): string[] {
+  const ident = loopVarIdent(loop.varName);
+  const sequence = compileLoopSequence(loop);
+  const env: XQueryEmitEnv = {
+    sourceVar: `$${ident}`,
+    bind: { [loop.varName]: ident },
+  };
+
   const attrs = [
     `attribute attach-slot-id { ${xqString(loop.attachSlotId)} }`,
     `attribute var-name { ${xqString(loop.varName)} }`,
@@ -89,16 +229,85 @@ function emitLoop(loop: import("../../types/mod.ts").MappingLoop): string[] {
   ];
   if (loop.path) attrs.push(`attribute path { ${xqString(loop.path)} }`);
   if (loop.collection) attrs.push(`attribute collection { ${xqString(loop.collection)} }`);
-  return [
+
+  const slotLines: string[] = [];
+  if (slots.length) {
+    slotLines.push("  element slots {");
+    for (let i = 0; i < slots.length; i++) {
+      const block = emitSlot(slots[i]!, env).map((line) => `    ${line}`).join("\n");
+      const comma = i < slots.length - 1 ? "," : "";
+      slotLines.push(block + comma);
+    }
+    slotLines.push("  }");
+  }
+
+  const body = [
     "element loop {",
-    ...attrs.map((line, index) => `  ${line}${index < attrs.length - 1 ? "," : ""}`),
+    ...attrs.map((line, index) => `  ${line}${index < attrs.length - 1 || slotLines.length ? "," : ""}`),
+    ...slotLines,
     "}",
   ];
+
+  return [
+    `for $${ident} in ${sequence}`,
+    "return",
+    ...body.map((line) => `  ${line}`),
+  ];
+}
+
+function loopVarIdent(varName: string): string {
+  return /^[A-Za-z_][A-Za-z0-9_]*$/.test(varName) ? varName : "item";
+}
+
+/** Compile a loop collection path to an XQuery sequence expression. */
+export function compileLoopSequence(loop: MappingLoop): string {
+  if (loop.kind === "list") {
+    if (!loop.collection) {
+      return "(: for_each_list without collection expression :) ()";
+    }
+    return emitXQueryExpr(parseExpression(loop.collection));
+  }
+
+  const path = loop.path.trim();
+  if (!path) {
+    return "(: for_each_source without PATH :) ()";
+  }
+
+  if (path.startsWith("$.")) {
+    const base = path.replace(/\[\*\]$/, "");
+    const lookup = jsonDollarPathToLookup(base);
+    if (lookup) {
+      return `local:iterable-sequence(${lookup})`;
+    }
+    return `local:lookup-sequence($source, ${xqString(path)})`;
+  }
+
+  if (path.startsWith("/")) {
+    return `$source${path}`;
+  }
+
+  return `local:lookup-sequence($source, ${xqString(path)})`;
 }
 
 function emitHelpers(): string[] {
   return [
     "(: --- Source access (fontoxpath-authored paths → XQuery 3.1) --- :)",
+    "",
+    "declare function local:iterable-sequence($nodes as item()*) as item()* {",
+    "  if ($nodes instance of array(*)) then $nodes?*",
+    "  else $nodes",
+    "};",
+    "",
+    "declare function local:lookup-sequence($ctx as item()*, $path as xs:string) as item()* {",
+    "  (: Dynamic or non-literal loop paths — prefer compile-time $. / / paths from export :) ",
+    "  if (starts-with($path, \"$\"))",
+    "  then let $nodes := local:json-lookup($ctx, $path)",
+    "       return if ($nodes instance of array(*)) then $nodes?* else $nodes",
+    "  else error(",
+    '    QName("http://intehrgrator.local/xquery", "DYNAMIC-LOOP-PATH"),',
+    '    "Prefer compile-time literal loop PATH from intEHRgrator export; got: " || $path',
+    "  )",
+    "};",
     "",
     "declare function local:string-at($ctx as item()*, $path as xs:string) as xs:string? {",
     "  let $value := local:lookup($ctx, $path)",
@@ -211,10 +420,10 @@ function emitHelpers(): string[] {
   ];
 }
 
-function emitSlot(slot: MappingSlot): string[] {
+function emitSlot(slot: MappingSlot, env: XQueryEmitEnv = {}): string[] {
   let exprXq: string;
   try {
-    exprXq = emitXQueryExpr(parseExpression(slot.expression));
+    exprXq = emitXQueryExpr(parseExpression(slot.expression), env);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     exprXq = `(: unparseable expression: ${xqComment(msg)} :) ()`;
@@ -232,7 +441,8 @@ function emitSlot(slot: MappingSlot): string[] {
 }
 
 /** Map Mapping Expression AST → XQuery 3.1 fragment (context variable `$source`). */
-export function emitXQueryExpr(ast: ExprAst, env: { bind?: Record<string, string> } = {}): string {
+export function emitXQueryExpr(ast: ExprAst, env: XQueryEmitEnv = {}): string {
+  const sourceVar = env.sourceVar ?? "$source";
   switch (ast.kind) {
     case "literal":
       if (typeof ast.value === "string") return xqString(ast.value);
@@ -298,28 +508,34 @@ export function emitXQueryExpr(ast: ExprAst, env: { bind?: Record<string, string
         case "sheet_get_header":
         case "sheet_get_data":
         case "sheet_lookup":
-          return `(: ${ast.name} — bind $sheets at convert time :) ()`;
+          throw new XQueryExportError(
+            `${ast.name} requires a $sheets map binding — export validation should have caught this`,
+          );
         case "decision_table":
-          return `(: decision_table — bind $sheets / evaluate Decision table at convert time :) ()`;
+          throw new XQueryExportError(
+            "decision_table requires Sheet/runtime evaluation — not supported in XQuery export",
+          );
         case "xpathString":
         case "xpath":
-          return emitXPathCall("string-at", ast.args[0]);
+          return emitXPathCall("string-at", ast.args[0], env);
         case "xpathNumber":
-          return emitXPathCall("number-at", ast.args[0]);
+          return emitXPathCall("number-at", ast.args[0], env);
         case "xpathBoolean":
-          return emitXPathCall("boolean-at", ast.args[0]);
+          return emitXPathCall("boolean-at", ast.args[0], env);
         case "xpathNode":
           if (ast.args[0]?.kind === "literal" && typeof ast.args[0].value === "string") {
             const path = ast.args[0].value.trim();
-            if (path.startsWith("/")) return `($source${path})[1]`;
+            if (path.startsWith("/")) return `(${sourceVar}${path})[1]`;
+            const lookup = compileRelativeLookup(path, sourceVar);
+            if (lookup) return `(${lookup})[1]`;
           }
-          return "$source";
+          return sourceVar;
         case "handlebars":
           return args[0] ?? '""';
         case "map":
           return "map {}";
         default:
-          return emitXPathCall("string-at", ast.args[0]);
+          return emitXPathCall("string-at", ast.args[0], env);
       }
     }
   }
@@ -327,7 +543,7 @@ export function emitXQueryExpr(ast: ExprAst, env: { bind?: Record<string, string
 
 function emitQuantifierXq(
   ast: Extract<ExprAst, { kind: "call" }>,
-  env: { bind?: Record<string, string> },
+  env: XQueryEmitEnv,
 ): string {
   const card = ast.name === "at_least" || ast.name === "at_most" || ast.name === "exactly";
   const list = emitXQueryExpr(ast.args[0]!, env);
@@ -336,7 +552,7 @@ function emitQuantifierXq(
   const predAst = card ? ast.args[3] : ast.args[2];
   const varName = varAst?.kind === "literal" ? String(varAst.value) : "item";
   const ident = /^[A-Za-z_][A-Za-z0-9_]*$/.test(varName) ? varName : "item";
-  const inner = { bind: { ...env.bind, [varName]: ident } };
+  const inner = { ...env, bind: { ...env.bind, [varName]: ident } };
   const pred = predAst ? emitXQueryExpr(predAst, inner) : "true()";
   const counted = `count(for $${ident} in ${list} where ${pred} return $${ident})`;
   switch (ast.name) {
@@ -360,13 +576,15 @@ function emitQuantifierXq(
 function emitXPathCall(
   helper: "string-at" | "number-at" | "boolean-at",
   pathAst: ExprAst | undefined,
+  env: XQueryEmitEnv,
 ): string {
+  const sourceVar = env.sourceVar ?? "$source";
   if (!pathAst) return "()";
   if (pathAst.kind === "literal" && typeof pathAst.value === "string") {
-    const compiled = compileLiteralPath(pathAst.value, helper);
+    const compiled = compileLiteralPath(pathAst.value, helper, sourceVar);
     if (compiled) return compiled;
   }
-  return `local:${helper}($source, ${emitXQueryExpr(pathAst)})`;
+  return `local:${helper}(${sourceVar}, ${emitXQueryExpr(pathAst, env)})`;
 }
 
 /**
@@ -376,6 +594,7 @@ function emitXPathCall(
 export function compileLiteralPath(
   path: string,
   helper: "string-at" | "number-at" | "boolean-at",
+  sourceVar = "$source",
 ): string | null {
   const trimmed = path.trim();
   if (!trimmed) return null;
@@ -387,31 +606,71 @@ export function compileLiteralPath(
     : "xs:string";
 
   if (trimmed === "." || trimmed === "./") {
-    return `${cast}(($source)[1])`;
+    return `${cast}((${sourceVar})[1])`;
   }
   if (trimmed.startsWith("./")) {
-    return `${cast}(($source/${trimmed.slice(2)})[1])`;
+    return `${cast}((${sourceVar}/${trimmed.slice(2)})[1])`;
   }
   if (trimmed.startsWith("/")) {
-    return `${cast}(($source${trimmed})[1])`;
+    return `${cast}((${sourceVar}${trimmed})[1])`;
   }
 
   if (trimmed.startsWith("$")) {
-    const lookup = jsonDollarPathToLookup(trimmed);
+    const lookup = jsonDollarPathToLookup(trimmed, sourceVar);
     if (!lookup) return null;
     return `${cast}((${lookup})[1])`;
   }
 
+  const relative = compileRelativeLookup(trimmed, sourceVar);
+  if (relative) return `${cast}((${relative})[1])`;
+
   return null;
 }
 
+function compileRelativeLookup(path: string, sourceVar: string): string | null {
+  const trimmed = path.trim();
+  if (!trimmed || trimmed.startsWith("$") || trimmed.startsWith("/")) return null;
+  if (trimmed === "." || trimmed === "./") return sourceVar;
+
+  const body = trimmed.replace(/^\.\//, "");
+  const segments: string[] = [];
+  let i = 0;
+  while (i < body.length) {
+    if (body[i] === ".") {
+      i++;
+      continue;
+    }
+    if (body[i] === "[") {
+      const close = body.indexOf("]", i + 1);
+      if (close < 0) return null;
+      const token = body.slice(i + 1, close);
+      if (/^\d+$/.test(token)) segments.push(token);
+      else return null;
+      i = close + 1;
+      continue;
+    }
+    let end = i;
+    while (end < body.length && !".[".includes(body[end]!)) end++;
+    segments.push(body.slice(i, end));
+    i = end;
+  }
+
+  let expr = sourceVar;
+  for (const seg of segments) {
+    if (/^\d+$/.test(seg)) expr += `[${seg}]`;
+    else if (/^[\p{L}_][\p{L}\p{N}_]*$/u.test(seg)) expr += `?${seg}`;
+    else expr += `?(${xqString(seg)})`;
+  }
+  return expr;
+}
+
 /** `$.patient.vitals[1].systolic` → `$source?patient?vitals?1?systolic` */
-export function jsonDollarPathToLookup(path: string): string | null {
+export function jsonDollarPathToLookup(path: string, root = "$source"): string | null {
   let body = path.trim();
   if (!body.startsWith("$")) return null;
   body = body.slice(1);
   if (body.startsWith(".")) body = body.slice(1);
-  if (!body) return "$source";
+  if (!body) return root;
 
   const segments: string[] = [];
   let i = 0;
@@ -442,7 +701,7 @@ export function jsonDollarPathToLookup(path: string): string | null {
     i = end;
   }
 
-  let expr = "$source";
+  let expr = root;
   for (const seg of segments) {
     if (/^\d+$/.test(seg)) expr += `?${seg}`;
     else if (/^[\p{L}_][\p{L}\p{N}_]*$/u.test(seg)) expr += `?${seg}`;

--- a/test/codegen_test.ts
+++ b/test/codegen_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertStringIncludes, assert } from "@std/assert";
+import { assertEquals, assertStringIncludes, assert, assertThrows } from "@std/assert";
 import { join, toFileUrl } from "@std/path";
 import { createEmptyModel, applyExpressionEdit } from "@intehrgrator/core/mapping_model/mod.ts";
 import {
@@ -6,7 +6,10 @@ import {
   getExportTargetAdapter,
   jsonDollarPathToLookup,
   emitXQueryExpr,
+  compileLoopSequence,
+  XQueryExportError,
 } from "@intehrgrator/core/codegen/mod.ts";
+import { upsertLoop } from "@intehrgrator/core/mapping_model/mod.ts";
 import { parseExpression } from "@intehrgrator/core/expression/mod.ts";
 import { runTest } from "@intehrgrator/core/test_runner/mod.ts";
 import {
@@ -112,9 +115,64 @@ Deno.test("xquery expression emit maps builtins and JSON paths", () => {
     emitXQueryExpr(parseExpression('maps_get("defaults", "language")')),
     '(if ("defaults" eq "defaults") then map:get($defaults, "language") else ())',
   );
+  assertThrows(
+    () => emitXQueryExpr(parseExpression('sheet_lookup("t", "code", "I10", "snomed")')),
+    XQueryExportError,
+    "$sheets",
+  );
+});
+
+Deno.test("xquery export fails with clear message when slots use sheet accessors", () => {
+  const model = applyExpressionEdit(
+    createEmptyModel("terms"),
+    "s1",
+    'sheet_lookup("icd10_snomed", "code", "I10", "snomed")',
+    { rmType: "DV_TEXT", returnType: "string" },
+  );
+  assertThrows(
+    () => generate(model, "xquery"),
+    XQueryExportError,
+    "$sheets",
+  );
+});
+
+Deno.test("xquery export emits for_each_source iteration with relative loop paths", () => {
+  let model = createEmptyModel("pulse-series");
+  model = upsertLoop(model, {
+    attachSlotId: "evt-1",
+    varName: "measurements",
+    path: "$.measurements",
+    kind: "source",
+  });
+  model = applyExpressionEdit(model, "slot/rate", 'xpathNumber("pulse")', {
+    rmType: "DV_QUANTITY",
+    returnType: "number",
+    label: "Rate",
+  });
+  model = applyExpressionEdit(model, "slot/time", 'xpathString("timestamp")', {
+    rmType: "DV_DATE_TIME",
+    returnType: "string",
+    label: "Time",
+  });
+  model = applyExpressionEdit(model, "slot/patient", 'xpathString("$.patient.id")', {
+    rmType: "DV_TEXT",
+    returnType: "string",
+    label: "Patient",
+  });
+
+  const xq = generate(model, "xquery");
+  assertStringIncludes(xq, "for $measurements in local:iterable-sequence($source?measurements)");
+  assertStringIncludes(xq, "element loops");
+  assertStringIncludes(xq, 'attribute attach-slot-id { "evt-1" }');
+  assertStringIncludes(xq, 'attribute id { "slot/rate" }');
+  assertStringIncludes(xq, "$measurements?pulse");
+  assertStringIncludes(xq, "$measurements?timestamp");
+  assertStringIncludes(xq, 'attribute id { "slot/patient" }');
+  assertStringIncludes(xq, "$source?patient?id");
+  assertEquals(xq.includes('attribute id { "slot/rate" }'), xq.indexOf("element loops") < xq.indexOf('attribute id { "slot/rate" }'));
   assertEquals(
-    emitXQueryExpr(parseExpression('sheet_lookup("t", "code", "I10", "snomed")')),
-    '(: sheet_lookup — bind $sheets at convert time :) ()',
+    compileLoopSequence({ attachSlotId: "e", varName: "items", path: "$.readings[*]", kind: "source" }),
+    "local:iterable-sequence($source?readings)",
   );
 });
 

--- a/test/decision_table_test.ts
+++ b/test/decision_table_test.ts
@@ -17,7 +17,7 @@ import {
 } from "@intehrgrator/core/sheets/mod.ts";
 import { checkVmsMustache } from "@intehrgrator/core/output/vms_hbs.ts";
 import { generateTypeScript } from "@intehrgrator/core/codegen/mod.ts";
-import { generateXQuery } from "@intehrgrator/core/codegen/xquery.ts";
+import { generateXQuery, XQueryExportError } from "@intehrgrator/core/codegen/xquery.ts";
 import type { MappingModel } from "@intehrgrator/types/mod.ts";
 
 /** Fixture: laterality × finding → value + VMS-Mustache snippet (don't-care on unused). */
@@ -237,12 +237,11 @@ Deno.test("TypeScript codegen emits decisionTable helper call", () => {
   assertEquals(code.includes("function decisionTable"), true);
 });
 
-Deno.test("XQuery codegen mentions decision_table bind stub or flatten", () => {
+Deno.test("XQuery export rejects decision_table with a clear export error", () => {
   const model = baseModel(
     'decision_table("findings", map("finding", "effusion", "laterality", "left"), "term_id")',
   );
-  const xq = generateXQuery(model);
-  assertEquals(xq.includes("decision_table"), true);
+  assertThrows(() => generateXQuery(model), XQueryExportError, "decision_table");
 });
 
 Deno.test("Test Run evaluates decision_table against project sheets", () => {

--- a/test/vms_golden_test.ts
+++ b/test/vms_golden_test.ts
@@ -154,6 +154,8 @@ Deno.test("XQuery export lists the same slot ids and loop metadata as Mapping Mo
     }
     if ((model.loops ?? []).length) {
       assertStringIncludes(xq, "element loops");
+      assertStringIncludes(xq, "for $");
+      assertStringIncludes(xq, "return");
     }
   } finally {
     workspace.dispose();

--- a/test/xquery_engine_test.ts
+++ b/test/xquery_engine_test.ts
@@ -1,0 +1,93 @@
+/**
+ * Optional golden run of generated `.xq` under BaseX when the engine is installed.
+ *
+ * Install hints: docs/agents/xquery-engine.md
+ */
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { join } from "@std/path";
+import {
+  applyExpressionEdit,
+  createEmptyModel,
+  upsertLoop,
+} from "@intehrgrator/core/mapping_model/mod.ts";
+import { generateXQuery } from "@intehrgrator/core/codegen/xquery.ts";
+
+const BASEX_CMD = Deno.env.get("BASEX_CMD") ?? "basex";
+
+async function basexAvailable(): Promise<boolean> {
+  try {
+    const cmd = new Deno.Command(BASEX_CMD, {
+      args: ["-q", "1"],
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const out = await cmd.output();
+    return out.success && new TextDecoder().decode(out.stdout).trim() === "1";
+  } catch {
+    return false;
+  }
+}
+
+/** Replace external $source with an inline JSON map for a self-contained BaseX run. */
+function bindSourceInline(xq: string, sourceJson: string): string {
+  const escaped = sourceJson.replace(/\\/g, "\\\\").replace(/'/g, "''");
+  return xq.replace(
+    "declare variable $source external;",
+    `declare variable $source as map(*) := parse-json('${escaped}');`,
+  );
+}
+
+Deno.test({
+  name: "BaseX runs generated for_each_source XQuery against JSON source (optional)",
+  ignore: false,
+  async fn() {
+    if (!(await basexAvailable())) {
+      console.warn(
+        `skip: ${BASEX_CMD} not found — install BaseX to enable XQuery engine golden tests (see docs/agents/xquery-engine.md)`,
+      );
+      return;
+    }
+
+    let model = createEmptyModel("pulse-series");
+    model = upsertLoop(model, {
+      attachSlotId: "evt-1",
+      varName: "measurements",
+      path: "$.measurements",
+      kind: "source",
+    });
+    model = applyExpressionEdit(model, "slot/rate", 'xpathNumber("pulse")', {
+      rmType: "DV_QUANTITY",
+      returnType: "number",
+    });
+    model = applyExpressionEdit(model, "slot/time", 'xpathString("timestamp")', {
+      rmType: "DV_DATE_TIME",
+      returnType: "string",
+    });
+
+    const source = await Deno.readTextFile(
+      join(import.meta.dirname!, "fixtures/legacy-simulated-json/instances-series/bp-series-inst.json"),
+    );
+    const xq = bindSourceInline(generateXQuery(model), source);
+
+    const dir = await Deno.makeTempDir({ prefix: "intehrgrator-xq-" });
+    const queryPath = join(dir, "convert.xq");
+    await Deno.writeTextFile(queryPath, xq);
+    try {
+      const result = await new Deno.Command(BASEX_CMD, {
+        args: [queryPath],
+        stdout: "piped",
+        stderr: "piped",
+      }).output();
+      const stderr = new TextDecoder().decode(result.stderr);
+      const stdout = new TextDecoder().decode(result.stdout);
+      assertEquals(result.success, true, stderr || stdout);
+      assertStringIncludes(stdout, "<mapping-result");
+      assertStringIncludes(stdout, 'attach-slot-id="evt-1"');
+      assertStringIncludes(stdout, "<rm:magnitude>72</rm:magnitude>");
+      assertStringIncludes(stdout, "<rm:magnitude>76</rm:magnitude>");
+      assertStringIncludes(stdout, "2026-07-02T08:30:00Z");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  },
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #39.

## Summary

XQuery codegen now compiles `for_each_source` / `for_each_list` from Mapping Model `loops[]` into real `for $var in … return` iteration, with loop-scoped slots emitted inside each `<loop>` element and top-level slots remaining in `<slots>`.

## Acceptance criteria

- [x] Fixture with `for_each_source` emits XQuery iteration (`for $measurements in … return`), not only flat slot metadata
- [x] Literal `$.` / `/` paths still inline; dynamic paths use documented `local:lookup-sequence` / `local:*-at` helpers
- [x] Sheet accessors fail export with `XQueryExportError` (no silent `()`)
- [x] Tests in `test/codegen_test.ts`, `test/vms_golden_test.ts`, and optional `test/xquery_engine_test.ts`
- [x] Removed block types (`unsupported[].reason === "removed"`) rejected at export

## Engine verification (follow-up groundwork)

- **Recommended engine:** BaseX 11 (Java 21 already on Cloud Agent images)
- **Docs:** `docs/agents/xquery-engine.md` — install, `parse-json` binding for JSON Example Instances, `BASEX_CMD` override
- **Task:** `deno task test:xquery-engine` (skips gracefully when BaseX is absent)

## Out of scope (deferred)

- Full COMPOSITION RM XML emit (Model A/C) — still mapping-result + loops only
- In-app Test Run execution of `.xq`
- Runtime `$sheets` implementation for Sheet accessors




# Made GitHub issues to implement the Still deferred:

- Full COMPOSITION RM XML emit (Model A/C). To make this meaningful we likely need a switch for openEHR targets visible in the user interface where you can switch the desired output between Json and XML
- In-app Test Run execution of .xq (lazy load xq module so that it does not eat resources until needed.
- Runtime $sheets binding for Sheet accessors (if tables are not supported in X query natively then use some kind of semantic preserving conversion for example lists in lists or maps in maps, preferably something that is somewhat readable when debugging the finished script)


Other issues created for generating native java conversion script, it would likely be good to base it on an openEHR library like Archie in order to make conversion scripts more readable and to have built-in verification possiblities using openEHR templates etc. this follows the same pattern more or less that we have used in the typescript variant of conversion script generation.


##	issues:

#75	XQuery export: full COMPOSITION RM XML emit and openEHR JSON/XML output switch	Model A/C from Template Skeleton; UI switch for JSON vs XML on openEHR targets

#76	XQuery export: runtime $sheets binding for Sheet accessors	external $sheets, readable map/list encoding, emitted lookup helpers; unblocks Sheet/decision-table export

#78	XQuery: in-app Test Run execution of generated .xq (lazy-loaded)	Output mode xquery runs generated script; runtime loads only on first use

#77	Java export: native Archie-based conversion script generation	Replace stub with Archie RM emit parallel to TypeScript; OPT validation hook
All three XQuery issues are marked as children of #39 in their bodies (per the “no parallel Chunk 9 epic” rule). 

# Suggested dependency:

#76 ($sheets) before full XQuery Output parity for Sheet mappings
#75 (COMPOSITION XML) orthogonal to #78 (Model B execution can ship first)
#77 (Java) is a separate Conversion script track, same pattern as TypeScript